### PR TITLE
Add VSCode Setting for Sequence Diagram Visibility

### DIFF
--- a/workspaces/ballerina/ballerina-extension/package.json
+++ b/workspaces/ballerina/ballerina-extension/package.json
@@ -199,6 +199,14 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Use Ballerina distribution language server instead of bundled language server. Note: This will be automatically enabled for Ballerina versions older than 2201.12.3."
+                },
+                "ballerina.enableSequenceDiagramView":{
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Enable the experimental Sequence Diagram View.",
+                    "tags": [
+                        "experimental"
+                    ]
                 }
             }
         },


### PR DESCRIPTION
## Purpose
This pull request introduces a VSCode setting to show or hide the experimental sequence diagram feature.

