### PR TITLE
fix type helper not closing when selecting

### DIFF
--- a/workspaces/ballerina/type-editor/src/TypeHelper/TypeHelper.tsx
+++ b/workspaces/ballerina/type-editor/src/TypeHelper/TypeHelper.tsx
@@ -356,12 +356,13 @@ export const TypeHelperComponent = (props: TypeHelperComponentProps) => {
                                     onClick={() => onTypeCreate(newTypeName.current)}
                                 />
                             )}
-                            <FooterButtons
+                            {/* TODO: Decided to either rewrite or remove it */}
+                            {/* <FooterButtons
                                 sx={{ display: 'flex', justifyContent: 'space-between' }}
                                 startIcon='library'
                                 title="Open Type Browser"
                                 onClick={() => setIsTypeBrowserOpen(true)}
-                            />
+                            /> */}
                         </div>
                     </SlidingPane>
                 </SlidingWindow>

--- a/workspaces/ballerina/type-editor/src/TypeHelper/TypeHelper.tsx
+++ b/workspaces/ballerina/type-editor/src/TypeHelper/TypeHelper.tsx
@@ -211,7 +211,7 @@ export const TypeHelperComponent = (props: TypeHelperComponentProps) => {
             currentType.slice(0, prefixCursorPosition) + item.insertText + currentType.slice(suffixCursorPosition),
             prefixCursorPosition + item.insertText.length
         );
-
+        onClose();
         onCloseCompletions?.();
     };
 


### PR DESCRIPTION
## Purpose
Fix the issue where the **TypeHelper** remains open after a suggestion is selected.  

**Resolves:** [Issue – https://github.com/wso2/product-ballerina-integrator/issues/1118]

## Goals
- Automatically close the **TypeHelper** when a suggestion is selected.  
- Removed the type browser from the type helper

## Approach
- Updated TypeHelper behavior to close when suggestion is selected.  
