### PR TITLE
Fix helperpane item light color

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/Configurables.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/Configurables.tsx
@@ -153,6 +153,7 @@ export const Configurables = (props: ConfigurablesPageProps) => {
 
     const handleItemClicked = (name: string) => {
         onChange(name, true)
+        onClose && onClose();
     }
 
     const handleAddNewConfigurable = () => {

--- a/workspaces/common-libs/ui-toolkit/src/components/ExpressionEditor/components/Common/SlidingPane/index.tsx
+++ b/workspaces/common-libs/ui-toolkit/src/components/ExpressionEditor/components/Common/SlidingPane/index.tsx
@@ -187,10 +187,8 @@ const SlidingPaneNavContainerElm = styled.div`
     align-items: center;
     &:hover {
         background-color: var(--vscode-list-activeSelectionBackground) !important;
-        cursor: pointer;
-    }
-    &:hover .sliding-pane-text {
         color:  ${ThemeColors.ON_PRIMARY};
+        cursor: pointer;
     }
 `
 export const SlidingPaneCallbackCOntainer = styled.div`


### PR DESCRIPTION
## Purpose
This PR addresses two issues observed in the **Helper Pane** and **Sliding Pane** components:  
1. **Light theme readability** – Items in the Helper Pane were not easily visible in light themes due to low contrast.  
2. **Pane closing behavior** – The Helper Pane remained open even after a configurable item was selected, leading to a less smooth user experience.  

Resolves: https://github.com/wso2/product-ballerina-integrator/issues/1298
Resolves: https://github.com/wso2/product-ballerina-integrator/issues/1297

## Goals
- Improve readability of Helper Pane items across themes, ensuring consistent visibility in both dark and light modes.  
- Close the Helper Pane automatically when a configurable item is clicked, providing a more intuitive and user-friendly flow.  

## Approach
- Updated the **Helper Pane item styles** to ensure proper text color and background contrast for light themes.  
- Modified the `handleItemClicked` method in `Configurables.tsx` to invoke `onClose()` after selecting an item, ensuring the pane closes automatically.  
- Cleaned up redundant CSS properties in the **Sliding Pane** component and standardized hover styles.  