### PR TITLE
Fix capturing project tags from resolved pom content

### DIFF
--- a/workspaces/mi/mi-extension/src/util/migrationUtils.ts
+++ b/workspaces/mi/mi-extension/src/util/migrationUtils.ts
@@ -299,7 +299,7 @@ export async function generateProjectDirToResolvedPomMap(multiModuleProjectDir: 
     }
     const resolvedPomContent = pomResolvedResult.content || '';
 
-    const projectRegex = /<project[\s\S]*?<\/project>/g;
+    const projectRegex = /<project [\s\S]*?<\/project>/g;
     let match;
     while ((match = projectRegex.exec(resolvedPomContent)) !== null) {
         const projectXml = match[0];


### PR DESCRIPTION
## Purpose
Previously it was capturing `projects` tags as well. But we need to only capture `project` tags. 