### PR TITLE
Update connector icon logic to show WSO2 logo

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/utils/bi.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/utils/bi.tsx
@@ -122,11 +122,12 @@ function convertDiagramCategoryToSidePanelCategory(category: Category, functionT
 
     // HACK: use the icon of the first item in the category
     const icon = category.items.at(0)?.metadata.icon;
+    const codedata = (category.items.at(0) as AvailableNode)?.codedata;
 
     return {
         title: category.metadata.label,
         description: category.metadata.description,
-        icon: <ConnectorIcon url={icon} style={{ width: "20px", height: "20px", fontSize: "20px" }} />,
+        icon: <ConnectorIcon url={icon} style={{ width: "20px", height: "20px", fontSize: "20px" }} codedata={codedata} />,
         items: items,
     };
 }
@@ -158,22 +159,30 @@ export function convertModelProviderCategoriesToSidePanelCategories(categories: 
     const panelCategories = categories.map((category) => convertDiagramCategoryToSidePanelCategory(category));
     panelCategories.forEach((category) => {
         category.items?.forEach((item) => {
-            item.icon = <AIModelIcon type={(item as PanelNode).metadata.codedata.module} />;
+            const codedata = (item as PanelNode).metadata.codedata;
+            item.icon = <AIModelIcon type={codedata?.module} codedata={codedata} />;
         });
     });
     return panelCategories;
 }
 
 export function convertVectorStoreCategoriesToSidePanelCategories(categories: Category[]): PanelCategory[] {
-    return categories.map((category) => convertDiagramCategoryToSidePanelCategory(category));
+    const panelCategories = categories.map((category) => convertDiagramCategoryToSidePanelCategory(category));
+    panelCategories.forEach((category) => {
+        category.items?.forEach((item) => {
+            const codedata = (item as PanelNode).metadata.codedata;
+            item.icon = <NodeIcon type={codedata?.node} size={24} />;
+        });
+    });
+    return panelCategories;
 }
 
 export function convertEmbeddingProviderCategoriesToSidePanelCategories(categories: Category[]): PanelCategory[] {
-    return categories.map((category) => convertDiagramCategoryToSidePanelCategory(category));
+    return convertModelProviderCategoriesToSidePanelCategories(categories);
 }
 
 export function convertVectorKnowledgeBaseCategoriesToSidePanelCategories(categories: Category[]): PanelCategory[] {
-    return categories.map((category) => convertDiagramCategoryToSidePanelCategory(category));
+    return convertModelProviderCategoriesToSidePanelCategories(categories);
 }
 
 export function convertNodePropertiesToFormFields(
@@ -1065,7 +1074,7 @@ export function filterUnsupportedDiagnostics(diagnostics: Diagnostic[]): Diagnos
 
 /**
  * Check if the type is supported by the data mapper
- * 
+ *
  * @param type - The type to check
  * @returns Whether the type is supported by the data mapper
  */

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
@@ -54,6 +54,7 @@ import {
     convertModelProviderCategoriesToSidePanelCategories,
     convertVectorStoreCategoriesToSidePanelCategories,
     convertEmbeddingProviderCategoriesToSidePanelCategories,
+    convertVectorKnowledgeBaseCategoriesToSidePanelCategories,
 } from "../../../utils/bi";
 import { NodePosition, STNode } from "@wso2/syntax-tree";
 import { View, ProgressRing, ProgressIndicator, ThemeColors } from "@wso2/ui-toolkit";
@@ -246,12 +247,7 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                     filePath: model?.fileName,
                 });
                 console.log(">>> Refreshed model provider list", response);
-                setCategories(
-                    convertFunctionCategoriesToSidePanelCategories(
-                        response.categories as Category[],
-                        FUNCTION_TYPE.REGULAR
-                    )
-                );
+                setCategories(convertModelProviderCategoriesToSidePanelCategories(response.categories as Category[]));
                 setSidePanelView(SidePanelView.MODEL_PROVIDER_LIST);
                 setShowSidePanel(true);
             } catch (error) {
@@ -280,10 +276,7 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                 });
                 console.log(">>> Refreshed vector store list", response);
                 setCategories(
-                    convertFunctionCategoriesToSidePanelCategories(
-                        response.categories as Category[],
-                        FUNCTION_TYPE.REGULAR
-                    )
+                    convertVectorStoreCategoriesToSidePanelCategories(response.categories as Category[])
                 );
                 setSidePanelView(SidePanelView.VECTOR_STORE_LIST);
                 setShowSidePanel(true);
