### PR TITLE
Update download-ls script to download both released and pre-released versions

### DIFF
--- a/workspaces/ballerina/ballerina-extension/package.json
+++ b/workspaces/ballerina/ballerina-extension/package.json
@@ -200,7 +200,7 @@
                     "default": false,
                     "description": "Use Ballerina distribution language server instead of bundled language server. Note: This will be automatically enabled for Ballerina versions older than 2201.12.3."
                 },
-                "ballerina.enableSequenceDiagramView":{
+                "ballerina.enableSequenceDiagramView": {
                     "type": "boolean",
                     "default": true,
                     "description": "Enable the experimental Sequence Diagram View.",
@@ -1088,7 +1088,7 @@
         "copyFonts": "copyfiles -f ./node_modules/@wso2/font-wso2-vscode/dist/* ./resources/font-wso2-vscode/dist/",
         "copyVSIX": "copyfiles *.vsix ./vsix",
         "copyVSIXToRoot": "copyfiles -f ./vsix/*.vsix ../../..",
-        "download-ls": "node scripts/download-ls.js --prerelease",
+        "download-ls": "node scripts/download-ls.js",
         "build": "pnpm run compile && pnpm run lint && pnpm run postbuild",
         "rebuild": "pnpm run clean && pnpm run compile && pnpm run postbuild",
         "postbuild": "if [ \"$isPreRelease\" = \"true\" ]; then pnpm run download-ls --prerelease; else pnpm run download-ls; fi && pnpm run copyFonts && pnpm run copyJSLibs && pnpm run package && pnpm run copyVSIX",


### PR DESCRIPTION
## Purpose

This pull request reverts the previous change that restricted the download-ls script to download only pre-released versions of the language server.