### PR TITLE
fix variables label trimming issue

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Components/ExpandableList.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Components/ExpandableList.tsx
@@ -61,13 +61,11 @@ interface ExpandableListSectionProps {
 const Section = ({ children, title, level = 0, sx }: ExpandableListSectionProps) => {
     return (
         <ExpandableListSection level={level} style={{ ...sx , display: 'flex', flexDirection: 'column'}}>
-            <ExpandableListSectionTitle>{title}</ExpandableListSectionTitle>
+            <ExpandableListSectionTitle style={{marginLeft: '8px'}}>{title}</ExpandableListSectionTitle>
             {children}
         </ExpandableListSection>
     );
 };
-
-
 
 
 ExpandableList.Item = Item;
@@ -77,7 +75,7 @@ export default ExpandableList;
 
 
 const ExpandableListSection = styled.div<{ level?: number }>`
-    padding-left: ${({ level = 0 }) => (level * 5) + 10}px;
+   
 `;
 
 

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/Variables.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/Variables.tsx
@@ -47,6 +47,54 @@ type VariablesPageProps = {
     handleRetrieveCompletions: (value: string, property: ExpressionProperty, offset: number, triggerCharacter?: string) => Promise<void>;
 }
 
+type VariableItemProps = {
+    item: CompletionItem;
+    onItemSelect: (value: string) => void;
+    onMoreIconClick: (value: string) => void;
+}
+
+const VariableItem = ({ item, onItemSelect, onMoreIconClick }: VariableItemProps) => {
+    const [isHovered, setIsHovered] = useState(false);
+
+    return (
+        <SlidingPaneNavContainer
+            onMouseEnter={() => setIsHovered(true)}
+            onMouseLeave={() => setIsHovered(false)}
+            onClick={() => onItemSelect(item.label)}
+            data
+            sx={{
+                maxHeight: isHovered?"none":"32px" 
+            }}
+            endIcon={
+                <VariablesMoreIconContainer style={{ height: "10px" }} onClick={(event) => {
+                    event.stopPropagation();
+                    onMoreIconClick(item.label);
+                }}>
+                    <VariableTypeIndicator >
+                        {item.description}
+                    </VariableTypeIndicator>
+                    <Codicon name="chevron-right" />
+                </VariablesMoreIconContainer>}
+        >
+            <ExpandableList.Item>
+                {getIcon(item.kind)}
+                <Typography 
+                    variant="body3"
+                    sx={{
+                        maxWidth: isHovered ? 'none' : '20ch',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: isHovered ? 'normal' : 'nowrap',
+                        transition: 'all 0.3s ease'
+                    }}
+                >
+                    {item.label}
+                </Typography>
+            </ExpandableList.Item>
+        </SlidingPaneNavContainer>
+    );
+};
+
 const VariablesMoreIconContainer = styled.div`
     display: flex;
     align-items: center;
@@ -153,31 +201,14 @@ export const Variables = (props: VariablesPageProps) => {
             <>
                 {
                     filteredDropDownItems.map((item) => (
-                        <SlidingPaneNavContainer
-                            onClick={() => handleItemSelect(item.label)}
-                            data
-                            endIcon={
-                                <VariablesMoreIconContainer onClick={(event) => {
-                                    event.stopPropagation()
-                                    handleVariablesMoreIconClick(item.label)
-                                }}>
-                                    <VariableTypeIndicator>
-                                        {item.description}
-                                    </VariableTypeIndicator>
-                                    <Codicon name="chevron-right" />
-                                </VariablesMoreIconContainer>}
-                        >
-                            <ExpandableList.Item>
-                                {getIcon(item.kind)}
-                                <Typography variant="body3">
-                                    {item.label}
-                                </Typography>
-
-                            </ExpandableList.Item>
-                        </SlidingPaneNavContainer>
+                        <VariableItem
+                            key={item.label}
+                            item={item}
+                            onItemSelect={handleItemSelect}
+                            onMoreIconClick={handleVariablesMoreIconClick}
+                        />
                     ))
                 }
-
             </>
         )
     }

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/Variables.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/Variables.tsx
@@ -63,7 +63,7 @@ const VariableItem = ({ item, onItemSelect, onMoreIconClick }: VariableItemProps
             onClick={() => onItemSelect(item.label)}
             data
             sx={{
-                maxHeight: isHovered?"none":"32px" 
+                maxHeight: isHovered ? "none" : "32px" 
             }}
             endIcon={
                 <VariablesMoreIconContainer style={{ height: "10px" }} onClick={(event) => {

--- a/workspaces/common-libs/ui-toolkit/src/components/ExpressionEditor/components/Common/SlidingPane/index.tsx
+++ b/workspaces/common-libs/ui-toolkit/src/components/ExpressionEditor/components/Common/SlidingPane/index.tsx
@@ -208,11 +208,13 @@ type SlidingPaneNavContainerProps = {
     data?: any;
     endIcon?: ReactNode;
     onClick?: () => void;
+    onMouseEnter?: () => void;
+    onMouseLeave?: () => void;
     sx?: React.CSSProperties;
     ref?: React.Ref<HTMLDivElement> | null;
 }
 
-export const SlidingPaneNavContainer = ({ children, to, data, endIcon, onClick, sx, ref }: SlidingPaneNavContainerProps) => {
+export const SlidingPaneNavContainer = ({ children, to, data, endIcon, onClick, sx, ref, onMouseEnter, onMouseLeave }: SlidingPaneNavContainerProps) => {
     const { moveToNext } = useSlidingPane();
     const handleNavigation = () => {
         if (!to) return;
@@ -223,7 +225,7 @@ export const SlidingPaneNavContainer = ({ children, to, data, endIcon, onClick, 
     }
 
     return (
-        <SlidingPaneNavContainerElm ref={ref} style={sx}>
+        <SlidingPaneNavContainerElm onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave} ref={ref} style={sx}>
             <InvisibleButton
                 className="sliding-pane-text"
                 style={{ width: '100%' }}


### PR DESCRIPTION
## Purpose
The helper pane currently crops longer content in variables dropdown, making it difficult for users to view the full suggestion.  
**Resolves:** [Issue: #1110]

## Goals
Introduce a solution that ensures longer content in the helper pane is accessible without breaking the current UI. This includes trimming text in the visible area while allowing full content on hover.

## Approach
- Truncate long text in the helper pane variables for better UI consistency.
- Implement a hover-based expansion that displays the complete text on hover.