### PR TITLE
Upgrade tmp to 0.2.4 to resolve CVE-2025-54798

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -3504,8 +3504,8 @@ importers:
         specifier: ^0.23.11
         version: 0.23.11
       tmp:
-        specifier: ~0.2.3
-        version: 0.2.3
+        specifier: ~0.2.4
+        version: 0.2.4
       to-json-schema:
         specifier: 0.2.5
         version: 0.2.5
@@ -20242,6 +20242,10 @@ packages:
 
   tmp@0.2.3:
     resolution: {integrity: sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==}
+    engines: {node: '>=14.14'}
+
+  tmp@0.2.4:
+    resolution: {integrity: sha512-UdiSoX6ypifLmrfQ/XfiawN6hkjSBpCjhKxxZcWlUUmoXLaCKQU0bx4HF/tdDK2uzRuchf1txGvrWBzYREssoQ==}
     engines: {node: '>=14.14'}
 
   tmpl@1.0.5:
@@ -40791,10 +40795,7 @@ snapshots:
       pretty-format: 25.5.0
       throat: 5.0.0
     transitivePeerDependencies:
-      - bufferutil
-      - canvas
       - supports-color
-      - utf-8-validate
 
   jest-leak-detector@25.5.0:
     dependencies:
@@ -46226,7 +46227,7 @@ snapshots:
     dependencies:
       '@bazel/runfiles': 6.3.1
       jszip: 3.10.1
-      tmp: 0.2.3
+      tmp: 0.2.4
       ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
@@ -47658,6 +47659,8 @@ snapshots:
       os-tmpdir: 1.0.2
 
   tmp@0.2.3: {}
+
+  tmp@0.2.4: {}
 
   tmpl@1.0.5: {}
 

--- a/workspaces/mi/mi-extension/package.json
+++ b/workspaces/mi/mi-extension/package.json
@@ -953,7 +953,7 @@
     "node-loader": "~2.1.0",
     "to-json-schema": "0.2.5",
     "xml2js": "0.6.2",
-    "tmp": "~0.2.3",
+    "tmp": "~0.2.4",
     "fs-extra": "~11.3.0",
     "@iarna/toml": "^2.2.5",
     "@types/tmp": "~0.2.6",


### PR DESCRIPTION
## Purpose

This PR upgrades the `tmp` package to resolve a low-severity security vulnerability identified by a Trivy scan.
The `tmp` package has been updated from version `0.2.3` to `0.2.4` to mitigate this issue.

