### PR TITLE
[Inline Data Mapper] Preserve node scroll position on mapping updates

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/inline-data-mapper/utils.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/inline-data-mapper/utils.ts
@@ -424,7 +424,6 @@ function isWithinArtifact(artifactPosition: NodePosition, varDeclRange: ELineRan
     const artifactStartLine = artifactPosition.startLine;
     const artifactEndLine = artifactPosition.endLine;
     const varDeclStartLine = varDeclRange.startLine.line;
-    const varDeclEndLine = varDeclRange.endLine.line;
 
-    return artifactStartLine <= varDeclStartLine && artifactEndLine >= varDeclEndLine;
+    return artifactStartLine <= varDeclStartLine && artifactEndLine >= varDeclStartLine;
 }

--- a/workspaces/ballerina/inline-data-mapper/src/components/DataMapper/DataMapper.tsx
+++ b/workspaces/ballerina/inline-data-mapper/src/components/DataMapper/DataMapper.tsx
@@ -139,8 +139,7 @@ export function InlineDataMapper(props: InlineDataMapperProps) {
     } = props;
     const {
         model,
-        hasInputsOutputsChanged = false,
-        hasSubMappingsChanged = false,
+        hasInputsOutputsChanged = false
     } = modelState;
 
     const initialView = [{
@@ -212,49 +211,24 @@ export function InlineDataMapper(props: InlineDataMapperProps) {
                 goToFunction
             );
 
-            // Only regenerate IO nodes if inputs/outputs have changed
-            let ioNodes: DataMapperNodeModel[] = [];
-            if (hasInputsOutputsChanged || nodes.length === 0) {
-                const ioNodeInitVisitor = new IONodeInitVisitor(context);
-                traverseNode(model, ioNodeInitVisitor);
-                ioNodes = ioNodeInitVisitor.getNodes();
-            } else {
-                // Reuse existing IO nodes but update their context
-                ioNodes = nodes
-                    .filter(node => 
-                        node instanceof InputNode || 
-                        node instanceof ArrayOutputNode || 
-                        node instanceof ObjectOutputNode ||
-                        node instanceof QueryOutputNode
-                    )
-                    .map(node => {
-                        node.context = context;
-                        return node;
-                    });
-            }
+            const ioNodeInitVisitor = new IONodeInitVisitor(context);
+            traverseNode(model, ioNodeInitVisitor);
+            const ioNodes = ioNodeInitVisitor.getNodes();
 
-            // Only regenerate sub mappiing node if sub mappings have changed
             const hasInputNodes = !ioNodes.some(node => node instanceof EmptyInputsNode);
             let subMappingNode: DataMapperNodeModel;
             if (hasInputNodes) {
-                if (hasSubMappingsChanged) {
-                    const subMappingNodeInitVisitor = new SubMappingNodeInitVisitor(context);
-                    traverseNode(model, subMappingNodeInitVisitor);
-                    subMappingNode = subMappingNodeInitVisitor.getNode();
-                } else {
-                    // Reuse existing sub mapping node
-                    subMappingNode = nodes.find(node => node instanceof SubMappingNode) as SubMappingNode;
-                }
+                const subMappingNodeInitVisitor = new SubMappingNodeInitVisitor(context);
+                traverseNode(model, subMappingNodeInitVisitor);
+                subMappingNode = subMappingNodeInitVisitor.getNode();
             }
 
-            // Always regenerate intermediate nodes as they depend on mappings
             const intermediateNodeInitVisitor = new IntermediateNodeInitVisitor(
                 context,
                 nodes.filter(node => node instanceof LinkConnectorNode || node instanceof QueryExprConnectorNode)
             );
             traverseNode(model, intermediateNodeInitVisitor);
 
-            // Only add subMappingNode if it is defined
             setNodes([
                 ...ioNodes,
                 ...(subMappingNode ? [subMappingNode] : []),

--- a/workspaces/ballerina/inline-data-mapper/src/components/DataMapper/Header/HeaderBreadcrumb.tsx
+++ b/workspaces/ballerina/inline-data-mapper/src/components/DataMapper/Header/HeaderBreadcrumb.tsx
@@ -57,13 +57,14 @@ export default function HeaderBreadcrumb(props: HeaderBreadcrumbProps) {
     const [activeLink, links] = useMemo(() => {
         if (views) {
             const focusedView = views[views.length - 1];
+            const isFocusedOnSubMappingRoot = focusedView?.subMappingInfo?.focusedOnSubMappingRoot;
             const otherViews = views.slice(0, -1);
             let isRootView = views.length === 1;
             let label = extractLastPartFromLabel(focusedView.label);
 
             const selectedLink = (
                 <div className={classes.active}>
-                    {isRootView ? label : `${label}:Query`}
+                    {isRootView ? label : `${label}:${isFocusedOnSubMappingRoot ? "SubMapping" : "Query"}`}
                 </div>
             );
 
@@ -79,7 +80,7 @@ export default function HeaderBreadcrumb(props: HeaderBreadcrumbProps) {
                             className={classes.link}
                             data-testid={`dm-header-breadcrumb-${index}`}
                         >
-                            {isRootView ? label : `${label}:Query`}
+                            {isRootView ? label : `${label}:${view.subMappingInfo ? "SubMapping" : "Query"}`}
                         </a>
                     );
                 })

--- a/workspaces/ballerina/inline-data-mapper/src/components/Diagram/LinkState/CreateLinkState.ts
+++ b/workspaces/ballerina/inline-data-mapper/src/components/Diagram/LinkState/CreateLinkState.ts
@@ -82,6 +82,8 @@ export class CreateLinkState extends State<DiagramEngine> {
 									portModel.attributes?.collapsed
 								) {
 									handleExpand(portModel.attributes.fieldFQN, false);
+									this.clearState();
+									this.eject();
 								} else if (portModel) {
 									element = portModel;
 								}

--- a/workspaces/ballerina/inline-data-mapper/src/components/Diagram/Node/Input/InputNode.ts
+++ b/workspaces/ballerina/inline-data-mapper/src/components/Diagram/Node/Input/InputNode.ts
@@ -38,7 +38,7 @@ export class InputNode extends DataMapperNodeModel {
         public hasNoMatchingFields?: boolean
     ) {
         super(
-            NODE_ID,
+            `${NODE_ID}-${inputType?.id}`,
             context,
             INPUT_NODE_TYPE
         );

--- a/workspaces/ballerina/inline-data-mapper/src/components/Diagram/utils/diagram-utils.ts
+++ b/workspaces/ballerina/inline-data-mapper/src/components/Diagram/utils/diagram-utils.ts
@@ -15,12 +15,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { FieldCount } from "../../../components/Hooks";
+import { InputNode } from "../Node";
+import { DataMapperNodeModel } from "../Node/commons/DataMapperNode";
 import {
     GAP_BETWEEN_FIELDS,
     GAP_BETWEEN_NODE_HEADER_AND_BODY,
     IO_NODE_FIELD_HEIGHT,
     IO_NODE_HEADER_HEIGHT,
-    OFFSETS,
     defaultModelOptions
 } from "./constants";
 
@@ -54,4 +56,29 @@ export function calculateControlPointOffset(screenWidth: number) {
     const interpolationFactor = (clampedWidth - minWidth) / (maxWidth - minWidth);
     const interpolatedOffset = minOffset + interpolationFactor * (maxOffset - minOffset);
     return interpolatedOffset;
+}
+
+export function getInputNodeFieldCounts(nodes: DataMapperNodeModel[]): { id: string, numberOfFields: number }[] {
+    const inputNodes = nodes.filter(node => node instanceof InputNode);
+    const fieldCounts = inputNodes.map(node => ({
+        id: node.id,
+        numberOfFields: node.numberOfFields
+    }));
+
+    return fieldCounts;
+}
+
+export function getFieldCountMismatchIndex(newFieldCounts: FieldCount[], existingFieldCounts: FieldCount[]) {
+    if (existingFieldCounts.length === 0) return 0;
+
+    for (let i = 0; i < newFieldCounts.length; i++) {
+        const newNode = newFieldCounts[i];
+        const existingNode = existingFieldCounts[i];
+        
+        if (newNode.numberOfFields !== existingNode.numberOfFields) {
+            return i;
+        }
+    }
+    
+    return -1;
 }


### PR DESCRIPTION
## Purpose
$title
This PR also fix:
- deleting multilined expressions
- selecting links after inputs expand by clicking on input fields