### PR TITLE
Add fallback support for environment variables from .env to process.env

### DIFF
--- a/common/scripts/env-webpack-helper.js
+++ b/common/scripts/env-webpack-helper.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Creates environment variables object for webpack DefinePlugin with fallback logic:
+ * 1. Check .env file first for variable values
+ * 2. If .env declares a variable but has no value, fallback to process.env
+ * 3. Only define variables that are explicitly declared in .env file
+ * 
+ * @param {Object} env - Parsed environment variables from .env file (from dotenv.config().parsed)
+ * @returns {Object} Environment variables object ready for webpack.DefinePlugin
+ */
+function createEnvDefinePlugin(env) {
+  
+    const envKeys = Object.create(null);
+    const missingVars = [];
+  
+    if (env) {
+      Object.entries(env).forEach(([key, value]) => {
+        if (value !== undefined && value !== '') {
+          envKeys[`process.env.${key}`] = JSON.stringify(value);
+        }
+        else if (process.env[key] !== undefined && process.env[key] !== '') {
+          envKeys[`process.env.${key}`] = JSON.stringify(process.env[key]);
+        }
+        else {
+          missingVars.push(key);
+        }
+      });
+    }
+  
+    if (missingVars.length > 0) {
+      throw new Error(
+        `Missing required environment variables: ${missingVars.join(', ')}\n` +
+        `Please provide values in either .env file or runtime environment.\n`
+      );
+    }
+  
+    return envKeys;
+  }
+  
+  module.exports = {
+    createEnvDefinePlugin
+  }; 
+  

--- a/workspaces/ballerina/ballerina-extension/webpack.config.js
+++ b/workspaces/ballerina/ballerina-extension/webpack.config.js
@@ -15,9 +15,10 @@ let envKeys;
 try {
   envKeys = createEnvDefinePlugin(env);
 } catch (error) {
-  console.error('\n❌ Environment Variable Configuration Error:');
-  console.error(error.message);
-  process.exit(1);
+  console.warn('\n⚠️  Environment Variable Configuration Warning:');
+  console.warn(error.message);
+  console.warn('Continuing build with empty environment variables...');
+  envKeys = {};
 }
 
 /** @type {import('webpack').Configuration} */

--- a/workspaces/ballerina/ballerina-extension/webpack.config.js
+++ b/workspaces/ballerina/ballerina-extension/webpack.config.js
@@ -6,29 +6,19 @@ const path = require('path');
 const MergeIntoSingleFile = require('webpack-merge-and-include-globally');
 const dotenv = require('dotenv');
 const webpack = require('webpack');
+const { createEnvDefinePlugin } = require('../../../common/scripts/env-webpack-helper');
 
 const envPath = path.resolve(__dirname, '.env');
 const env = dotenv.config({ path: envPath }).parsed;
 
