### PR TITLE
Use descriptor.xml to read project details

### DIFF
--- a/workspaces/mi/mi-extension/src/util/importCapp.ts
+++ b/workspaces/mi/mi-extension/src/util/importCapp.ts
@@ -92,6 +92,19 @@ export async function importCapp(params: ImportProjectRequest): Promise<ImportPr
 
     let { projectName, groupId, artifactId, version } = getProjectDetails(path.basename(source));
 
+    // If extractFolderPath contains descriptor.xml get project details from there
+    const descriptorPath = path.join(extractFolderPath, "descriptor.xml");
+    if (fs.existsSync(descriptorPath)) {
+        const descriptorContent = fs.readFileSync(descriptorPath, "utf-8");
+        const descriptorInfo = xmlParser.parse(descriptorContent);
+        const id = descriptorInfo["project"]["id"];
+        const idMatch = id.match(/^(.+?)__(.+?)__(\d+(?:\.\d+){0,2}(?:-[\w\d]+)?)$/);
+        projectName = idMatch ? idMatch[2] : projectName;
+        groupId = idMatch ? idMatch[1] : groupId;
+        artifactId = projectName;
+        version = idMatch ? idMatch[3] : version;
+    }
+
     if (projectName && groupId && artifactId && version) {
         const folderStructure: FileStructure = {
             'pom.xml': rootPomXmlContent(projectName, groupId, artifactId, projectUuid, version, LATEST_MI_VERSION, ""),


### PR DESCRIPTION
## Purpose

With the new CAPP versioning feature, we need to have the correct groupID and artifactID per each dependent project. Therefore, we need to use the descriptor.xml to read project details