### PR TITLE
Add VSCode Setting for AI Suggestions in Flow Diagram

### DIFF
--- a/workspaces/ballerina/ballerina-extension/package.json
+++ b/workspaces/ballerina/ballerina-extension/package.json
@@ -207,6 +207,11 @@
                     "tags": [
                         "experimental"
                     ]
+                },
+                "ballerina.enableAiSuggestions": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Enable AI suggestions in the Flow Diagram View."
                 }
             }
         },


### PR DESCRIPTION
## Purpose
This pull request adds a missing VSCode extension setting to enable or disable AI-powered suggestions within the flow diagram.

Fixed: https://github.com/wso2/product-ballerina-integrator/issues/719