### PR TITLE
fix variable creation form variable name reset on type change

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/Form/index.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/Form/index.tsx
@@ -442,7 +442,9 @@ export const Form = forwardRef((props: FormProps, ref) => {
                 } else {
                     defaultValues[field.key] = field.value ?? "";
                 }
-
+                if (field.key === "variable") {
+                    defaultValues[field.key] = formValues[field.key] ?? "";
+                }
                 if (field.key === "parameters" && field.value.length === 0) {
                     defaultValues[field.key] = formValues[field.key] ?? [];
                 }


### PR DESCRIPTION
## Purpose
When updating the variable type in the variable form, entered data (such as the variable name) is reset. This forces the user to re-enter information, which negatively impacts the user experience.  
Fixes #1109

---

## Goals
- Preserve other form fields (e.g., variable name) when the variable type is changed.
- Improve the overall user experience by preventing unnecessary data loss.

---