@@ -313,10 +306,7 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                 });
                 console.log(">>> Refreshed embedding provider list", response);
                 setCategories(
-                    convertFunctionCategoriesToSidePanelCategories(
-                        response.categories as Category[],
-                        FUNCTION_TYPE.REGULAR
-                    )
+                    convertVectorKnowledgeBaseCategoriesToSidePanelCategories(response.categories as Category[])
                 );
                 setSidePanelView(SidePanelView.EMBEDDING_PROVIDER_LIST);
                 setShowSidePanel(true);

--- a/workspaces/ballerina/bi-diagram/src/components/AIModelIcon/index.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/AIModelIcon/index.tsx
@@ -24,13 +24,20 @@ import DeepseekIcon from "../../resources/icons/DeepseekIcon";
 import { AnthropicIcon } from "../../resources/icons/AnthropicIcon";
 import { MistralAIIcon } from "../../resources/icons/MistralAIIcon";
 import { OllamaIcon } from "../../resources/icons/OllamaIcon";
+import { Icon } from "@wso2/ui-toolkit";
+import { CodeData } from "@wso2/ballerina-core";
 
 interface AIModelIconProps {
     type: string;
+    codedata?: CodeData;
 }
 
 export function AIModelIcon(props: AIModelIconProps): React.ReactElement {
-    const { type } = props;
+    const { type, codedata } = props;
+
+    if (codedata && isWso2Module(codedata)) {
+        return <Icon name="bi-wso2" sx={{ width: 24, height: 24, fontSize: 24 }} />;
+    }
 
     switch (type) {
         case "OpenAiProvider":
@@ -54,4 +61,16 @@ export function AIModelIcon(props: AIModelIconProps): React.ReactElement {
         default:
             return <DefaultLlmIcon />;
     }
+}
+
+export function isWso2Module(codedata: CodeData): boolean {
+    if (codedata?.module === "ai") {
+        if (["Wso2ModelProvider", "Wso2EmbeddingProvider"].includes(codedata.object)) {
+            return true;
+        }
+        if (["getDefaultModelProvider", "getDefaultEmbeddingProvider"].includes(codedata.symbol)) {
+            return true;
+        }
+    }
+    return false;
 }

--- a/workspaces/ballerina/bi-diagram/src/components/ConnectorIcon/index.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/ConnectorIcon/index.tsx
@@ -16,10 +16,9 @@
  * under the License.
  */
 
-import React, { CSSProperties, useState } from "react";
+import React, { CSSProperties } from "react";
 import { Icon } from "@wso2/ui-toolkit";
 import { ApiIcon } from "../../resources";
-import { getAIColor, ThemeListener } from "../NodeIcon";
 import OpenAiIcon from "../../resources/icons/OpenAiIcon";
 import AzureOpenAiIcon from "../../resources/icons/AzureOpenAiIcon";
 import AnthropicIcon from "../../resources/icons/AnthropicIcon";
@@ -27,16 +26,19 @@ import OllamaIcon from "../../resources/icons/OllamaIcon";
 import MistralAIIcon from "../../resources/icons/MistralAIIcon";
 import DeepseekIcon from "../../resources/icons/DeepseekIcon";
 import DefaultLlmIcon from "../../resources/icons/DefaultLlmIcon";
+import { CodeData } from "@wso2/ballerina-core";
+import { isWso2Module } from "../AIModelIcon";
 
 interface ConnectorIconProps {
     url?: string;
     fallbackIcon?: React.ReactNode;
     style?: CSSProperties; // Custom style for images
     className?: string;
+    codedata?: CodeData;
 }
 
 export function ConnectorIcon(props: ConnectorIconProps): React.ReactElement {
-    const { url, fallbackIcon, className, style } = props;
+    const { url, fallbackIcon, className, style, codedata } = props;
     const [imageError, setImageError] = React.useState(false);
 
     // use custom icon for http
@@ -49,6 +51,11 @@ export function ConnectorIcon(props: ConnectorIconProps): React.ReactElement {
     if (aiModules.some((module) => url?.includes(module))) {
         const selectedModule = aiModules.find((module) => url?.includes(module));
         return getLlmModelIcons(selectedModule);
+    }
+
+    // use custom icon for wso2 module
+    if (codedata && isWso2Module(codedata)) {
+        return <Icon name="bi-wso2" className={className} sx={{ width: 24, height: 24, fontSize: 24, ...style }} />;
     }
 
     // use custom icon for ai module

--- a/workspaces/ballerina/bi-diagram/src/components/NodeIcon/index.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/NodeIcon/index.tsx
@@ -222,10 +222,14 @@ const NODE_ICONS: Record<NodeKind, React.FC<{ size: number; color: string }>> = 
     FAIL: ({ size, color }) => <Icon name="bi-error" sx={{ fontSize: size, width: size, height: size, color }} />,
     RETRY: ({ size, color }) => <Icon name="bi-retry" sx={{ fontSize: size, width: size, height: size, color }} />,
     AGENT_CALL: ({ size, color }) => <Icon name="bi-ai-agent" sx={{ fontSize: size, width: size, height: size, color }} />,
+    MODEL_PROVIDER: ({ size, color }) => <Icon name="bi-ai-model" sx={{ fontSize: size, width: size, height: size, color }} />,
     MODEL_PROVIDERS: ({ size, color }) => <Icon name="bi-ai-model" sx={{ fontSize: size, width: size, height: size, color }} />,
+    VECTOR_KNOWLEDGE_BASE: ({ size, color }) => <Icon name="bi-db-kb" sx={{ fontSize: size, width: size, height: size, color }} />,
     VECTOR_KNOWLEDGE_BASES: ({ size, color }) => <Icon name="bi-db-kb" sx={{ fontSize: size, width: size, height: size, color }} />,
     VECTOR_KNOWLEDGE_BASE_CALL: ({ size, color }) => <CallIcon />,
+    VECTOR_STORE: ({ size, color }) => <Icon name="bi-db" sx={{ fontSize: size, width: size, height: size, color }} />,
     VECTOR_STORES: ({ size, color }) => <Icon name="bi-db" sx={{ fontSize: size, width: size, height: size, color }} />,
+    EMBEDDING_PROVIDER: ({ size, color }) => <Icon name="bi-doc" sx={{ fontSize: size, width: size, height: size, color }} />,
     EMBEDDING_PROVIDERS: ({ size, color }) => <Icon name="bi-doc" sx={{ fontSize: size, width: size, height: size, color }} />,
     // Default case for any NodeKind not explicitly handled
 } as Record<NodeKind, React.FC<{ size: number; color: string }>>;

--- a/workspaces/ballerina/bi-diagram/src/components/nodes/AgentCallNode/AgentCallNodeWidget.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/nodes/AgentCallNode/AgentCallNodeWidget.tsx
@@ -733,6 +733,7 @@ export function AgentCallNodeWidget(props: AgentCallNodeWidgetProps) {
                                         url={tool.path}
                                         style={{ width: 24, height: 24, fontSize: 24 }}
                                         fallbackIcon={<Icon name="bi-function" sx={{ fontSize: "24px" }} />}
+                                        codedata={model.node?.codedata}
                                     />
                                 )}
                                 {!tool.path && <Icon name="bi-function" sx={{ fontSize: "24px" }} />}

--- a/workspaces/ballerina/bi-diagram/src/components/nodes/ApiCallNode/ApiCallNodeWidget.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/nodes/ApiCallNode/ApiCallNodeWidget.tsx
@@ -381,7 +381,7 @@ export function ApiCallNodeWidget(props: ApiCallNodeWidgetProps) {
                         : model.node.properties.connection.value as ReactNode}
                 </text>
                 <foreignObject x="68" y="12" width="24" height="24" fill={ThemeColors.ON_SURFACE}>
-                    <ConnectorIcon url={model.node.metadata.icon} style={{ width: 24, height: 24, fontSize: 24 }} />
+                    <ConnectorIcon url={model.node.metadata.icon} style={{ width: 24, height: 24, fontSize: 24 }} codedata={model.node?.codedata} />
                 </foreignObject>
                 <line
                     x1="0"

--- a/workspaces/common-libs/font-wso2-vscode/src/icons/bi-wso2.svg
+++ b/workspaces/common-libs/font-wso2-vscode/src/icons/bi-wso2.svg
@@ -1,0 +1,70 @@
+<!--
+ ~ Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ ~
+ ~ WSO2 LLC. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied. See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+-->
+
+
+<svg
+    version="1.1"
+    id="layer"
+    x="0px"
+    y="0px"
+    viewBox="0 0 652 652"
+    style="enable-background:new 0 0 652 652;"
+    xml:space="preserve"
+    sodipodi:docname="bi-wso2-2.svg"
+    inkscape:version="1.3.2 (091e20e, 2023-11-25)"
+    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs2" /><sodipodi:namedview
+   id="namedview2"
+   pagecolor="#505050"
+   bordercolor="#eeeeee"
+   borderopacity="1"
+   inkscape:showpageshadow="0"
+   inkscape:pageopacity="0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#505050"
+   inkscape:zoom="0.65191397"
+   inkscape:cx="258.46969"
+   inkscape:cy="96.638518"
+   inkscape:window-width="1728"
+   inkscape:window-height="1051"
+   inkscape:window-x="0"
+   inkscape:window-y="38"
+   inkscape:window-maximized="0"
+   inkscape:current-layer="layer" />
+<style
+   type="text/css"
+   id="style1">
+	.st0{fill:#FF7300;}
+	.st1{fill:#FFFFFF;}
+</style>
+
+<polygon
+   class="st1"
+   points="433.2,315.7 373.9,315.7 373.9,304.5 425.6,304.5 457.3,234 492.6,319.8 506.7,294.6 540.8,294.6 540.8,305.7 513.7,305.7 491.4,346.3 456.7,262.8 "
+   id="polygon1"
+   style="fill:#000000"
+   transform="matrix(2.9791676,0,0,2.9791676,-1034.035,-566.8927)" />
+<path
+   d="M 533.3051,123.38044 C 479.08425,67.372089 410.86132,39.367914 328.33837,39.367914 h -3.575 c -50.64585,0 -99.80211,12.214587 -143.59588,38.431262 -43.79377,26.216674 -78.65003,61.370854 -105.164621,106.654204 -26.514592,45.28333 -38.431262,94.4396 -38.431262,147.17086 0,78.65003 28.004175,147.17088 84.012523,203.17923 56.00835,56.00835 124.2313,84.01253 206.45633,84.01253 v 0 c 80.43752,0 148.95838,-28.00418 204.96673,-84.01253 56.00835,-56.00835 84.01252,-124.23129 84.01252,-204.96673 2.08542,-82.22502 -25.91875,-152.23545 -83.71461,-206.4563 z m -1.7875,323.83551 c -21.15209,36.64376 -49.15626,64.64793 -84.01252,85.80002 -36.64376,21.15209 -75.37294,31.57918 -117.37921,31.57918 h -1.7875 c -64.64793,0 -119.16671,-22.64167 -164.45006,-66.43544 -45.58126,-45.58126 -68.222935,-99.80211 -68.222935,-166.23755 0,-43.79376 10.427085,-84.01253 29.791675,-120.65628 21.15209,-35.15417 49.15627,-64.64793 85.80003,-85.80002 36.64377,-21.15209 75.37295,-31.579179 115.59171,-31.579179 h 1.7875 c 40.21876,0 80.43753,10.427089 115.5917,31.579179 36.64376,21.15209 64.64794,49.15626 85.80003,84.01252 21.15209,35.15417 29.79168,75.37293 29.79168,119.1667 1.48958,43.19793 -9.23542,83.41669 -28.3021,118.57087 z"
+   id="path2"
+   sodipodi:nodetypes="csssssssssccccsscscssscccc"
+   style="stroke-width:2.97917" />
+</svg>


### PR DESCRIPTION
## Purpose

This pull request updates the connector icon rendering to display the WSO2 logo for specific WSO2 components.

Changes

- The WSO2 logo has been added to the icon font library.
- The connector icon rendering component is updated to display the WSO2 logo for the `Wso2ModelProvider` and `Wso2EmbeddingProvider`.
- The component now checks the `codeData` to identify if it is a WSO2 module and renders the appropriate logo.