### PR TITLE
Temporarily disable  the on-the-fly mappings options in BI Inline datamapper

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/inline-data-mapper/rpc-manager.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/inline-data-mapper/rpc-manager.ts
@@ -82,7 +82,7 @@ export class InlineDataMapperRpcManager implements InlineDataMapperAPI {
                                 }
                             });
                             resolve({ textEdits: model.textEdits });
-                        })
+                        });
                 })
                 .catch((error) => {
                     console.log(">>> error fetching inline data mapper initial source from ls", error);
@@ -251,10 +251,12 @@ export class InlineDataMapperRpcManager implements InlineDataMapperAPI {
             await StateMachine
                 .langClient()
                 .deleteMapping(params)
-                .then(async (resp) => {
+                .then((resp) => {
                     console.log(">>> inline data mapper delete mapping response", resp);
-                    await updateAndRefreshDataMapper(resp.textEdits, params.filePath, params.codedata, params.varName);
-                    resolve({ textEdits: resp.textEdits });
+                    updateAndRefreshDataMapper(resp.textEdits, params.filePath, params.codedata, params.varName)
+                    .then(() => {
+                        resolve({ textEdits: resp.textEdits });
+                    });
                 });
         });
     }

--- a/workspaces/ballerina/inline-data-mapper/src/components/Diagram/utils/common-utils.ts
+++ b/workspaces/ballerina/inline-data-mapper/src/components/Diagram/utils/common-utils.ts
@@ -74,7 +74,7 @@ export function getValueType(lm: DataMapperLinkModel): ValueType {
 
 
 export function isPendingMappingRequired(mappingType: MappingType): boolean {
-    return mappingType === MappingType.ArrayToSingleton || mappingType === MappingType.ArrayToSingletonWithCollect;
+    return false; // TODO: Implement logic when LS supports on the fly mappings
 }
 
 export function genArrayElementAccessSuffix(sourcePort: PortModel, targetPort: PortModel) {


### PR DESCRIPTION
## Purpose
> Temporarily disable  the on-the-fly mappings options in BI Inline datamapper until LS supports
> Additionally, refactor the delete mapping RPC method promise handling

