### PR TITLE
Type creator color0change

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/utils/bi.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/utils/bi.tsx
@@ -500,6 +500,10 @@ export function convertBalCompletion(completion: ExpressionCompletionItem): Comp
     const description = completion.detail;
     const sortText = completion.sortText;
     const additionalTextEdits = completion.additionalTextEdits;
+    const labelDetails = {
+        description,
+        detail: completion.detail,
+    };
 
     return {
         tag,
@@ -509,7 +513,8 @@ export function convertBalCompletion(completion: ExpressionCompletionItem): Comp
         kind,
         sortText,
         additionalTextEdits,
-        cursorOffset
+        cursorOffset,
+        labelDetails
     };
 }
 
@@ -843,6 +848,7 @@ export function convertToVisibleTypes(types: VisibleTypeItem[], isFetchingTypesF
         value: type.insertText,
         kind: convertCompletionItemKind(type.kind),
         insertText: type.insertText,
+        labelDetails: type.labelDetails,
     }));
 }
 

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/DeclareVariableForm/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/DeclareVariableForm/index.tsx
@@ -33,21 +33,8 @@ export const VariableForm = (props: FormProps) => {
     }, [props.formFields]);
 
     const handleOnTypeChange = (type: CompletionItem) => {
-        updateExpressionValueTypeConstraint(type?.value || '');
         handleSelectedTypeChange(type);
     };
