### PR TITLE
Fix duplicate `accessToken` when configuring default WSO2 Model Provider

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/features/ai/utils.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/utils.ts
@@ -21,7 +21,7 @@ import path from "path";
 import vscode, { Uri, workspace } from 'vscode';
 
 import { StateMachine } from "../../stateMachine";
-import { getRefreshedAccessToken, REFRESH_TOKEN_NOT_AVAILABLE_ERROR_MESSAGE } from '../../../src/utils/ai/auth';
+import { getRefreshedAccessToken, REFRESH_TOKEN_NOT_AVAILABLE_ERROR_MESSAGE, TOKEN_REFRESH_ONLY_SUPPORTED_FOR_BI_INTEL } from '../../../src/utils/ai/auth';
 import { AIStateMachine } from '../../../src/views/ai-panel/aiMachine';
 import { AIMachineEventType } from '@wso2/ballerina-core/lib/state-machine-types';
 import { CONFIG_FILE_NAME, ERROR_NO_BALLERINA_SOURCES, LOGIN_REQUIRED_WARNING, PROGRESS_BAR_MESSAGE_FROM_WSO2_DEFAULT_MODEL } from './constants';
@@ -137,7 +137,7 @@ export async function getTokenForDefaultModel() {
         }
         return token;
     } catch (error) {
-        if ((error as Error).message === REFRESH_TOKEN_NOT_AVAILABLE_ERROR_MESSAGE) {
+        if ((error as Error).message === REFRESH_TOKEN_NOT_AVAILABLE_ERROR_MESSAGE || (error as Error).message === TOKEN_REFRESH_ONLY_SUPPORTED_FOR_BI_INTEL) {
             vscode.window.showWarningMessage(LOGIN_REQUIRED_WARNING);
         }
         throw error;

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/utils.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/utils.ts
@@ -158,6 +158,18 @@ function findFileCaseInsensitive(directory: string, fileName: string): string {
     return path.join(directory, file);
 }
 
+// Helper to add or replace a config line
+function addOrReplaceConfigLine(lines: string[], key: string, value: string) {
+    const configLine = `${key} = "${value}"`;
+    const idx = lines.findIndex(l => l.trim().startsWith(`${key} =`));
+    if (idx === -1) {
+        // Add after header
+        lines.splice(1, 0, configLine);
+    } else {
+        lines[idx] = configLine;
+    }
+}
+
 function addDefaultModelConfig(
     projectPath: string, token: string, backendUrl: string) {
     const targetTable = `[ballerina.ai.wso2ProviderConfig]`;
@@ -195,18 +207,6 @@ function addDefaultModelConfig(
     // Extract table content and split into lines once
     let tableContent = fileContent.substring(tableStartIndex, tableEndIndex);
     let lines = tableContent.split('\n');
-
-    // Helper to add or replace a config line
-    function addOrReplaceConfigLine(lines: string[], key: string, value: string) {
-        const configLine = `${key} = "${value}"`;
-        const idx = lines.findIndex(l => l.trim().startsWith(`${key} =`));
-        if (idx === -1) {
-            // Add after header
-            lines.splice(1, 0, configLine);
-        } else {
-            lines[idx] = configLine;
-        }
-    }
 
     // Add or replace serviceUrl
     addOrReplaceConfigLine(lines, SERVICE_URL_KEY, backendUrl);

--- a/workspaces/ballerina/ballerina-extension/src/features/natural-programming/utils.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/natural-programming/utils.ts
@@ -43,7 +43,7 @@ import { OLD_BACKEND_URL } from '../ai/utils';
 import { AIMachineEventType, BallerinaProject } from '@wso2/ballerina-core';
 import { getCurrentBallerinaProjectFromContext } from '../config-generator/configGenerator';
 import { BallerinaExtension } from 'src/core';
-import { getRefreshedAccessToken, REFRESH_TOKEN_NOT_AVAILABLE_ERROR_MESSAGE } from '../../../src/utils/ai/auth';
+import { getRefreshedAccessToken, REFRESH_TOKEN_NOT_AVAILABLE_ERROR_MESSAGE, TOKEN_REFRESH_ONLY_SUPPORTED_FOR_BI_INTEL } from '../../../src/utils/ai/auth';
 import { AIStateMachine } from '../../../src/views/ai-panel/aiMachine';
 import { fetchWithAuth } from '../ai/service/connection';
 
@@ -614,7 +614,7 @@ export async function getTokenForNaturalFunction() {
         }
         return token;
     } catch (error) {
-        if ((error as Error).message === REFRESH_TOKEN_NOT_AVAILABLE_ERROR_MESSAGE) {
+        if ((error as Error).message === REFRESH_TOKEN_NOT_AVAILABLE_ERROR_MESSAGE || (error as Error).message === TOKEN_REFRESH_ONLY_SUPPORTED_FOR_BI_INTEL) {
             vscode.window.showWarningMessage(LOGIN_REQUIRED_WARNING);
         }
         throw error;

--- a/workspaces/ballerina/ballerina-extension/src/utils/ai/auth.ts
+++ b/workspaces/ballerina/ballerina-extension/src/utils/ai/auth.ts
@@ -24,6 +24,7 @@ import { jwtDecode, JwtPayload } from 'jwt-decode';
 import { AuthCredentials, LoginMethod } from '@wso2/ballerina-core';
 
 export const REFRESH_TOKEN_NOT_AVAILABLE_ERROR_MESSAGE = "Refresh token is not available.";
+export const TOKEN_REFRESH_ONLY_SUPPORTED_FOR_BI_INTEL = "Token refresh is only supported for BI Intelligence authentication";
 export const AUTH_CREDENTIALS_SECRET_KEY = 'BallerinaAuthCredentials';
 
 //TODO: What if user doesnt have github copilot.
@@ -214,7 +215,7 @@ export const getRefreshedAccessToken = async (): Promise<string> => {
         try {
             const credentials = await getAuthCredentials();
             if (!credentials || credentials.loginMethod !== LoginMethod.BI_INTEL) {
-                throw new Error('Token refresh is only supported for BI Intel authentication');
+                throw new Error(TOKEN_REFRESH_ONLY_SUPPORTED_FOR_BI_INTEL);
             }
 
             const { refreshToken } = credentials.secrets;


### PR DESCRIPTION
## Purpose

Related Issue: [wso2/product-ballerina-integrator#822](https://github.com/wso2/product-ballerina-integrator/issues/822)

This PR refactors the `addDefaultModelConfig` function to ensure that the configuration values for the WSO2 Model Provider are added or updated correctly without duplicating entries, particularly the accessToken.

**Current behavior:** When an accessToken is already set in the config, using the "Ballerina: Configure Default WSO2 Model Provider" command results in a duplicate accessToken line being added.

https://github.com/user-attachments/assets/ab76c361-e9e4-4223-b765-136fbdc9095a

Changes Include:
The updated logic now handles the following scenarios:

**1. No existing config**
Adds the full configuration block:
```toml
[ballerina.ai.wso2ProviderConfig]
serviceUrl = "SERVICE-URL"
accessToken = "ACCESS-TOKEN"
```
**2. Config already exists**
Updates the `serviceUrl` and `accessToken` if they are present.

**3. Partial config exists**
Adds any missing fields (`serviceUrl`, `accessToken`) while preserving existing values.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## UI Component Development
> Specify the reason if following are not followed.
- [ ] Added reusable UI components to the ui-toolkit. Follow the [intructions](./workspaces/common-libs/ui-toolkit/README.md) when adding the componenent.
- [ ] Use ui-toolkit components wherever possible. Run `npm run storybook` from the root directory to view current components.
- [ ] Matches with the native VSCode look and feel.

## Manage Icons
> Specify the reason if following are not followed.
- [ ] Added Icons to the font-wso2-vscode. Follow the [instructions](./workspaces/common-libs/font-wso2-vscode/README.md).

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.