### PR TITLE
type helper do not concat the type when using operators

### DIFF
--- a/workspaces/ballerina/type-editor/src/TypeHelper/TypeHelper.tsx
+++ b/workspaces/ballerina/type-editor/src/TypeHelper/TypeHelper.tsx
@@ -198,11 +198,18 @@ export const TypeHelperComponent = (props: TypeHelperComponentProps) => {
 
 
     const handleTypeItemClick = (item: TypeHelperItem) => {
-        onChange(
-            item.insertText,
-            item.insertText.length
-        );
-
+        if (currentType.trimEnd().endsWith('|')) {
+            const newType = currentType + item.insertText;
+            onChange(
+                newType,
+                newType.length
+            );
+        } else {
+            onChange(
+                item.insertText,
+                item.insertText.length
+            );
+        }
         onCloseCompletions?.();
         onClose();
     };

--- a/workspaces/ballerina/type-editor/src/TypeHelper/TypeHelper.tsx
+++ b/workspaces/ballerina/type-editor/src/TypeHelper/TypeHelper.tsx
@@ -198,7 +198,11 @@ export const TypeHelperComponent = (props: TypeHelperComponentProps) => {
 
 
     const handleTypeItemClick = (item: TypeHelperItem) => {
-        if (currentType.trimEnd().endsWith('|')) {
+        const trimmedType = currentType.trimEnd();
+        if (
+            /\|$/.test(trimmedType) ||
+            /readonly\s*&$/.test(trimmedType)
+        ) {
             const newType = currentType + item.insertText;
             onChange(
                 newType,


### PR DESCRIPTION
## Purpose
Previously, when selecting a type item from the type helper in the type editor, the existing editor value was always replaced. This caused issues when users were working with operators like `|` or `readonly &`, as they were unable to conveniently combine multiple types using those operators.

## Goals
- Allow users to seamlessly add new type items without losing existing ones when operators (`|`, `readonly &`) are being used in the type editor.
- Improve usability of the type editor by enabling operator-based concatenation of types.

## Approach
- Updated the type editor logic to detect when the current value includes supported operators (`|`, `readonly &`).
- Instead of replacing the existing value, the newly selected type item is concatenated to the current value, allowing users to construct complex type expressions.
- Preserved the existing replacement behavior when no operators are present, ensuring backward compatibility.
