### PR TITLE
configure rush to accept all versions of node v22

### DIFF
--- a/rush.json
+++ b/rush.json
@@ -38,7 +38,7 @@
    * LTS schedule: https://nodejs.org/en/about/releases/
    * LTS versions: https://nodejs.org/en/download/releases/
    */
-  "nodeSupportedVersionRange": ">=20.0.0 <=22.16.0",
+  "nodeSupportedVersionRange": ">=20.0.0 <23.0.0",
   /**
    * If the version check above fails, Rush will display a message showing the current
    * node version and the supported version range. You can use this setting to provide


### PR DESCRIPTION
## Purpose
> Node js version currently specify node v22.16 as the max node version, which breaks when installed node version is above that but still node v22

## Goals
> Make the project support all the versions of node v22

## Approach
Edit the rush.json file to have the attribute

`nodeSupportedVersionRange` as ">=20.0.0 <23.0.0" so that all the versions of node 22 will be accepted by rush