-function shouldSkipEnvVar(key) {
-  const pathVariables = ['PATH', 'Path'];
-  return pathVariables.includes(key);
+let envKeys;
+try {
+  envKeys = createEnvDefinePlugin(env);
+} catch (error) {
+  console.error('\n❌ Environment Variable Configuration Error:');
+  console.error(error.message);
+  process.exit(1);
 }
-
-const filteredProcessEnv = Object.fromEntries(
-  Object.entries(process.env).filter(([key, value]) => !shouldSkipEnvVar(key))
-);
-
-const mergedEnv = { ...env, ...filteredProcessEnv };
-
-const envKeys = Object.fromEntries(
-  Object.entries(mergedEnv)
-    .filter(([key, value]) => key && value !== undefined && value !== '')
-    .map(([key, value]) => [
-      `process.env.${key}`,
-      JSON.stringify(value),
-    ])
-);
 
 /** @type {import('webpack').Configuration} */
 module.exports = {

--- a/workspaces/mi/mi-extension/webpack.config.js
+++ b/workspaces/mi/mi-extension/webpack.config.js
@@ -32,9 +32,10 @@ let envKeys;
 try {
   envKeys = createEnvDefinePlugin(env);
 } catch (error) {
-  console.error('\n❌ Environment Variable Configuration Error:');
-  console.error(error.message);
-  process.exit(1);
+  console.warn('\n⚠️  Environment Variable Configuration Warning:');
+  console.warn(error.message);
+  console.warn('Continuing build with empty environment variables...');
+  envKeys = {};
 }
 
 /** @type {import('webpack').Configuration} */

--- a/workspaces/mi/mi-extension/webpack.config.js
+++ b/workspaces/mi/mi-extension/webpack.config.js
@@ -20,22 +20,22 @@
 
 'use strict';
 
-const fs = require('fs');
 const path = require('path');
 const dotenv = require('dotenv');
 const webpack = require('webpack');
+const { createEnvDefinePlugin } = require('../../../common/scripts/env-webpack-helper');
 
 const envPath = path.resolve(__dirname, '.env');
 const env = dotenv.config({ path: envPath }).parsed;
 
-const mergedEnv = { ...env, ...process.env };
-
-const envKeys = Object.fromEntries(
-  Object.entries(mergedEnv).map(([key, value]) => [
-    `process.env.${key}`,
-    JSON.stringify(value),
-  ])
-);
+let envKeys;
+try {
+  envKeys = createEnvDefinePlugin(env);
+} catch (error) {
+  console.error('\n❌ Environment Variable Configuration Error:');
+  console.error(error.message);
+  process.exit(1);
+}
 
 /** @type {import('webpack').Configuration} */
 module.exports = {

--- a/workspaces/wso2-platform/wso2-platform-extension/webpack.config.js
+++ b/workspaces/wso2-platform/wso2-platform-extension/webpack.config.js
@@ -22,16 +22,19 @@ const CopyPlugin = require("copy-webpack-plugin");
 const PermissionsOutputPlugin = require("webpack-permissions-plugin");
 const webpack = require("webpack");
 const dotenv = require("dotenv");
+const { createEnvDefinePlugin } = require('../../../common/scripts/env-webpack-helper');
 
 const envPath = path.resolve(__dirname, ".env");
 const env = dotenv.config({ path: envPath }).parsed;
 
-const mergedEnv = { ...env, ...process.env };
-
-const platformEnv = Object.fromEntries(Object.entries(mergedEnv).filter(([key]) => key.startsWith("PLATFORM_")));
-
-const envKeys = Object.fromEntries(Object.entries(platformEnv).map(([key, value]) => [`process.env.${key}`, JSON.stringify(value)]));
-
+let envKeys;
+try {
+  	envKeys = createEnvDefinePlugin(env);
+} catch (error) {
+	console.error('\n❌ Environment Variable Configuration Error:');
+	console.error(error.message);
+	process.exit(1);
+}
 //@ts-check
 /** @typedef {import('webpack').Configuration} WebpackConfig **/
 

--- a/workspaces/wso2-platform/wso2-platform-extension/webpack.config.js
+++ b/workspaces/wso2-platform/wso2-platform-extension/webpack.config.js
@@ -31,9 +31,10 @@ let envKeys;
 try {
   	envKeys = createEnvDefinePlugin(env);
 } catch (error) {
-	console.error('\n❌ Environment Variable Configuration Error:');
-	console.error(error.message);
-	process.exit(1);
+	console.warn('\n⚠️  Environment Variable Configuration Warning:');
+	console.warn(error.message);
+	console.warn('Continuing build with empty environment variables...');
+	envKeys = {};
 }
 //@ts-check
 /** @typedef {import('webpack').Configuration} WebpackConfig **/


### PR DESCRIPTION
## Purpose
Enhance webpack environment variable handling to support fallback logic:
- Check .env file first for variable values  
- If .env declares a variable but has no value, fallback to process.env
- Only define variables that are explicitly declared in .env file
- Prevents webpack from replacing undefined variables, maintaining runtime flexibility

This allows developers to declare environment variables in .env with empty values and have webpack automatically use runtime environment values as fallback, while still maintaining control over which variables get replaced during build time.