### PR TITLE
Hide AI RAG nodes as advanced nodes

### DIFF
--- a/workspaces/ballerina/ballerina-extension/package.json
+++ b/workspaces/ballerina/ballerina-extension/package.json
@@ -224,7 +224,7 @@
                 "ballerina.showAdvancedAiNodes": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Show advanced AI nodes (Chunker, Vector Store, Embedding Provider, Recursive Document Chunker) in the Flow Diagram View node palette."
+                    "description": "Show advanced AI nodes (Chunker, Vector Store, Embedding Provider, Recursive Document Chunker) in the Flow Diagram View's node palette."
                 },
                 "ballerina-vscode.trace.server": {
                     "type": "string",

--- a/workspaces/ballerina/ballerina-extension/package.json
+++ b/workspaces/ballerina/ballerina-extension/package.json
@@ -221,6 +221,11 @@
                         "experimental"
                     ]
                 },
+                "ballerina.showAdvancedAiNodes": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Show advanced AI nodes (Chunker, Vector Store, Embedding Provider, Recursive Document Chunker) in the Flow Diagram View node palette."
+                },
                 "ballerina-vscode.trace.server": {
                     "type": "string",
                     "default": "off",

--- a/workspaces/ballerina/ballerina-extension/src/core/extension.ts
+++ b/workspaces/ballerina/ballerina-extension/src/core/extension.ts
@@ -48,7 +48,8 @@ import {
     SHOW_LIBRARY_CONFIG_VARIABLES,
     LANG_SERVER_PATH,
     USE_BALLERINA_CLI_LANG_SERVER,
-    INCLUDE_CURRENT_ORGANIZATION_IN_SEARCH
+    INCLUDE_CURRENT_ORGANIZATION_IN_SEARCH,
+    SHOW_ADVANCED_AI_NODES
 }
     from "./preferences";
 import TelemetryReporter from "vscode-extension-telemetry";
@@ -1726,6 +1727,10 @@ export class BallerinaExtension {
 
     public getIncludeCurrentOrgComponents(): boolean {
         return <boolean>workspace.getConfiguration().get(INCLUDE_CURRENT_ORGANIZATION_IN_SEARCH);
+    }
+
+    public getShowAdvancedAiNodes(): boolean {
+        return <boolean>workspace.getConfiguration().get(SHOW_ADVANCED_AI_NODES);
     }
 
     public getDocumentContext(): DocumentContext {

--- a/workspaces/ballerina/ballerina-extension/src/core/preferences.ts
+++ b/workspaces/ballerina/ballerina-extension/src/core/preferences.ts
@@ -41,3 +41,4 @@ export const SHOW_LIBRARY_CONFIG_VARIABLES = "ballerina.showLibraryConfigVariabl
 export const LANG_SERVER_PATH = "ballerina.langServerPath"; // this setting is not visible to the extension user
 export const USE_BALLERINA_CLI_LANG_SERVER = "ballerina.useDistributionLanguageServer";
 export const INCLUDE_CURRENT_ORGANIZATION_IN_SEARCH = "ballerina.includeCurrentOrganizationInSearch";
+export const SHOW_ADVANCED_AI_NODES = "ballerina.showAdvancedAiNodes";

--- a/workspaces/ballerina/bi-diagram/src/components/NodeIcon/index.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/NodeIcon/index.tsx
@@ -90,7 +90,11 @@ const NODE_COLOR_GROUPS = {
         "VECTOR_STORES",
         "EMBEDDING_PROVIDER",
         "EMBEDDING_PROVIDERS",
-    ],    
+        "DATA_LOADER",
+        "DATA_LOADERS",
+        "CHUNKER",
+        "CHUNKERS"
+    ],
     // Data related - magenta variants
     MAGENTA_DATA_GROUP: ["VARIABLE", "NEW_DATA", "UPDATE_DATA", "ASSIGN"],
     
@@ -231,6 +235,10 @@ const NODE_ICONS: Record<NodeKind, React.FC<{ size: number; color: string }>> = 
     VECTOR_STORES: ({ size, color }) => <Icon name="bi-db" sx={{ fontSize: size, width: size, height: size, color }} />,
     EMBEDDING_PROVIDER: ({ size, color }) => <Icon name="bi-doc" sx={{ fontSize: size, width: size, height: size, color }} />,
     EMBEDDING_PROVIDERS: ({ size, color }) => <Icon name="bi-doc" sx={{ fontSize: size, width: size, height: size, color }} />,
+    DATA_LOADER: ({ size, color }) => <Icon name="bi-data-table" sx={{ fontSize: size, width: size, height: size, color }} />,
+    DATA_LOADERS: ({ size, color }) => <Icon name="bi-data-table" sx={{ fontSize: size, width: size, height: size, color }} />,
+    CHUNKER: ({ size, color }) => <Icon name="bi-cut" sx={{ fontSize: size, width: size, height: size, color }} />,
+    CHUNKERS: ({ size, color }) => <Icon name="bi-cut" sx={{ fontSize: size, width: size, height: size, color }} />,
     // Default case for any NodeKind not explicitly handled
 } as Record<NodeKind, React.FC<{ size: number; color: string }>>;
 

--- a/workspaces/common-libs/font-wso2-vscode/src/icons/bi-data-table.svg
+++ b/workspaces/common-libs/font-wso2-vscode/src/icons/bi-data-table.svg
@@ -1,0 +1,21 @@
+<!--
+ ~ Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ ~
+ ~ WSO2 LLC. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied. See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <path fill="#000"
+        d="M5 21q-.825 0-1.412-.587T3 19V5q0-.825.588-1.412T5 3h14q.825 0 1.413.588T21 5v14q0 .825-.587 1.413T19 21zM5 8.325h14V5H5zm0 5.35h14v-3.35H5zM5 19h14v-3.325H5zM7 7.65q-.425 0-.712-.288T6 6.65t.288-.712T7 5.65t.713.288T8 6.65t-.288.713T7 7.65M7 13q-.425 0-.712-.288T6 12t.288-.712T7 11t.713.288T8 12t-.288.713T7 13m0 5.35q-.425 0-.712-.288T6 17.35t.288-.712T7 16.35t.713.288t.287.712t-.288.713T7 18.35" />
+</svg>


### PR DESCRIPTION
## Purpose
Hides the following AI RAG node types by default: `Chunker, Vector Store, Embedding Provider, and Recursive Document Chunker`. These nodes can be enabled by setting `ballerina.showAdvancedAiNodes` to true in the Ballerina extension.

**Task**: https://github.com/wso2/product-ballerina-integrator/issues/1019

https://github.com/user-attachments/assets/6cc0a3af-dff8-4d14-9689-8ec8fe17b5a4




