### PR TITLE
Move migrate project button to unsupported project page

### DIFF
--- a/workspaces/mi/mi-extension/package.json
+++ b/workspaces/mi/mi-extension/package.json
@@ -190,16 +190,6 @@
       },
       {
         "view": "MI.project-explorer",
-        "contents": "This project appears to have been created with Integration Studio. Please note that the VS Code extension offers limited support for these projects. To enhance compatibility, consider migrating your project using the provided migration tool.\n[Migrate Project](command:MI.migrateProject)",
-        "when": "MI.status == 'projectLoaded' && MI.projectType == 'oldProject' && MI.migrationStatus != 'migrating' && workspaceFolderCount == 1"
-      },
-      {
-        "view": "MI.project-explorer",
-        "contents": "Migrating project... Please wait.",
-        "when": "MI.status == 'projectLoaded' && MI.projectType == 'oldProject' && MI.migrationStatus == 'migrating' && workspaceFolderCount == 1"
-      },
-      {
-        "view": "MI.project-explorer",
         "contents": "Some errors occurred while activating the extension. Please check the output channel for more information.",
         "when": "MI.status == 'disabled'"
       },

--- a/workspaces/mi/mi-visualizer/src/constants/index.ts
+++ b/workspaces/mi/mi-visualizer/src/constants/index.ts
@@ -52,6 +52,10 @@ export const SIDE_PANEL_WIDTH = 450;
 
 export const gitIssueUrl = "https://github.com/wso2/mi-vscode/issues";
 
+export const COMMANDS = {
+    MIGRATE_PROJECT: "MI.migrateProject",
+}
+
 // Actions for service designer
 export const ARTIFACT_TEMPLATES = {
     ADD_API: "add-api",

--- a/workspaces/mi/mi-visualizer/src/views/UnsupportedProject/index.tsx
+++ b/workspaces/mi/mi-visualizer/src/views/UnsupportedProject/index.tsx
@@ -23,6 +23,7 @@ import { Button, Typography } from '@wso2/ui-toolkit';
 import styled from '@emotion/styled';
 import { View, ViewContent, ViewHeader } from '../../components/View';
 import { VSCodeCheckbox } from '@vscode/webview-ui-toolkit/react';
+import { COMMANDS } from '../../constants';
 
 const Container = styled.div`
   display: flex;
@@ -155,9 +156,9 @@ const Card: React.FC<CardProps> = ({ title, description, expanded, onClick }) =>
         </CardExpanded>
       ) : (
         <CardCollapsed onClick={onClick}>
-            <CardTitle variant='body3' sx={{ fontWeight: 600 }}>
-              {title}
-            </CardTitle>
+          <CardTitle variant='body3' sx={{ fontWeight: 600 }}>
+            {title}
+          </CardTitle>
         </CardCollapsed>
       )}
     </React.Fragment>
@@ -219,9 +220,8 @@ export function UnsupportedProject(props: UnsupportedProjectProps) {
   };
 
   const migrateProject = async () => {
-    await rpcClient
-                .getMiDiagramRpcClient()
-                .executeCommand({ commands: ["MI.migrateProject", { source: undefined }] });
+    await rpcClient.getMiDiagramRpcClient()
+      .executeCommand({ commands: [COMMANDS.MIGRATE_PROJECT, { source: undefined }] });
   }
 
   useEffect(() => {
@@ -309,7 +309,7 @@ export function UnsupportedProject(props: UnsupportedProjectProps) {
           </Steps>
           <Footer>
             <VSCodeCheckbox value='display-overview' checked={displayOverviewOnStartup} onClick={disableOverview}>
-                Show overview page on startup
+              Show overview page on startup
             </VSCodeCheckbox>
           </Footer>
         </Container>

--- a/workspaces/mi/mi-visualizer/src/views/UnsupportedProject/index.tsx
+++ b/workspaces/mi/mi-visualizer/src/views/UnsupportedProject/index.tsx
@@ -19,7 +19,7 @@
 import React, { useEffect } from 'react';
 import { ColorThemeKind, WorkspaceFolder } from '@wso2/mi-core';
 import { useVisualizerContext } from '@wso2/mi-rpc-client';
-import { Typography } from '@wso2/ui-toolkit';
+import { Button, Typography } from '@wso2/ui-toolkit';
 import styled from '@emotion/styled';
 import { View, ViewContent, ViewHeader } from '../../components/View';
 import { VSCodeCheckbox } from '@vscode/webview-ui-toolkit/react';
@@ -218,6 +218,12 @@ export function UnsupportedProject(props: UnsupportedProjectProps) {
     setDisplayOverviewOnStartup(!displayOverviewOnStartup);
   };
 
+  const migrateProject = async () => {
+    await rpcClient
+                .getMiDiagramRpcClient()
+                .executeCommand({ commands: ["MI.migrateProject", { source: undefined }] });
+  }
+
   useEffect(() => {
     rpcClient
       .getMiVisualizerRpcClient()
@@ -273,6 +279,9 @@ export function UnsupportedProject(props: UnsupportedProjectProps) {
                 migration documentation
               </a>
               .
+              <div style={{ display: 'flex', gap: '1rem', marginTop: '1rem' }}>
+                <Button onClick={() => migrateProject()}>Migrate Project</Button>
+              </div>
             </Body>
           </Block>
           <Steps>


### PR DESCRIPTION
## Purpose
Previously the **Migrate Project** button appeared in the side panel. However when we introduce multi workspace, it no longer can be displayed in the side panel. Hence this PR will introduce following changes.
* **Migrate Project** button removed from side panel
* **Migrate Project** button is moved to the Unsupported Project page

Previous View 
<img width="1870" height="651" alt="Screenshot 2025-07-17 at 23 28 34" src="https://github.com/user-attachments/assets/3bfed14e-c851-40c6-bcad-51780600ba3c" />

New View 
<img width="1853" height="967" alt="Screenshot 2025-07-17 at 23 25 14" src="https://github.com/user-attachments/assets/ca2a1a4c-2162-4018-95c8-6b8bd3d8e701" />


Fixes: https://github.com/wso2/mi-vscode/issues/1190