### PR TITLE
Fix cannot focus search bar input in TypeHelper search in typeFIeld and helperpane not closing when opening recordCOnfig view

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/index.tsx
@@ -334,6 +334,7 @@ const HelperPaneNewEl = ({
                 />
             </div>
             , POPUP_IDS.RECORD_CONFIG, "Record Configuration", 600, 500);
+            onClose();
     }
 
     return (

--- a/workspaces/ballerina/type-editor/src/TypeHelper/TypeHelper.tsx
+++ b/workspaces/ballerina/type-editor/src/TypeHelper/TypeHelper.tsx
@@ -262,6 +262,7 @@ export const TypeHelperComponent = (props: TypeHelperComponentProps) => {
                             }}>
 
                                 <SearchBox
+                                    id={'helper-pane-search'}
                                     sx={{ width: "100%" }}
                                     placeholder='Search'
                                     value={searchValue}


### PR DESCRIPTION
## Purpose  
Previously:  
- The search bar input in the **TypeHelper** search (inside the type field) could not be focused properly, preventing users from interacting with it.  
- When the **RecordConfig** view was open, the helper pane was not closing, causing the two views to overlap and making the UI cluttered.  

## Goals  
- Allow users to focus and interact with the TypeHelper search bar input without issues.  
- Automatically close the helper pane when the RecordConfig view is open, ensuring a clean and non-overlapping UI experience.  

## Approach  
- Added a necessary component ID to properly track and manage the focus state of the TypeHelper search input.  
- Updated the view handling logic so that opening the RecordConfig view now closes the helper pane, avoiding overlapping.  
- Verified the fixes by:  
  - Confirming that the TypeHelper search input can now be focused and typed into.  
  - Opening RecordConfig and ensuring the helper pane closes automatically.  