-
-    const updateExpressionValueTypeConstraint = (valueTypeConstraint: string) => {
-        const fieldsWithoutExpression = props.formFields.filter((field) => {
-            return field.type !== "ACTION_OR_EXPRESSION";
-        });
-        const expressionField = props.formFields.find((field) => field.type === "ACTION_OR_EXPRESSION");
-        if (expressionField) {
-            expressionField.valueTypeConstraint = valueTypeConstraint;
-        }
-        const updatedFields = [...fieldsWithoutExpression, expressionField];
-        setFormFields(updatedFields);
-    }
     return (
         <>
             <Form {...props}  handleSelectedTypeChange={handleOnTypeChange} formFields={formFields} />

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FormGenerator/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FormGenerator/index.tsx
@@ -880,22 +880,22 @@ export const FormGenerator = forwardRef<FormExpressionEditorRef, FormProps>(func
         setTypeEditorState({ isOpen: stack.length !== 1 });
     }
 
-        /**
-         * Updates record type fields and value type constraints when a type is selected.
-         * This is used in variable declaration forms where the variable type dynamically changes.
-         */
-        const updateRecordTypeFields = (type?: { label: string; labelDetails?: { description?: string } }) => {
-            if (!type) {
-                setValueTypeConstraints([]);
-                return;
-            }
-            setValueTypeConstraints(type.label);
-    
-            // If not a Record, remove the 'expression' entry from recordTypeFields and return
-            if (type?.labelDetails?.description !== "Record") {
-                setRecordTypeFields(prevFields => prevFields.filter(f => f.key !== "expression"));
-                return;
-            }
+    /**
+     * Updates record type fields and value type constraints when a type is selected.
+     * This is used in variable declaration forms where the variable type dynamically changes.
+     */
+    const updateRecordTypeFields = (type?: { label: string; labelDetails?: { description?: string } }) => {
+        if (!type) {
+            setValueTypeConstraints([]);
+            return;
+        }
+        setValueTypeConstraints(type.label);
+
+        // If not a Record, remove the 'expression' entry from recordTypeFields and return
+        if (type?.labelDetails?.description !== "Record") {
+            setRecordTypeFields(prevFields => prevFields.filter(f => f.key !== "expression"));
+            return;
+        }
 
         // Find the Expression property
         const expressionEntry = Object.entries(getFormProperties(node))

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FormGenerator/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FormGenerator/index.tsx
@@ -1030,16 +1030,18 @@ export const FormGenerator = forwardRef<FormExpressionEditorRef, FormProps>(func
                         openState={typeEditorState.isOpen}
                         setOpenState={handleTypeEditorStateChange}>
                         <div style={{ padding: '0px 15px' }}>
-                            <BreadcrumbContainer>
-                                {stack.slice(0, i + 1).map((stackItem, index) => (
-                                    <React.Fragment key={index}>
-                                        {index > 0 && <BreadcrumbSeparator>/</BreadcrumbSeparator>}
-                                        <BreadcrumbItem>
-                                            {stackItem?.type?.name || "New Type"}
-                                        </BreadcrumbItem>
-                                    </React.Fragment>
-                                ))}
-                            </BreadcrumbContainer>
+                            {stack.slice(0, i + 1).length > 1 && (
+                                <BreadcrumbContainer>
+                                    {stack.slice(0, i + 1).map((stackItem, index) => (
+                                        <React.Fragment key={index}>
+                                            {index > 0 && <BreadcrumbSeparator>/</BreadcrumbSeparator>}
+                                            <BreadcrumbItem>
+                                                {stackItem?.type?.name || "New Type"}
+                                            </BreadcrumbItem>
+                                        </React.Fragment>
+                                    ))}
+                                </BreadcrumbContainer>
+                            )}
                             <FormTypeEditor
                                 type={peekTypeStack()?.type}
                                 newType={peekTypeStack() ? peekTypeStack().isDirty : false}
@@ -1107,16 +1109,18 @@ export const FormGenerator = forwardRef<FormExpressionEditorRef, FormProps>(func
                     openState={typeEditorState.isOpen}
                     setOpenState={handleTypeEditorStateChange}>
                     <div style={{ padding: '0px 20px' }}>
-                        <BreadcrumbContainer>
-                            {stack.slice(0, i + 1).map((stackItem, index) => (
-                                <React.Fragment key={index}>
-                                    {index > 0 && <BreadcrumbSeparator>/</BreadcrumbSeparator>}
-                                    <BreadcrumbItem>
-                                        {stackItem?.type?.name || "New Type"}
-                                    </BreadcrumbItem>
-                                </React.Fragment>
-                            ))}
-                        </BreadcrumbContainer>
+                        {stack.slice(0, i + 1).length > 2 && (
+                            <BreadcrumbContainer>
+                                {stack.slice(0, i + 1).map((stackItem, index) => (
+                                    <React.Fragment key={index}>
+                                        {index > 0 && <BreadcrumbSeparator>/</BreadcrumbSeparator>}
+                                        <BreadcrumbItem>
+                                            {stackItem?.type?.name || "NewType"}
+                                        </BreadcrumbItem>
+                                    </React.Fragment>
+                                ))}
+                            </BreadcrumbContainer>
+                        )}
                         <FormTypeEditor
                             type={peekTypeStack()?.type}
                             newType={peekTypeStack() ? peekTypeStack().isDirty : false}

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FormGeneratorNew/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FormGeneratorNew/index.tsx
@@ -802,16 +802,18 @@ export function FormGeneratorNew(props: FormProps) {
                     openState={typeEditorState.isOpen}
                     setOpenState={handleTypeEditorStateChange}>
                     <div style={{ padding: '0px 15px' }}>
-                        <BreadcrumbContainer>
-                            {stack.slice(0, i + 1).map((stackItem, index) => (
-                                <React.Fragment key={index}>
-                                    {index > 0 && <BreadcrumbSeparator>/</BreadcrumbSeparator>}
-                                    <BreadcrumbItem>
-                                        {stackItem?.type?.name || "New Type"}
-                                    </BreadcrumbItem>
-                                </React.Fragment>
-                            ))}
-                        </BreadcrumbContainer>
+                        {stack.slice(0, i + 1).slice(0, i + 1).length > 1 && (
+                            <BreadcrumbContainer>
+                                {stack.slice(0, i + 1).map((stackItem, index) => (
+                                    <React.Fragment key={index}>
+                                        {index > 0 && <BreadcrumbSeparator>/</BreadcrumbSeparator>}
+                                        <BreadcrumbItem>
+                                            {stackItem?.type?.name || "New Type"}
+                                        </BreadcrumbItem>
+                                    </React.Fragment>
+                                ))}
+                            </BreadcrumbContainer>
+                        )}
                         <FormTypeEditor
                             type={ isGraphqlEditor? defaultType() : undefined}
                             newType={peekTypeStack() ? peekTypeStack().isDirty : false}

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPane/ConfigureRecordPage.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPane/ConfigureRecordPage.tsx
@@ -19,10 +19,9 @@
 import { GetRecordConfigResponse, GetRecordConfigRequest, LineRange, RecordTypeField, TypeField, PropertyTypeMemberInfo, UpdateRecordConfigRequest, RecordSourceGenRequest, RecordSourceGenResponse, GetRecordModelFromSourceRequest, GetRecordModelFromSourceResponse } from "@wso2/ballerina-core";
 import { Dropdown, HelperPane, Typography } from "@wso2/ui-toolkit";
 import styled from "@emotion/styled";
-import { useEffect, useRef, useState, useCallback, useMemo } from "react";
+import { useEffect, useRef, useState} from "react";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { RecordConfigView } from "./RecordConfigView";
-import { debounce } from "lodash";
 
 type ConfigureRecordPageProps = {
     fileName: string;
@@ -102,13 +101,20 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
         let org = "";
         let module = "";
         let version = "";
-
-        // Parse packageInfo if it exists and contains colon separators
-        if (defaultSelection?.packageInfo) {
+        let packageName = "";
+        if (defaultSelection?.packageInfo.length > 0) {
             const parts = defaultSelection.packageInfo.split(':');
             if (parts.length === 3) {
                 [org, module, version] = parts;
+                packageName = defaultSelection.packageName;
             }
+        } else {
+            // Fetch from TOML
+            const tomValues = await rpcClient.getCommonRpcClient().getCurrentProjectTomlValues();
+            org = tomValues?.package?.org || "";
+            module = tomValues?.package?.name || "";
+            version = tomValues?.package?.version || "";
+            packageName = `${org}/${module}`;
         }
 
         const request: GetRecordConfigRequest = {
@@ -143,13 +149,21 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
             let org = "";
             let module = "";
             let version = "";
+            let packageName = "";
 
-            // Parse packageInfo if it exists
-            if (member.packageInfo) {
+            if (member?.packageInfo.length > 0) {
                 const parts = member.packageInfo.split(':');
                 if (parts.length === 3) {
                     [org, module, version] = parts;
+                    packageName = member.packageName;
                 }
+            } else {
+                // Fetch from TOML
+                const tomValues = await rpcClient.getCommonRpcClient().getCurrentProjectTomlValues();
+                org = tomValues?.package?.org || "";
+                module = tomValues?.package?.name || "";
+                version = tomValues?.package?.version || "";
+                packageName = `${org}/${module}`;
             }
 
             const request: GetRecordConfigRequest = {

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/Configurables.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/Configurables.tsx
@@ -89,7 +89,8 @@ export const Configurables = (props: ConfigurablesPageProps) => {
                 setPackageInfo({
                     org: "",
                     name: "",
-                    version: ""
+                    version: "",
+                    title: ""
                 });
             }
         };

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/RecordConfigModal.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/RecordConfigModal.tsx
@@ -120,7 +120,7 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
         const request: GetRecordConfigRequest = {
             filePath: fileName,
             codedata: {
-                org: "org",
+                org: org,
                 module: module,
                 version: version,
                 packageName: packageName,

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/RecordConfigModal.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/RecordConfigModal.tsx
@@ -101,22 +101,29 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
         let org = "";
         let module = "";
         let version = "";
+        let packageName = "";
 
-        // Parse packageInfo if it exists and contains colon separators
-        if (defaultSelection?.packageInfo) {
+        if (defaultSelection?.packageInfo.length > 0) {
             const parts = defaultSelection.packageInfo.split(':');
             if (parts.length === 3) {
                 [org, module, version] = parts;
+                packageName = defaultSelection.packageName;
             }
+        } else {
+            const tomValues = await rpcClient.getCommonRpcClient().getCurrentProjectTomlValues();
+            org = tomValues?.package?.org || "";
+            module = tomValues?.package?.name || "";
+            version = tomValues?.package?.version || "";
+            packageName = `${org}/${module}`;
         }
 
         const request: GetRecordConfigRequest = {
             filePath: fileName,
             codedata: {
-                org: org,
+                org: "org",
                 module: module,
                 version: version,
-                packageName: defaultSelection?.packageName,
+                packageName: packageName,
             },
             typeConstraint: defaultSelection.type,
         }

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/index.tsx
@@ -56,6 +56,7 @@ export type HelperPaneNewProps = {
     filteredCompletions?: CompletionItem[];
     isInModal?: boolean;
     valueTypeConstraint?: string | string[];
+    forcedValueTypeConstraint?: string | string[];
     handleRetrieveCompletions: (value: string, property: ExpressionProperty, offset: number, triggerCharacter?: string) => Promise<void>;
 };
 
@@ -81,7 +82,8 @@ const HelperPaneNewEl = ({
     filteredCompletions,
     isInModal,
     valueTypeConstraint,
-    handleRetrieveCompletions
+    handleRetrieveCompletions,
+    forcedValueTypeConstraint
 }: HelperPaneNewProps) => {
     const [position, setPosition] = useState<{ top: number, left: number }>({ top: 0, left: 0 });
     const paneRef = useRef<HTMLDivElement>(null);
@@ -253,7 +255,7 @@ const HelperPaneNewEl = ({
                         <div style={{ padding: '8px 0px' }}>
                             <ExpandableList >
 
-                                {valueTypeConstraint && (
+                                {(valueTypeConstraint || forcedValueTypeConstraint) && (
                                     recordTypeField ?
                                         <SlidingPaneNavContainer onClick={() => setIsModalOpen(true)}>
                                             <ExpandableList.Item>
@@ -346,7 +348,7 @@ const HelperPaneNewEl = ({
                             fileName={fileName}
                             onChange={handleChange}
                             currentValue={currentValue}
-                            selectedType={valueTypeConstraint}
+                            selectedType={valueTypeConstraint || forcedValueTypeConstraint || ''}
                             recordTypeField={recordTypeField}
                             anchorRef={anchorRef} />
                     </SlidingPane>
@@ -444,7 +446,8 @@ export const getHelperPaneNew = (props: HelperPaneNewProps) => {
         selectedType,
         filteredCompletions,
         isInModal,
-        valueTypeConstraint
+        valueTypeConstraint,
+        forcedValueTypeConstraint,
     } = props;
 
     return (
@@ -470,6 +473,7 @@ export const getHelperPaneNew = (props: HelperPaneNewProps) => {
             isInModal={isInModal}
             valueTypeConstraint={valueTypeConstraint}
             handleRetrieveCompletions={props.handleRetrieveCompletions}
+            forcedValueTypeConstraint={forcedValueTypeConstraint}
         />
     );
 };

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/TypeEditor/utils.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/TypeEditor/utils.tsx
@@ -59,7 +59,8 @@ export const getTypes = (types: VisibleTypeItem[], filterDMTypes?: boolean): Typ
         categoryRecord[type.labelDetails.detail].push({
             name: type.label,
             insertText: type.insertText,
-            type: convertCompletionItemKind(type.kind)
+            type: convertCompletionItemKind(type.kind),
+            labelDetails: type.labelDetails
         });
     }
 

--- a/workspaces/ballerina/type-editor/src/TypeHelper/index.tsx
+++ b/workspaces/ballerina/type-editor/src/TypeHelper/index.tsx
@@ -41,6 +41,10 @@ export type TypeHelperItem = {
     type: CompletionItemKind;
     codedata?: CodeData;
     kind?: FunctionKind;
+    labelDetails?: {
+        description: string;
+        detail: string;
+    };
 };
 
 export type TypeHelperCategory = {

--- a/workspaces/common-libs/ui-toolkit/src/components/TabPanel/TabPanel.tsx
+++ b/workspaces/common-libs/ui-toolkit/src/components/TabPanel/TabPanel.tsx
@@ -18,6 +18,7 @@
 
 import React, { ReactNode } from 'react';
 import styled from '@emotion/styled';
+import { ThemeColors } from '../../styles';
 
 export interface TabView {
     id: string;
@@ -94,7 +95,7 @@ const TabButton = styled.button<{ isActive: boolean }>`
 `;
 
 const TabContent = styled.div`
-    background-color: var(--vscode-editor-background, #ffffff);
+    background-color: ${ThemeColors.SURFACE_DIM};
     color: var(--vscode-editor-foreground, #333333);
     flex: 1;
     overflow: auto;


### PR DESCRIPTION
## Purpose
> This PR introduces recordConfig support for user-defined types in the Ballerina Integrator extension. Currently, recordConfig is not properly recognized or handled when applied to user-defined types, limiting the ability to configure such types consistently within the extension. Additionally it changes the styling in type creator and also the breadcrumbs.

## Goals
> Enable full support for recordConfig usage in user-defined types.
> Match the typeCreator color to match the current theme.
> Breadcrumb now only show the steps only when there are atleast two steps present

## Approach
> Extended the type handling logic to recognize and apply recordConfig annotations for user-defined types.
> Change color of components using ThemeColors
