### PR TITLE
Fix variable form field reorder on edit

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/utils/bi.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/utils/bi.tsx
@@ -419,7 +419,7 @@ export function removeDraftNodeFromDiagram(flowModel: Flow) {
     return newFlow;
 }
 
-export function enrichFormPropertiesWithValueConstraint(
+export function enrichFormTemplatePropertiesWithValues(
     formProperties: NodeProperties,
     formTemplateProperties: NodeProperties
 ) {
@@ -428,7 +428,10 @@ export function enrichFormPropertiesWithValueConstraint(
     for (const key in formProperties) {
         if (formProperties.hasOwnProperty(key)) {
             const formProperty = formProperties[key as NodePropertyKey];
-            if (formProperty && enrichedFormTemplateProperties[key as NodePropertyKey]) {
+            if (
+                formProperty &&
+                enrichedFormTemplateProperties[key as NodePropertyKey] != null
+            ) {
                 // Copy the value from formProperties to formTemplateProperties
                 enrichedFormTemplateProperties[key as NodePropertyKey].value = formProperty.value;
             }

--- a/workspaces/ballerina/ballerina-visualizer/src/utils/bi.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/utils/bi.tsx
@@ -423,21 +423,19 @@ export function enrichFormPropertiesWithValueConstraint(
     formProperties: NodeProperties,
     formTemplateProperties: NodeProperties
 ) {
-    const enrichedFormProperties = cloneDeep(formProperties);
+    const enrichedFormTemplateProperties = cloneDeep(formTemplateProperties);
 
-    for (const key in formTemplateProperties) {
-        if (formTemplateProperties.hasOwnProperty(key)) {
-            const expression = formTemplateProperties[key as NodePropertyKey];
-            if (expression) {
-                const valConstraint = formTemplateProperties[key as NodePropertyKey]?.valueTypeConstraint;
-                if (valConstraint && enrichedFormProperties[key as NodePropertyKey]) {
-                    enrichedFormProperties[key as NodePropertyKey].valueTypeConstraint = valConstraint;
-                }
+    for (const key in formProperties) {
+        if (formProperties.hasOwnProperty(key)) {
+            const formProperty = formProperties[key as NodePropertyKey];
+            if (formProperty && enrichedFormTemplateProperties[key as NodePropertyKey]) {
+                // Copy the value from formProperties to formTemplateProperties
+                enrichedFormTemplateProperties[key as NodePropertyKey].value = formProperty.value;
             }
         }
     }
 
-    return enrichedFormProperties;
+    return enrichedFormTemplateProperties;
 }
 
 function getEnrichedValue(kind: CompletionItemKind, value: string): CompletionInsertText {

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FormGenerator/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FormGenerator/index.tsx
@@ -62,7 +62,7 @@ import {
     convertNodePropertiesToFormFields,
     convertToFnSignature,
     convertToVisibleTypes,
-    enrichFormPropertiesWithValueConstraint,
+    enrichFormTemplatePropertiesWithValues,
     filterUnsupportedDiagnostics,
     getFormProperties,
     getImportsForFormFields,
@@ -243,7 +243,7 @@ export const FormGenerator = forwardRef<FormExpressionEditorRef, FormProps>(func
         let enrichedNodeProperties;
         if (nodeFormTemplate) {
             const formTemplateProperties = getFormProperties(nodeFormTemplate);
-            enrichedNodeProperties = enrichFormPropertiesWithValueConstraint(formProperties, formTemplateProperties);
+            enrichedNodeProperties = enrichFormTemplatePropertiesWithValues(formProperties, formTemplateProperties);
             console.log(">>> Form properties", { formProperties, formTemplateProperties, enrichedNodeProperties });
         }
         if (Object.keys(formProperties).length === 0) {


### PR DESCRIPTION
## Purpose

Fixes an issue where variable form fields were reordered when a user attempted to edit a variable node. This is achieved by refactoring enrichFormPropertiesWithValueConstraint to correctly copy values from formProperties to formTemplateProperties.

Related Issue: https://github.com/wso2/product-ballerina-integrator/issues/970