### PR TITLE
Fix Incorrect Type Check in `getExternalTypeDefRefs` for Record Type Definitions

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/features/ai/service/libs/funcs.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/service/libs/funcs.ts
@@ -596,7 +596,7 @@ function getExternalTypeDefRefs(
     
     // Check type definition fields
     for (const typeDef of allTypeDefs) {
-        if (typeDef.type === 'record') {
+        if (typeDef.type === 'Record') {
             const recordDef = typeDef as RecordTypeDefinition;
             for (const field of recordDef.fields) {
                 addExternalRecord(field.type, externalRecords);


### PR DESCRIPTION
This PR fixes a bug in `getExternalTypeDefRefs` (`funcs.ts`) where the function incorrectly checks `typeDef.type === 'record'` (lowercase) instead of `typeDef.type === 'Record'` (uppercase). This caused the function to skip processing record type definitions, resulting in missing dependent libraries during library fetching, leading to compilation errors.

**Key Changes**:
- Updated `getExternalTypeDefRefs` in `funcs.ts` to check `typeDef.type === 'Record'` (uppercase), ensuring correct processing of record type definitions and inclusion of dependent libraries.


- Fixes https://github.com/wso2/product-ballerina-integrator/issues/1213