### PR TITLE
Add sanitized intergration name preview in ProjectForm component

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/ProjectForm/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/ProjectForm/index.tsx
@@ -142,6 +142,7 @@ export function ProjectForm() {
                     value={name}
                     label="Integration Name"
                     placeholder="Enter a integration name"
+                    autoFocus={true}
                 />
                 <PreviewContainer>
                     <PreviewIcon name="project" iconSx={{ fontSize: 14, color: "var(--vscode-descriptionForeground)" }} />


### PR DESCRIPTION
Resolves [#654](https://github.com/wso2/product-ballerina-integrator/issues/654): Display Sanitized intergration Name in Real-Time

https://github.com/user-attachments/assets/cc431a5c-38b4-4dee-a862-b717e601b528



## Goals
To display a sanitized version of the integration name when creating an integration