### PR TITLE
fix graphql typeHelper displays incorrect options

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FormGeneratorNew/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FormGeneratorNew/index.tsx
@@ -223,7 +223,7 @@ export function FormGeneratorNew(props: FormProps) {
                 allowAdditionalFields: false
             };
         } return {
-            name: typeEditorState.newTypeValue || "MyType2",
+            name: typeEditorState.newTypeValue || "MyType",
             editable: true,
             metadata: {
                 label: "",

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FormGeneratorNew/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FormGeneratorNew/index.tsx
@@ -813,7 +813,7 @@ export function FormGeneratorNew(props: FormProps) {
                             ))}
                         </BreadcrumbContainer>
                         <FormTypeEditor
-                            type={ defaultType()}
+                            type={ isGraphqlEditor? defaultType() : undefined}
                             newType={peekTypeStack() ? peekTypeStack().isDirty : false}
                             newTypeValue={typeEditorState.newTypeValue}
                             onTypeChange={handleTypeChange}

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FormGeneratorNew/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FormGeneratorNew/index.tsx
@@ -208,7 +208,7 @@ export function FormGeneratorNew(props: FormProps) {
     const defaultType = (): Type => {
         if (typeEditorState.field?.type === 'PARAM_MANAGER') {
             return {
-                name: typeEditorState.newTypeValue || "MyType1",
+                name: typeEditorState.newTypeValue || "MyType",
                 editable: true,
                 metadata: {
                     label: "",

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FormGeneratorNew/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FormGeneratorNew/index.tsx
@@ -205,6 +205,41 @@ export function FormGeneratorNew(props: FormProps) {
         });
     };
 
+    const defaultType = (): Type => {
+        if (typeEditorState.field?.type === 'PARAM_MANAGER') {
+            return {
+                name: typeEditorState.newTypeValue || "MyType1",
+                editable: true,
+                metadata: {
+                    label: "",
+                    description: "",
+                },
+                codedata: {
+                    node: "RECORD",
+                },
+                properties: {},
+                members: [],
+                includes: [] as string[],
+                allowAdditionalFields: false
+            };
+        } return {
+            name: typeEditorState.newTypeValue || "MyType2",
+            editable: true,
+            metadata: {
+                label: "",
+                description: ""
+            },
+            codedata: {
+                node: "CLASS"
+            },
+            properties: {},
+            members: [],
+            includes: [] as string[],
+            functions: []
+        };
+    }
+
+
     useEffect(() => {
         if (rpcClient) {
             // Set current theme
@@ -649,26 +684,8 @@ export function FormGeneratorNew(props: FormProps) {
 
     const getNewTypeCreateForm = () => {
         pushTypeStack({
-            type: {
-                name: "",
-                members: [] as Member[],
-                editable: true,
-                metadata: {
-                    description: "",
-                    label: ""
-                },
-                properties: {},
-                codedata: {
-                    node: "RECORD" as TypeNodeKind
-                },
-                includes: [] as string[],
-                allowAdditionalFields: false
-            },
+            type: defaultType(), 
             isDirty: false
-        })
-        setTypeEditorState({
-            isOpen: true,
-            newTypeValue: "Haha Value"
         })
     }
 
@@ -796,15 +813,15 @@ export function FormGeneratorNew(props: FormProps) {
                             ))}
                         </BreadcrumbContainer>
                         <FormTypeEditor
-                            type={peekTypeStack()?.type}
+                            type={ defaultType()}
                             newType={peekTypeStack() ? peekTypeStack().isDirty : false}
                             newTypeValue={typeEditorState.newTypeValue}
-                            isGraphql={isGraphqlEditor}
                             onTypeChange={handleTypeChange}
                             onSaveType={onSaveType}
                             onTypeCreate={handleTypeCreate}
                             getNewTypeCreateForm={getNewTypeCreateForm}
                             refetchTypes={refetchStates[i]}
+                            isGraphql={isGraphqlEditor}
                         />
                     </div>
                 </DynamicModal>)

--- a/workspaces/ballerina/ballerina-visualizer/src/views/GraphQLDiagram/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/GraphQLDiagram/index.tsx
@@ -355,11 +355,7 @@ export function GraphQLDiagram(props: GraphQLDiagramProps) {
                         newType={false}
                         isGraphql={true}
                         onTypeCreate={() => { }}
-                        getNewTypeCreateForm={function (): void {
-                            throw new Error("Function not implemented.");
-                        }} onSaveType={function (type: Type): void {
-                            throw new Error("Function not implemented.");
-                        }} refetchTypes={false} />
+                    />
                 </PanelContainer>
             )}
             {isTypeEditorOpen && editingType && editingType.codedata.node === "CLASS" && (

--- a/workspaces/ballerina/ballerina-visualizer/src/views/GraphQLDiagram/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/GraphQLDiagram/index.tsx
@@ -355,7 +355,11 @@ export function GraphQLDiagram(props: GraphQLDiagramProps) {
                         newType={false}
                         isGraphql={true}
                         onTypeCreate={() => { }}
-                    />
+                        getNewTypeCreateForm={function (): void {
+                            throw new Error("Function not implemented.");
+                        }} onSaveType={function (type: Type): void {
+                            throw new Error("Function not implemented.");
+                        }} refetchTypes={false} />
                 </PanelContainer>
             )}
             {isTypeEditorOpen && editingType && editingType.codedata.node === "CLASS" && (

--- a/workspaces/ballerina/ballerina-visualizer/src/views/TypeDiagram/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/TypeDiagram/index.tsx
@@ -382,11 +382,7 @@ export function TypeDiagram(props: TypeDiagramProps) {
                         newType={typeEditorState.editingTypeId ? false : true}
                         onTypeChange={onTypeChange}
                         onTypeCreate={handleTypeCreate} 
-                        getNewTypeCreateForm={function (): void {
-                            throw new Error("Function not implemented.");
-                        } } onSaveType={function (type: Type): void {
-                            throw new Error("Function not implemented.");
-                        } } refetchTypes={false}                    />
+                     />
                 </PanelContainer>
             )}
         </>

--- a/workspaces/ballerina/ballerina-visualizer/src/views/TypeDiagram/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/TypeDiagram/index.tsx
@@ -381,8 +381,12 @@ export function TypeDiagram(props: TypeDiagramProps) {
                         type={findSelectedType(typeEditorState.editingTypeId)}
                         newType={typeEditorState.editingTypeId ? false : true}
                         onTypeChange={onTypeChange}
-                        onTypeCreate={handleTypeCreate}
-                    />
+                        onTypeCreate={handleTypeCreate} 
+                        getNewTypeCreateForm={function (): void {
+                            throw new Error("Function not implemented.");
+                        } } onSaveType={function (type: Type): void {
+                            throw new Error("Function not implemented.");
+                        } } refetchTypes={false}                    />
                 </PanelContainer>
             )}
         </>


### PR DESCRIPTION
## Purpose
Fix the incorrect options shown in the **Create New Type** flow in `TypeHelper` within the GraphQL context.  

**Resolves:** Issue – [wso2/product-ballerina-integrator#](https://github.com/wso2/product-ballerina-integrator/issues/1120)1120

## Goals
- Ensure field types correctly display **Object types (Service classes)** and **Input Object types (Records)**.  

## Approach
- Updated the `TypeHelper` logic to differentiate between graphql and other forms.  