### PR TITLE
Fix helper not close

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/Variables.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/Variables.tsx
@@ -21,7 +21,7 @@ import { VariableTypeIndicator } from "../Components/VariableTypeIndicator"
 import { SlidingPaneNavContainer } from "@wso2/ui-toolkit/lib/components/ExpressionEditor/components/Common/SlidingPane"
 import { useRpcContext } from "@wso2/ballerina-rpc-client"
 import { DataMapperDisplayMode, ExpressionProperty, FlowNode, LineRange, RecordTypeField } from "@wso2/ballerina-core"
-import { Codicon, CompletionItem, Divider, getIcon, HelperPaneCustom, SearchBox, ThemeColors, Typography } from "@wso2/ui-toolkit"
+import { Codicon, CompletionItem, Divider, getIcon, HelperPaneCustom, SearchBox, ThemeColors, Tooltip, Typography } from "@wso2/ui-toolkit"
 import { useEffect, useMemo, useRef, useState } from "react"
 import { getPropertyFromFormField, useFieldContext } from "@wso2/ballerina-side-panel"
 import FooterButtons from "../Components/FooterButtons"
@@ -71,9 +71,11 @@ const VariableItem = ({ item, onItemSelect, onMoreIconClick }: VariableItemProps
                     event.stopPropagation();
                     onMoreIconClick(item.label);
                 }}>
-                    <VariableTypeIndicator >
-                        {item.description}
-                    </VariableTypeIndicator>
+                    <Tooltip content={item.description} position="top">
+                        <VariableTypeIndicator >
+                            {item.description.length > 5 ? item.description.slice(0, 5) + '…' : item.description}
+                        </VariableTypeIndicator>
+                    </Tooltip>
                     <Codicon name="chevron-right" />
                 </VariablesMoreIconContainer>}
         >

--- a/workspaces/common-libs/ui-toolkit/src/components/ExpressionEditor/components/Form/ExpressionEditor.tsx
+++ b/workspaces/common-libs/ui-toolkit/src/components/ExpressionEditor/components/Form/ExpressionEditor.tsx
@@ -239,6 +239,7 @@ export const ExpressionEditor = forwardRef<FormExpressionEditorRef, FormExpressi
     }, [extractArgsFromFunction]);
 
     const handleChange = async (text: string, cursorPosition?: number) => {
+        changeHelperPaneState?.(false);
         const updatedCursorPosition =
             cursorPosition ?? textAreaRef.current.shadowRoot.querySelector('textarea').selectionStart;
         // Update the text field value


### PR DESCRIPTION
## Purpose  
Previously:  
- When a value was copy-pasted manually by a user into the expression editor, the **helper did not close automatically**, leaving the UI in an inconsistent state.  
- In the expression helper variables list, the **variable type indicator was cropped** when long type names appeared, making it hard to identify the full type.  

Resolves https://github.com/wso2/product-ballerina-integrator/issues/1280  

## Goals  
- Ensure the helper closes automatically when a value is manually copy-pasted into the expression editor.  
- Improve the readability of variable type indicators by preventing cropped display of long type names.  

## Approach  
- Added **value change handling** so that the helper now closes properly when a value is pasted manually into the expression editor.  
- Updated the variable type indicator display logic:  
  - If the type name is longer than 5 characters, display the first 5 characters followed by `...`.  
  - If the type name is 5 characters or fewer, display the full name.  
  - Added a **tooltip** so that users can always view the full type name on hover, even when truncated.  
- Verified the fixes by:  
  - Copy-pasting values into the expression editor and confirming the helper closes.  
  - Testing long and short type names in the variable list to ensure truncation, tooltips, and full display work as expected.  
