### PR TITLE
fix incorrect error message in record config editor

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/RecordConfigModal.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/RecordConfigModal.tsx
@@ -247,7 +247,7 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
                                     onModelChange={handleModelChange}
                                 />
                             ) : (
-                                <Typography variant="body3">Record construction assistance is unavailable. Please check the Suggestions tab.</Typography>
+                                <Typography variant="body3">Record construction assistance is unavailable.</Typography>
                             )}
                     </>
                 )}


### PR DESCRIPTION
## Purpose
When the record configuration checkbox model cannot be retrieved, the UI currently displays the following message:  
> *“Record construction assistance is unavailable.”*  

Previously, this message also included a reference to the **Suggestions tab**, which is no longer part of the UI. Removing that part ensures the message is accurate and not misleading.  

Resolves: https://github.com/wso2/product-ballerina-integrator/issues/1323

## Goals
- Remove outdated references from the invalid record configuration message.  
- Ensure the updated message reflects the current UI flow.  
- Improve user experience by providing clear and correct feedback.  

## Approach
- Identify the component responsible for rendering the invalid record configuration message.  
- Update the string by removing the outdated reference to the Suggestions tab.  

