### PR TITLE
Fix helper pane click not responding

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Components/VariableTypeIndicator.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Components/VariableTypeIndicator.tsx
@@ -18,6 +18,7 @@
 
 import styled from "@emotion/styled";
 import { VSCodeTag } from "@vscode/webview-ui-toolkit/react";
+import { ThemeColors } from "@wso2/ui-toolkit";
 
 export const VariableTypeIndicator = styled(VSCodeTag)`
     ::part(control) {
@@ -27,5 +28,15 @@ export const VariableTypeIndicator = styled(VSCodeTag)`
         display: flex;
         align-items: center;
         justify-content: center;
+        max-width: 60px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        padding: 0px 2px;
+    }
+
+    &:hover::part(control) {
+        background-color: ${ThemeColors.PRIMARY};
+        cursor: pointer;
     }
 `;

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/Variables.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/Variables.tsx
@@ -101,7 +101,6 @@ const VariablesMoreIconContainer = styled.div`
     justify-content: center;
     padding: 4px;
      &:hover {
-        background-color:  ${ThemeColors.ON_SURFACE_VARIANT};
         cursor: pointer;
     }
 `;

--- a/workspaces/common-libs/ui-toolkit/src/components/ExpressionEditor/components/Common/SlidingPane/index.tsx
+++ b/workspaces/common-libs/ui-toolkit/src/components/ExpressionEditor/components/Common/SlidingPane/index.tsx
@@ -95,7 +95,7 @@ export const SlidingWindow = ({ children }: SlidingWindowProps) => {
                 getParams: getParams,
                 isInitialRender: isInitialRender
             }}>
-            <SlidingWindowContainer style={{  width: width }}>
+            <SlidingWindowContainer style={{ width: width }}>
                 {children}
             </SlidingWindowContainer>
         </SlidingPaneContext.Provider>
@@ -108,7 +108,7 @@ export const SlidingPaneContainer = styled.div<{ index: number; isCurrent?: bool
   flex-direction: column;
   transition: ${({ clearAnimations }: { clearAnimations: boolean }) =>
         clearAnimations ? 'none' : 'transform 0.3s ease-in-out, height 0.3s ease-in-out'};
-  transform: ${({ index, isInitialRender }: { index: number, isInitialRender?: React.MutableRefObject<boolean> }) => 
+  transform: ${({ index, isInitialRender }: { index: number, isInitialRender?: React.MutableRefObject<boolean> }) =>
         isInitialRender?.current ? 'none' : `translateX(${index * 100}%)`};
 `;
 
@@ -225,33 +225,27 @@ export const SlidingPaneNavContainer = ({ children, to, data, endIcon, onClick, 
     }
 
     return (
-        <SlidingPaneNavContainerElm onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave} ref={ref} style={sx}>
-            <InvisibleButton
-                className="sliding-pane-text"
-                style={{ width: '100%' }}
-                onClick={() => {
-                    if (onClick) {
-                        onClick();
-                    } else {
-                        handleNavigation();
-                    }
-                }}
-            >
-                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', width: '100%' }}>
-                    <div>
-                        {children}
-                    </div>
-                    {
-                        endIcon ? (
-                            <>{endIcon}</>
-                        ) : to ? (
-                            <div style={{ marginLeft: '8px', display: 'flex', alignItems: 'center' }}>
-                                <Codicon name="chevron-right" />
-                            </div>
-                        ) : null
-                    }
+        <SlidingPaneNavContainerElm onClick={() => {
+            if (onClick) {
+                onClick();
+            } else {
+                handleNavigation();
+            }
+        }} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave} ref={ref} style={sx}>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', width: '100%' }}>
+                <div>
+                    {children}
                 </div>
-            </InvisibleButton>
+                {
+                    endIcon ? (
+                        <>{endIcon}</>
+                    ) : to ? (
+                        <div style={{ marginLeft: '8px', display: 'flex', alignItems: 'center' }}>
+                            <Codicon name="chevron-right" />
+                        </div>
+                    ) : null
+                }
+            </div>
         </SlidingPaneNavContainerElm>
     )
 }
@@ -291,7 +285,7 @@ export const SlidingPaneHeader = ({ children }: { children: ReactNode }) => {
         <StickyHeader>
             <div style={{ display: 'flex', gap: '8px', alignItems: 'center', justifyContent: 'flex-start', color: ThemeColors.ON_SURFACE_VARIANT }}>
                 <SlidingPaneBackButton>
-                    <Codicon sx={{ color: ThemeColors.ON_SURFACE_VARIANT }} name="chevron-left"/>
+                    <Codicon sx={{ color: ThemeColors.ON_SURFACE_VARIANT }} name="chevron-left" />
                 </SlidingPaneBackButton>
                 {children}
             </div>


### PR DESCRIPTION
## Purpose  
This PR fixes two issues in the Helper Pane:  
1. **Click events on Helper Pane items not responding correctly** – users were unable to reliably select items.  
2. **Item text cropping when names are long** – long item names were truncated or cut off, reducing readability.  

---

## Goals  
- Ensure Helper Pane items respond consistently to click interactions.  
- Improve the UI/UX by preventing long item names from being cropped.  
- Provide a smoother, more accessible user experience in the Helper Pane.  

---

## Approach  
- Updated the UI styles/layout for Helper Pane items so that click actions are correctly captured and executed.  
- Updated the UI styles/layout to properly display long item names without cropping, ensuring that all content remains visible and accessible.  
---
