### PR TITLE
Fix type crease modal

### DIFF
--- a/workspaces/ballerina/ballerina-core/src/interfaces/bi.ts
+++ b/workspaces/ballerina/ballerina-core/src/interfaces/bi.ts
@@ -417,7 +417,6 @@ export type NodeKind =
     | "STOP"
     | "TRANSACTION"
     | "UPDATE_DATA"
-    | "VARIABLE"
     | "WAIT"
     | "WHILE"
     | "WORKER"

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/TypeEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/TypeEditor.tsx
@@ -91,7 +91,7 @@ const getDefaultCompletion = (newType: string) => {
 }
 
 export function TypeEditor(props: TypeEditorProps) {
-    const { field, openRecordEditor, handleOnFieldFocus, handleOnTypeChange, autoFocus, handleNewTypeSelected } = props;
+    const { field, openRecordEditor, handleOnFieldFocus, handleOnTypeChange, autoFocus } = props;
     const { form, expressionEditor } = useFormContext();
     const { control } = form;
     const {
@@ -268,7 +268,6 @@ export function TypeEditor(props: TypeEditorProps) {
 
                                 // Set show default completion
                                 const typeExists = referenceTypes.find((type) => type.label === updatedValue);
-                                handleNewTypeSelected && handleNewTypeSelected(typeExists)
                                 const validTypeForCreation = updatedValue.match(/^[a-zA-Z_'][a-zA-Z0-9_]*$/);
                                 if (updatedValue && !typeExists && validTypeForCreation) {
                                     setShowDefaultCompletion(true);

--- a/workspaces/ballerina/ballerina-visualizer/src/components/Modal/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/components/Modal/index.tsx
@@ -115,8 +115,10 @@ const DynamicModal: React.FC<DynamicModalProps> & { Trigger: typeof Trigger } = 
         setShowOverlay(false);
         onClose && onClose();
     };
-
-    setShowOverlay(openState === true);
+    
+    useEffect(() => {
+        setShowOverlay(openState === true);
+    });
 
     useEffect(() => {
         return () => {

--- a/workspaces/ballerina/ballerina-visualizer/src/components/Modal/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/components/Modal/index.tsx
@@ -116,9 +116,7 @@ const DynamicModal: React.FC<DynamicModalProps> & { Trigger: typeof Trigger } = 
         onClose && onClose();
     };
 
-    if (openState) {
-        setShowOverlay(true);
-    }
+    setShowOverlay(openState === true);
 
     useEffect(() => {
         return () => {

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FormGenerator/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FormGenerator/index.tsx
@@ -37,7 +37,8 @@ import {
     CodeData,
     VisualizableField,
     Member,
-    TypeNodeKind
+    TypeNodeKind,
+    NodeKind
 } from "@wso2/ballerina-core";
 import {
     FormField,
@@ -241,12 +242,26 @@ export const FormGenerator = forwardRef<FormExpressionEditorRef, FormProps>(func
     };
 
     const popTypeStack = () => {
-        setStack((prev) => prev.slice(0, -1));
+        setStack((prev) => {
+            const newStack = prev.slice(0, -1);
+            // If stack becomes empty, reset to initial state
+            if (newStack.length === 0) {
+                return [{
+                    isDirty: false,
+                    type: undefined
+                }];
+            }
+            return newStack;
+        });
         setRefetchStates((prev) => {
             const newStates = [...prev];
             const currentState = newStates.pop();
             if (currentState && newStates.length > 0) {
                 newStates[newStates.length - 1] = true;
+            }
+            // If no states left, add initial state
+            if (newStates.length === 0) {
+                newStates.push(false);
             }
             return newStates;
         });
@@ -858,9 +873,8 @@ export const FormGenerator = forwardRef<FormExpressionEditorRef, FormProps>(func
         if (stack.length > 0) {
             setRefetchForCurrentModal(true);
             popTypeStack();
-        } else {
-            setTypeEditorState({ isOpen: false });
         }
+        setTypeEditorState({ isOpen: stack.length !== 1 });
     }
 
     const handleSelectedTypeChange = (type: CompletionItem) => {
@@ -1018,7 +1032,7 @@ export const FormGenerator = forwardRef<FormExpressionEditorRef, FormProps>(func
                     isInferredReturnType={!!node.codedata?.inferredReturnType}
                     formImports={formImports}
                     handleSelectedTypeChange={handleSelectedTypeChange}
-                    preserveOrder={node.codedata.node === "VARIABLE" || node.codedata.node === "CONFIG_VARIABLE"}
+                    preserveOrder={node.codedata.node === "VARIABLE" as NodeKind || node.codedata.node === "CONFIG_VARIABLE" as NodeKind}
                 />
                 {
                     stack.map((item, i) => <DynamicModal
@@ -1089,7 +1103,7 @@ export const FormGenerator = forwardRef<FormExpressionEditorRef, FormProps>(func
                     isInferredReturnType={!!node.codedata?.inferredReturnType}
                     formImports={formImports}
                     handleSelectedTypeChange={handleSelectedTypeChange}
-                    preserveOrder={node.codedata.node === "VARIABLE" || node.codedata.node === "CONFIG_VARIABLE"}
+                    preserveOrder={node.codedata.node === "VARIABLE" as NodeKind || node.codedata.node === "CONFIG_VARIABLE" as NodeKind}
                     scopeFieldAddon={scopeFieldAddon}
                     newServerUrl={newServerUrl}
                     onChange={onChange}

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FormGeneratorNew/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FormGeneratorNew/index.tsx
@@ -171,12 +171,26 @@ export function FormGeneratorNew(props: FormProps) {
     };
 
     const popTypeStack = () => {
-        setStack((prev) => prev.slice(0, -1));
+        setStack((prev) => {
+            const newStack = prev.slice(0, -1);
+            // If stack becomes empty, reset to initial state
+            if (newStack.length === 0) {
+                return [{
+                    isDirty: false,
+                    type: undefined
+                }];
+            }
+            return newStack;
+        });
         setRefetchStates((prev) => {
             const newStates = [...prev];
             const currentState = newStates.pop();
             if (currentState && newStates.length > 0) {
                 newStates[newStates.length - 1] = true;
+            }
+            // If no states left, add initial state
+            if (newStates.length === 0) {
+                newStates.push(false);
             }
             return newStates;
         });
@@ -676,9 +690,8 @@ export function FormGeneratorNew(props: FormProps) {
         if (stack.length > 0) {
             setRefetchForCurrentModal(true);
             popTypeStack();
-        } else {
-            setTypeEditorState({ isOpen: false });
         }
+        setTypeEditorState({ isOpen: stack.length !== 1 });
     }
 
     const extractArgsFromFunction = async (value: string, property: ExpressionProperty, cursorPosition: number) => {

--- a/workspaces/ballerina/ballerina-visualizer/src/views/GraphQLDiagram/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/GraphQLDiagram/index.tsx
@@ -175,7 +175,6 @@ export function GraphQLDiagram(props: GraphQLDiagramProps) {
                 popTypeStack();
                 return;
             }
-            stack[0].type = undefined
         }
         setTypeEditorState({ isOpen: state });
     }
@@ -468,22 +467,6 @@ export function GraphQLDiagram(props: GraphQLDiagramProps) {
                 />
             )}
             {isTypeEditorOpen && editingType && editingType.codedata.node !== "CLASS" && (
-                // <PanelContainer
-                //     title={`Edit Type${getTypeKindDisplayName(editingType?.codedata?.node) ?
-                //         ` : ${getTypeKindDisplayName(editingType?.codedata?.node)}` :
-                //         ''}`}
-                //     show={true}
-                //     onClose={onTypeEditorClosed}
-                // >
-                //     <FormTypeEditor
-                //         key={editingType.name}
-                //         type={editingType}
-                //         onTypeChange={onTypeChange}
-                //         newType={false}
-                //         isGraphql={true}
-                //         onTypeCreate={() => { }}
-                //     />
-                // </PanelContainer>
                 <>
                     {
                         stack.map((item, i) => <DynamicModal

--- a/workspaces/ballerina/ballerina-visualizer/src/views/GraphQLDiagram/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/GraphQLDiagram/index.tsx
@@ -113,12 +113,26 @@ export function GraphQLDiagram(props: GraphQLDiagramProps) {
     };
 
     const popTypeStack = () => {
-        setStack((prev) => prev.slice(0, -1));
+        setStack((prev) => {
+            const newStack = prev.slice(0, -1);
+            // If stack becomes empty, reset to initial state
+            if (newStack.length === 0) {
+                return [{
+                    isDirty: false,
+                    type: undefined
+                }];
+            }
+            return newStack;
+        });
         setRefetchStates((prev) => {
             const newStates = [...prev];
             const currentState = newStates.pop();
             if (currentState && newStates.length > 0) {
                 newStates[newStates.length - 1] = true;
+            }
+            // If no states left, add initial state
+            if (newStates.length === 0) {
+                newStates.push(false);
             }
             return newStates;
         });
@@ -151,9 +165,8 @@ export function GraphQLDiagram(props: GraphQLDiagramProps) {
         if (stack.length > 0) {
             setRefetchForCurrentModal(true);
             popTypeStack();
-        } else {
-            setTypeEditorState({ isOpen: false });
         }
+        setTypeEditorState({ isOpen: stack.length !== 1 });
     }
 
     const handleTypeEditorStateChange = (state: boolean) => {

--- a/workspaces/ballerina/ballerina-visualizer/src/views/TypeDiagram/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/TypeDiagram/index.tsx
@@ -119,7 +119,6 @@ export function TypeDiagram(props: TypeDiagramProps) {
     };
 
     const replaceTop = (item: StackItem) => {
-        console.log("this meses up")
         if (stack.length === 0) return;
         setStack((prev) => {
             const newStack = [...prev];

--- a/workspaces/ballerina/ballerina-visualizer/src/views/TypeDiagram/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/TypeDiagram/index.tsx
@@ -20,14 +20,14 @@ import React, { useEffect, useRef, useState } from "react";
 import { VisualizerLocation, NodePosition, Type, EVENT_TYPE, MACHINE_VIEW, TypeNodeKind, ComponentInfo, Member } from "@wso2/ballerina-core";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { TypeDiagram as TypeDesignDiagram } from "@wso2/type-diagram";
-import { BreadcrumbContainer, Button, Codicon, ProgressRing, ThemeColors, View, ViewContent } from "@wso2/ui-toolkit";
+import { Button, Codicon, ProgressRing, ThemeColors, View, ViewContent } from "@wso2/ui-toolkit";
 import styled from "@emotion/styled";
 import { PanelContainer } from "@wso2/ballerina-side-panel";
 import { TopNavigationBar } from "../../components/TopNavigationBar";
 import { TitleBar } from "../../components/TitleBar";
 import { FormTypeEditor } from "../BI/TypeEditor";
 import DynamicModal from "../../components/Modal";
-import { BreadcrumbItem, BreadcrumbSeparator } from "../BI/Forms/FormGenerator";
+import { BreadcrumbContainer, BreadcrumbItem, BreadcrumbSeparator } from "../BI/Forms/FormGenerator";
 import { EditorContext, StackItem } from "@wso2/type-editor";
 
 const HeaderContainer = styled.div`

--- a/workspaces/ballerina/ballerina-visualizer/src/views/TypeDiagram/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/TypeDiagram/index.tsx
@@ -89,12 +89,26 @@ export function TypeDiagram(props: TypeDiagramProps) {
     };
 
     const popTypeStack = () => {
-        setStack((prev) => prev.slice(0, -1));
+        setStack((prev) => {
+            const newStack = prev.slice(0, -1);
+            // If stack becomes empty, reset to initial state
+            if (newStack.length === 0) {
+                return [{
+                    isDirty: false,
+                    type: undefined
+                }];
+            }
+            return newStack;
+        });
         setRefetchStates((prev) => {
             const newStates = [...prev];
             const currentState = newStates.pop();
             if (currentState && newStates.length > 0) {
                 newStates[newStates.length - 1] = true;
+            }
+            // If no states left, add initial state
+            if (newStates.length === 0) {
+                newStates.push(false);
             }
             return newStates;
         });
@@ -170,19 +184,17 @@ export function TypeDiagram(props: TypeDiagramProps) {
         }));
     }
 
-
     const onSaveType = (type: Type) => {
         if (stack.length > 0) {
             setRefetchForCurrentModal(true);
             popTypeStack();
-        } else {
-            setTypeEditorState({
-                editingTypeId: undefined,
-                editingType: undefined,
-                isTypeCreatorOpen: false,
-                newTypeName: undefined,
-            });
         }
+        setTypeEditorState({
+            editingTypeId: undefined,
+            editingType: undefined,
+            isTypeCreatorOpen: stack.length !== 1,
+            newTypeName: undefined,
+        });
     }
 
     const getNewTypeCreateForm = () => {

--- a/workspaces/ballerina/type-editor/src/TypeEditor/Tabs/TypeCreatorTab.tsx
+++ b/workspaces/ballerina/type-editor/src/TypeEditor/Tabs/TypeCreatorTab.tsx
@@ -447,7 +447,7 @@ export function TypeCreatorTab(props: TypeCreatorTabProps) {
                         rpcClient={rpcClient}
                         onValidationError={handleValidationError}
                     />
-                    <AdvancedOptions type={type} onChange={setType} />
+                    <AdvancedOptions type={type} onChange={handleSetType} />
                     </>
                 );
             case TypeKind.CLASS:
@@ -467,7 +467,7 @@ export function TypeCreatorTab(props: TypeCreatorTabProps) {
                         onChange={handleSetType}
                         onValidationError={handleValidationError}
                     />
-                    <AdvancedOptions type={type} onChange={setType} />
+                    <AdvancedOptions type={type} onChange={handleSetType} />
                     </>
                 );
             default:

--- a/workspaces/ballerina/type-editor/src/TypeHelper/TypeHelper.tsx
+++ b/workspaces/ballerina/type-editor/src/TypeHelper/TypeHelper.tsx
@@ -211,7 +211,7 @@ export const TypeHelperComponent = (props: TypeHelperComponentProps) => {
             currentType.slice(0, prefixCursorPosition) + item.insertText + currentType.slice(suffixCursorPosition),
             prefixCursorPosition + item.insertText.length
         );
-
+        onClose();
         onCloseCompletions?.();
     };
 
@@ -356,12 +356,13 @@ export const TypeHelperComponent = (props: TypeHelperComponentProps) => {
                                     onClick={() => onTypeCreate(newTypeName.current)}
                                 />
                             )}
-                            <FooterButtons
+                            {/* TODO: Decided to either rewrite or remove it */}
+                            {/* <FooterButtons
                                 sx={{ display: 'flex', justifyContent: 'space-between' }}
                                 startIcon='library'
                                 title="Open Type Browser"
                                 onClick={() => setIsTypeBrowserOpen(true)}
-                            />
+                            /> */}
                         </div>
                     </SlidingPane>
                 </SlidingWindow>


### PR DESCRIPTION
## Purpose
This PR addresses two main issues:
1. **Type Editor not opening** on the type diagram.
2. **Build errors** that were blocking successful compilation.

Resolves: https://github.com/wso2/product-ballerina-integrator/issues/1122, https://github.com/wso2/product-ballerina-integrator/issues/1154

## Goals
- Ensure that the Type Editor opens correctly when interacting with the type diagram.
- Eliminate build errors to restore a stable development workflow.
- Improve overall reliability of the type diagram functionality.

## Approach
- Investigated the root cause of the Type Editor not opening and applied fixes to the event handling logic in the type diagram.
- Resolved build errors by fixing incompatible code segments and adding mission props and implementations.
- Verified that the Type Editor now consistently opens as expected on the diagram.



