### PR TITLE
fix data mapper open does not update the variables list

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
@@ -1256,6 +1256,11 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                 .then((response) => {
                     console.log(">>> Updated source code", response);
                     if (response.codedata) {
+                        if (options?.postUpdateCallBack) {
+                            options.postUpdateCallBack();
+                        }
+                        shouldUpdateLineRangeRef.current = options?.updateLineRange;
+                        updatedNodeRef.current = updatedNode;
                         rpcClient.getVisualizerRpcClient().openView({
                             type: EVENT_TYPE.OPEN_VIEW,
                             location: {


### PR DESCRIPTION
## Purpose
This PR fixes an issue in the Data Mapper where newly created variables were not reflected in the **Expression Helper variables list** after navigating back.  
Previously, when a user clicked **Open in Data Mapper**, created a new variable, and then navigated back, the new variable would not appear in the variables list, causing inconsistency between the editor state and the helper.  

## Goals
- Ensure that newly created variables are correctly updated and displayed in the **Expression Helper variables list** after returning from the Data Mapper.  
- Provide a consistent and reliable user experience when working with variables across the Data Mapper and Expression Helper.  

## Approach
- Updated the state synchronization between the Data Mapper and Expression Helper.  
- Ensured that variable updates are re-fetched when navigating back from the Data Mapper.  
