### PR TITLE
Add expand/collapse icon instead of circle bullet in deployment options

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/Overview/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/Overview/index.tsx
@@ -329,10 +329,17 @@ function DeploymentOption({
             onClick={onToggle}
         >
             <DeploymentHeader>
-                <Codicon
-                    name={'circle-outline'}
-                    sx={{ color: isExpanded ? 'var(--vscode-textLink-foreground)' : 'inherit' }}
-                />
+                {isExpanded ? (
+                    <Codicon
+                        name={'triangle-down'}
+                        sx={{ color: 'var(--vscode-textLink-foreground)'}}
+                    />
+                ) : (
+                    <Codicon
+                        name={'triangle-right'}
+                        sx={{ color: 'inherit' }}
+                    />
+                )}
                 <h3>{title}</h3>
             </DeploymentHeader>
             <DeploymentBody isExpanded={isExpanded}>


### PR DESCRIPTION
## Purpose
> $title

<img width="1602" height="946" alt="image" src="https://github.com/user-attachments/assets/4d6b715c-2b91-41c3-87f9-967283315cea" />
