### PR TITLE
Fix record config popup crops the content

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/RecordConfigView.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/RecordConfigView.tsx
@@ -63,7 +63,12 @@ export function RecordConfigView(props: ConfigureViewProps) {
                 <LabelContainer>
                     <Description >{`Select fields to construct the record`}</Description>
                 </LabelContainer>
-                <MemoizedParameterBranch key={JSON.stringify(recordModel)} parameters={recordModel} depth={1} onChange={handleOnChange} />
+                <div style={{
+                    maxHeight: '590px',
+                    overflowY: 'auto'
+                }}>
+                    <MemoizedParameterBranch key={JSON.stringify(recordModel)} parameters={recordModel} depth={1} onChange={handleOnChange} />
+                </div>
             </>
         </PanelBody>
     );

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/index.tsx
@@ -323,7 +323,7 @@ const HelperPaneNewEl = ({
 
     const openRecordConfigView = () => {
         addModal(
-            <div style={{ padding: '0px 10px' }}>
+            <div style={{ padding: '10px 10px' }}>
                 <ConfigureRecordPage
                     fileName={fileName}
                     targetLineRange={targetLineRange}


### PR DESCRIPTION
## Purpose
Fix an issue where the record configuration content was being cropped inside the popup, making it difficult for users to view or interact with the full content. 

## Goals
Ensure that the record configuration content is fully visible within the popup. Improve the usability and readability of the configuration UI so users can see and interact with all fields without content being cut off.

## Approach
- Adjusted the popup layout and styling to properly accommodate the full content of record configurations.  
- Tested with different record sizes to ensure content is no longer cropped.  
- Improved scroll behavior and resizing to handle large or deeply nested records.
