### PR TITLE
fix recordConfig not scrollable in popup

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/RecordConfigView.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/RecordConfigView.tsx
@@ -64,7 +64,7 @@ export function RecordConfigView(props: ConfigureViewProps) {
                     <Description >{`Select fields to construct the record`}</Description>
                 </LabelContainer>
                 <div style={{
-                    maxHeight: '590px',
+                    maxHeight: '450px',
                     overflowY: 'auto'
                 }}>
                     <MemoizedParameterBranch key={JSON.stringify(recordModel)} parameters={recordModel} depth={1} onChange={handleOnChange} />


### PR DESCRIPTION
## Purpose
Fix an issue where the record configuration content was being cropped inside the popup, making it difficult for users to view or interact with the full content. 

## Goals
Ensure that the record configuration content is fully visible within the popup. Improve the usability and readability of the configuration UI so users can see and interact with all fields without content being cut off.

## Approach
- Adjusted the popup layout and styling to properly accommodate the full content of record configurations.  
- Tested with different record sizes to ensure content is no longer cropped.  
- Improved scroll behavior and resizing to handle large or deeply nested records.
