### PR TITLE
Add an extension setting to include the current organization in the search

### DIFF
--- a/workspaces/ballerina/ballerina-core/src/interfaces/extended-lang-client.ts
+++ b/workspaces/ballerina/ballerina-core/src/interfaces/extended-lang-client.ts
@@ -836,6 +836,7 @@ export type SearchQueryParams = {
     limit?: number;
     offset?: number;
     includeAvailableFunctions?: string;
+    includeCurrentOrganizationInSearch?: boolean;
 }
 
 export type SearchKind = 'FUNCTION' | 'CONNECTOR' | 'TYPE' | "NP_FUNCTION" | "MODEL_PROVIDER" | "VECTOR_STORE" | "EMBEDDING_PROVIDER" | "VECTOR_KNOWLEDGE_BASE";

--- a/workspaces/ballerina/ballerina-extension/package.json
+++ b/workspaces/ballerina/ballerina-extension/package.json
@@ -212,6 +212,14 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Enable AI suggestions in the Flow Diagram View."
+                },
+                "ballerina.includeCurrentOrganizationInSearch": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Include components from the current organization in the search. This queries the Ballerina Central using the organization specified in the `Ballerina.toml`.",
+                    "tags": [
+                        "experimental"
+                    ]
                 }
             }
         },

--- a/workspaces/ballerina/ballerina-extension/src/core/extension.ts
+++ b/workspaces/ballerina/ballerina-extension/src/core/extension.ts
@@ -47,7 +47,8 @@ import {
     DEFINE_BALLERINA_INTEGRATOR_SCOPE,
     SHOW_LIBRARY_CONFIG_VARIABLES,
     LANG_SERVER_PATH,
-    USE_BALLERINA_CLI_LANG_SERVER
+    USE_BALLERINA_CLI_LANG_SERVER,
+    INCLUDE_CURRENT_ORGANIZATION_IN_SEARCH
 }
     from "./preferences";
 import TelemetryReporter from "vscode-extension-telemetry";
@@ -84,7 +85,6 @@ export enum WEBVIEW_TYPE {
     BBE,
     CONFIGURABLE
 }
-
 export interface ConstructIdentifier {
     filePath: string;
     kind: string;
@@ -1720,6 +1720,10 @@ export class BallerinaExtension {
 
     public showLibraryConfigVariables(): boolean {
         return <boolean>workspace.getConfiguration().get(SHOW_LIBRARY_CONFIG_VARIABLES);
+    }
+
+    public getIncludeCurrentOrgComponents(): boolean {
+        return <boolean>workspace.getConfiguration().get(INCLUDE_CURRENT_ORGANIZATION_IN_SEARCH);
     }
 
     public getDocumentContext(): DocumentContext {

--- a/workspaces/ballerina/ballerina-extension/src/core/preferences.ts
+++ b/workspaces/ballerina/ballerina-extension/src/core/preferences.ts
@@ -38,3 +38,4 @@ export const DEFINE_BALLERINA_INTEGRATOR_SCOPE = "ballerina.scope";
 export const SHOW_LIBRARY_CONFIG_VARIABLES = "ballerina.showLibraryConfigVariables"; // this setting is not visible to the extension user
 export const LANG_SERVER_PATH = "ballerina.langServerPath"; // this setting is not visible to the extension user
 export const USE_BALLERINA_CLI_LANG_SERVER = "ballerina.useDistributionLanguageServer";
+export const INCLUDE_CURRENT_ORGANIZATION_IN_SEARCH = "ballerina.includeCurrentOrganizationInSearch";

--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/bi-diagram/rpc-manager.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/bi-diagram/rpc-manager.ts
@@ -1536,6 +1536,10 @@ export class BiDiagramRpcManager implements BIDiagramAPI {
 
     async search(params: BISearchRequest): Promise<BISearchResponse> {
         return new Promise((resolve, reject) => {
+            params.queryMap = {
+                ...params.queryMap,
+                includeCurrentOrganizationInSearch: extension.ballerinaExtInstance.getIncludeCurrentOrgComponents(),
+            };
             StateMachine.langClient().search(params).then((res) => {
                 resolve(res);
             }).catch((error) => {


### PR DESCRIPTION
## Purpose
This flag will be appended to each search query, allowing the LS to query the central with the organization specified in the `Ballerina.toml`.

Addresses https://github.com/wso2/product-ballerina-integrator/issues/758