### PR TITLE
Indicate warning message when MI version is not found

### DIFF
--- a/workspaces/mi/mi-extension/src/util/onboardingUtils.ts
+++ b/workspaces/mi/mi-extension/src/util/onboardingUtils.ts
@@ -116,7 +116,7 @@ export async function isMIUpToDate(): Promise<boolean> {
 export async function getProjectSetupDetails(projectUri: string): Promise<SetupDetails> {
     const miVersion = await getMIVersionFromPom(projectUri);
     if (!miVersion) {
-        vscode.window.showErrorMessage('Failed to get WSO2 Integrator: MI version from pom.xml.');
+        vscode.window.showWarningMessage('Failed to get WSO2 Integrator: MI version from pom.xml.');
         return { miVersionStatus: 'missing', javaDetails: { status: 'not-valid' }, miDetails: { status: 'not-valid' } };
     }
     if (isSupportedMIVersion(miVersion)) {


### PR DESCRIPTION
## Purpose
Previously it was indicated as an error message. It is now indicated as a warning message. 

Fixes: https://github.com/wso2/mi-vscode/issues/1257 