### PR TITLE
Fix race condition in flow diagram and improve readonly mode

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/Form/index.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/Form/index.tsx
@@ -493,10 +493,10 @@ export const Form = forwardRef((props: FormProps, ref) => {
     };
 
     // Expose a method to trigger the save
-    useImperativeHandle(ref, () => ({
-        triggerSave: () => handleSubmit(handleOnSave)(), // Call handleSubmit with the save function
-        resetForm: (values) => reset(values),
-    }));
+    // useImperativeHandle(ref, () => ({
+    //     triggerSave: () => handleSubmit(handleOnSave)(), // Call handleSubmit with the save function
+    //     resetForm: (values) => reset(values),
+    // }));
 
     const handleOpenRecordEditor = (open: boolean, typeField?: FormField, newType?: string | NodeProperties) => {
         openRecordEditor?.(open, getValues(), typeField, newType);

--- a/workspaces/ballerina/ballerina-side-panel/src/components/NodeList/index.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/NodeList/index.tsx
@@ -435,6 +435,7 @@ export function NodeList(props: NodeListProps) {
 
                         return (
                             <Tooltip 
+                                key={node.id + index}
                                 content={node.description} 
                                 sx={{ 
                                     maxWidth: "280px",
@@ -444,7 +445,6 @@ export function NodeList(props: NodeListProps) {
                                 }}
                             >
                                 <S.Component
-                                    key={node.id + index}
                                     enabled={node.enabled}
                                     onClick={() => handleAddNode(node)}
                                 >

--- a/workspaces/ballerina/ballerina-visualizer/src/components/RelativeLoader/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/components/RelativeLoader/index.tsx
@@ -34,7 +34,7 @@ export const RelativeLoader = ({ message }: LoadingRingProps) => {
 
     const LoadingText = styled(Typography)`
         margin-top: 16px;
-        color: var(--vscode-descriptionForeground);
+        color: ${ThemeColors.ON_SURFACE_VARIANT};
         font-size: 14px;
     `;
 

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/Connection/AddConnectionWizard/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/Connection/AddConnectionWizard/index.tsx
@@ -63,16 +63,15 @@ const PopupContainer = styled.div`
 `;
 
 const StatusCard = styled.div`
-    margin: 16px 16px 0 16px;
-    padding: 16px;
-    border-radius: 8px;
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
     align-items: center;
     gap: 16px;
 
     & > svg {
-        font-size: 24px;
+        font-size: 32px;
+        width: 32px;
+        height: 32px;
         color: ${ThemeColors.ON_SURFACE};
     }
 `;
@@ -82,10 +81,14 @@ const StatusContainer = styled.div`
     justify-content: center;
     align-items: center;
     height: 100%;
+    padding: 40px;
 `;
 
 const StatusText = styled(Typography)`
-    color: ${ThemeColors.ON_SURFACE};
+    margin-top: 16px;
+    color: ${ThemeColors.ON_SURFACE_VARIANT};
+    font-size: 14px;
+    text-align: center;
 `;
 
 enum WizardStep {
@@ -196,7 +199,7 @@ export function AddConnectionWizard(props: AddConnectionWizardProps) {
                     }
                     return res;
                 }),
-                timeoutPromise.then(() => nodeTemplatePromise)
+                timeoutPromise.then(() => nodeTemplatePromise),
             ]);
 
             if (didTimeout) {
@@ -269,7 +272,9 @@ export function AddConnectionWizard(props: AddConnectionWizardProps) {
                         selectedNodeRef.current = undefined;
                         setSavingFormStatus(SavingFormStatus.SUCCESS);
                         const newConnection = response.artifacts.find((artifact) => artifact.isNew);
-                        onClose ? onClose({ recentIdentifier: newConnection.name, artifactType: DIRECTORY_MAP.CONNECTION }) : gotoHome();
+                        onClose
+                            ? onClose({ recentIdentifier: newConnection.name, artifactType: DIRECTORY_MAP.CONNECTION })
+                            : gotoHome();
                     } else {
                         console.error(">>> Error updating source code", response);
                         setSavingFormStatus(SavingFormStatus.ERROR);
@@ -280,20 +285,22 @@ export function AddConnectionWizard(props: AddConnectionWizardProps) {
 
     const handleOnGenerateSubmit = async (data: FormValues) => {
         // Note: Project path is empty as the value is overridden in the rpc client
-        const response = await rpcClient
-            .getBIDiagramRpcClient()
-            .generateOpenApiClient({ openApiContractPath: data["openApiSpecPath"], projectPath: "", module: data["module"] });
+        const response = await rpcClient.getBIDiagramRpcClient().generateOpenApiClient({
+            openApiContractPath: data["openApiSpecPath"],
+            projectPath: "",
+            module: data["module"],
+        });
         if (response.errorMessage) {
             setGenConnectorFields((prevFields) =>
                 prevFields.map((field) =>
                     field.key === "module"
                         ? {
-                            ...field,
-                            diagnostics: [
-                                ...field.diagnostics,
-                                { message: response.errorMessage, severity: "ERROR" },
-                            ],
-                        }
+                              ...field,
+                              diagnostics: [
+                                  ...field.diagnostics,
+                                  { message: response.errorMessage, severity: "ERROR" },
+                              ],
+                          }
                         : field
                 )
             );
@@ -358,21 +365,25 @@ export function AddConnectionWizard(props: AddConnectionWizardProps) {
                     onClose={onClose}
                     openCustomConnectorView={openCustomConnectorView}
                 />
-            ) : (currentStep === WizardStep.CONNECTOR_LIST) && (
-                <>
-                    <Overlay sx={{ background: `${ThemeColors.SURFACE_CONTAINER}`, opacity: `0.5`, zIndex: 1999 }} />
-                    <PopupContainer>
-                        <ConnectorView
-                            key={connectorsViewKey}
-                            fileName={fileName}
-                            targetLinePosition={target}
-                            onSelectConnector={handleOnSelectConnector}
-                            onAddGeneratedConnector={handleOnAddGeneratedConnector}
-                            onClose={onClose}
-                            isPopupView={true}
+            ) : (
+                currentStep === WizardStep.CONNECTOR_LIST && (
+                    <>
+                        <Overlay
+                            sx={{ background: `${ThemeColors.SURFACE_CONTAINER}`, opacity: `0.5`, zIndex: 1999 }}
                         />
-                    </PopupContainer>
-                </>
+                        <PopupContainer>
+                            <ConnectorView
+                                key={connectorsViewKey}
+                                fileName={fileName}
+                                targetLinePosition={target}
+                                onSelectConnector={handleOnSelectConnector}
+                                onAddGeneratedConnector={handleOnAddGeneratedConnector}
+                                onClose={onClose}
+                                isPopupView={true}
+                            />
+                        </PopupContainer>
+                    </>
+                )
             )}
             {(currentStep === WizardStep.CONNECTION_CONFIG || currentStep === WizardStep.GENERATE_CONNECTOR) && (
                 <Overlay sx={{ background: `${ThemeColors.SURFACE_CONTAINER}`, opacity: `0.3`, zIndex: 2000 }} />
@@ -403,13 +414,29 @@ export function AddConnectionWizard(props: AddConnectionWizardProps) {
                                 )}
                                 {pullingStatus === PullingStatus.SUCCESS && (
                                     <StatusCard>
-                                        <Icon name="bi-success" sx={{ color: ThemeColors.PRIMARY, fontSize: "18px" }} />
+                                        <Icon
+                                            name="bi-success"
+                                            sx={{
+                                                color: ThemeColors.PRIMARY,
+                                                fontSize: "28px",
+                                                width: "28px",
+                                                height: "28px",
+                                            }}
+                                        />
                                         <StatusText variant="body2">Connector package pulled successfully.</StatusText>
                                     </StatusCard>
                                 )}
                                 {pullingStatus === PullingStatus.ERROR && (
                                     <StatusCard>
-                                        <Icon name="bi-error" sx={{ color: ThemeColors.ERROR, fontSize: "18px" }} />
+                                        <Icon
+                                            name="bi-error"
+                                            sx={{
+                                                color: ThemeColors.ERROR,
+                                                fontSize: "28px",
+                                                width: "28px",
+                                                height: "28px",
+                                            }}
+                                        />
                                         <StatusText variant="body2">
                                             Failed to pull the connector package. Please try again.
                                         </StatusText>
@@ -420,8 +447,8 @@ export function AddConnectionWizard(props: AddConnectionWizardProps) {
                         {!pullingStatus && selectedNodeRef.current && (
                             <>
                                 <BodyText style={{ padding: "20px 16px 0 16px" }}>
-                                    Provide the necessary configuration details for the selected connector to complete the
-                                    setup.
+                                    Provide the necessary configuration details for the selected connector to complete
+                                    the setup.
                                 </BodyText>
                                 <ConnectionConfigView
                                     fileName={fileName}
@@ -472,7 +499,7 @@ export function AddConnectionWizard(props: AddConnectionWizardProps) {
                     </>
                 </PanelContainer>
             )}
-        </Container >
+        </Container>
     );
 }
 

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/FlowDiagram/PanelManager.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/FlowDiagram/PanelManager.tsx
@@ -225,11 +225,6 @@ export function PanelManager(props: PanelManagerProps) {
         setSidePanelView(SidePanelView.ADD_MCP_SERVER);
     };
 
-    const handleSubmitAndClose = () => {
-        onSubmitForm();
-        onClose();
-    };
-
     const findSubPanelComponent = (subPanel: SubPanel) => {
         switch (subPanel.view) {
             case SubPanelView.HELPER_PANEL:

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/FlowDiagram/hooks/useDraftNodeManager.ts
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/FlowDiagram/hooks/useDraftNodeManager.ts
@@ -59,8 +59,6 @@ export function useDraftNodeManager(currentModel?: Flow): UseDraftNodeManagerRet
                 return model;
             }
 
-            console.log(">>> useDraftNodeManager: Adding draft node", { parent, target });
-
             // Save original state
             setDraftState({
                 originalModel: model,
@@ -73,8 +71,6 @@ export function useDraftNodeManager(currentModel?: Flow): UseDraftNodeManagerRet
 
             // Add draft node to model and return the updated model
             const modelWithDraft = addDraftNodeToDiagram(model, parent, target);
-            console.log(">>> useDraftNodeManager: Draft node added", modelWithDraft);
-
             return modelWithDraft;
         },
         [currentModel]
@@ -82,11 +78,6 @@ export function useDraftNodeManager(currentModel?: Flow): UseDraftNodeManagerRet
 
     const cancelDraft = useCallback((): Flow | undefined => {
         const { originalModel } = draftState;
-
-        console.log(">>> useDraftNodeManager: Canceling draft", {
-            hasDraft: draftState.hasDraft,
-            originalModel: !!originalModel,
-        });
 
         // Clear draft state
         setDraftState({ hasDraft: false, isProcessing: false, description: "" });
@@ -96,15 +87,11 @@ export function useDraftNodeManager(currentModel?: Flow): UseDraftNodeManagerRet
     }, [draftState]);
 
     const savingDraft = useCallback(() => {
-        console.log(">>> useDraftNodeManager: Saving draft");
-
         // Clear draft state when draft is successfully saved
         setDraftState({ hasDraft: true, isProcessing: true, description: "Saving node..." });
     }, []);
 
     const completeDraft = useCallback(() => {
-        console.log(">>> useDraftNodeManager: Completing draft");
-
         // Clear draft state when draft is successfully saved
         setDraftState({ hasDraft: false, isProcessing: false, description: "" });
     }, []);

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/FlowDiagram/hooks/useDraftNodeManager.ts
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/FlowDiagram/hooks/useDraftNodeManager.ts
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useState, useCallback, useRef } from "react";
+import { Flow, FlowNode, Branch, LineRange } from "@wso2/ballerina-core";
+import { addDraftNodeToDiagram } from "../../../../utils/bi";
+
+interface DraftNodeManagerState {
+    originalModel?: Flow;
+    hasDraft: boolean;
+    draftParent?: FlowNode | Branch;
+    draftTarget?: LineRange;
+    isProcessing: boolean;
+    description: string;
+}
+
+interface UseDraftNodeManagerReturn {
+    addDraftNode: (parent: FlowNode | Branch, target: LineRange) => Flow;
+    cancelDraft: () => Flow | undefined;
+    savingDraft: () => void;
+    completeDraft: () => void;
+    setProcessing: (processing: boolean) => void;
+    setDescription: (description: string) => void;
+    hasDraft: boolean;
+    isProcessing: boolean;
+    description: string;
+    draftParent?: FlowNode | Branch;
+    draftTarget?: LineRange;
+    originalModel?: Flow;
+}
+
+export function useDraftNodeManager(currentModel?: Flow): UseDraftNodeManagerReturn {
+    const [draftState, setDraftState] = useState<DraftNodeManagerState>({
+        hasDraft: false,
+        isProcessing: false,
+        description: "",
+    });
+
+    const addDraftNode = useCallback(
+        (parent: FlowNode | Branch, target: LineRange): Flow => {
+            const model = currentModel;
+            if (!model) {
+                console.error(">>> useDraftNodeManager: No current model to add draft node");
+                return model;
+            }
+
+            console.log(">>> useDraftNodeManager: Adding draft node", { parent, target });
+
+            // Save original state
+            setDraftState({
+                originalModel: model,
+                hasDraft: true,
+                isProcessing: false,
+                description: "Select node from node panel.",
+                draftParent: parent,
+                draftTarget: target,
+            });
+
+            // Add draft node to model and return the updated model
+            const modelWithDraft = addDraftNodeToDiagram(model, parent, target);
+            console.log(">>> useDraftNodeManager: Draft node added", modelWithDraft);
+
+            return modelWithDraft;
+        },
+        [currentModel]
+    );
+
+    const cancelDraft = useCallback((): Flow | undefined => {
+        const { originalModel } = draftState;
+
+        console.log(">>> useDraftNodeManager: Canceling draft", {
+            hasDraft: draftState.hasDraft,
+            originalModel: !!originalModel,
+        });
+
+        // Clear draft state
+        setDraftState({ hasDraft: false, isProcessing: false, description: "" });
+
+        // Return original model to restore
+        return originalModel;
+    }, [draftState]);
+
+    const savingDraft = useCallback(() => {
+        console.log(">>> useDraftNodeManager: Saving draft");
+
+        // Clear draft state when draft is successfully saved
+        setDraftState({ hasDraft: true, isProcessing: true, description: "Saving node..." });
+    }, []);
+
+    const completeDraft = useCallback(() => {
+        console.log(">>> useDraftNodeManager: Completing draft");
+
+        // Clear draft state when draft is successfully saved
+        setDraftState({ hasDraft: false, isProcessing: false, description: "" });
+    }, []);
+
+    const setProcessing = useCallback((processing: boolean) => {
+        setDraftState((prev) => ({ ...prev, isProcessing: processing }));
+    }, []);
+
+    const setDescription = useCallback((description: string) => {
+        setDraftState((prev) => ({ ...prev, description }));
+    }, []);
+
+    return {
+        addDraftNode,
+        cancelDraft,
+        savingDraft,
+        completeDraft,
+        setProcessing,
+        setDescription,
+        hasDraft: draftState.hasDraft,
+        isProcessing: draftState.isProcessing,
+        description: draftState.description,
+        draftParent: draftState.draftParent,
+        draftTarget: draftState.draftTarget,
+        originalModel: draftState.originalModel,
+    };
+}

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
@@ -122,6 +122,7 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
     const [breakpointInfo, setBreakpointInfo] = useState<BreakpointInfo>();
     const [selectedMcpToolkitName, setSelectedMcpToolkitName] = useState<string | undefined>(undefined);
     const [selectedConnectionKind, setSelectedConnectionKind] = useState<ConnectionKind>();
+    const [selectedNodeId, setSelectedNodeId] = useState<string>();
 
     // Navigation stack for back navigation
     const [navigationStack, setNavigationStack] = useState<NavigationStackItem[]>([]);
@@ -634,6 +635,7 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
         setShowSidePanel(false);
         setSidePanelView(SidePanelView.NODE_LIST);
         setSubPanel({ view: SubPanelView.UNDEFINED });
+        setSelectedNodeId(undefined);
         selectedNodeRef.current = undefined;
         nodeTemplateRef.current = undefined;
         topNodeRef.current = undefined;
@@ -1430,6 +1432,7 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
 
     const handleOnEditNode = (node: FlowNode) => {
         console.log(">>> on edit node", node);
+        setSelectedNodeId(node.id);
         selectedNodeRef.current = node;
         if (suggestedText.current) {
             // use targetRef from suggested model
@@ -2208,6 +2211,7 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                 showSpinner: isDraftProcessing,
                 description: draftDescription,
             },
+            selectedNodeId, // ✅ Pass selected node ID for highlighting
             agentNode: {
                 onModelSelect: handleOnEditAgentModel,
                 onAddTool: handleOnAddTool,
@@ -2226,7 +2230,7 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
             },
             projectPath,
             breakpointInfo,
-            readOnly: showProgressSpinner || showProgressIndicator || hasDraft,
+            readOnly: showProgressSpinner || showProgressIndicator || hasDraft || selectedNodeId !== undefined,
         }),
         [
             flowModel,
@@ -2236,6 +2240,7 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
             showProgressSpinner,
             showProgressIndicator,
             hasDraft,
+            selectedNodeId,
         ]
     );
 

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
@@ -1221,7 +1221,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
             return;
         }
         setShowProgressIndicator(true);
-        setShowProgressSpinner(true);
         savingDraft();
         const noFormSubmitOptions = !options ||
             (
@@ -2131,7 +2130,7 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                 showSpinner: isDraftProcessing,
                 description: draftDescription,
             },
-            selectedNodeId, // ✅ Pass selected node ID for highlighting
+            selectedNodeId,
             agentNode: {
                 onModelSelect: handleOnEditAgentModel,
                 onAddTool: handleOnAddTool,

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
@@ -168,7 +168,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                 // Skip if the parent is a data mapper popup
                 return;
             }
-            console.log(">>> on parent popup submitted", parent);
             if (
                 parent.artifactType === DIRECTORY_MAP.FUNCTION ||
                 parent.artifactType === DIRECTORY_MAP.NP_FUNCTION ||
@@ -290,8 +289,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
     };
 
     const handleModelProviderAdded = async () => {
-        console.log(">>> Model provider added, navigating back to model provider list");
-
         // Try to navigate back to MODEL_PROVIDER_LIST in the stack
         const foundInStack = popNavigationStackUntilView(SidePanelView.MODEL_PROVIDER_LIST);
 
@@ -302,7 +299,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                     position: targetRef.current.startLine,
                     filePath: model?.fileName,
                 });
-                console.log(">>> Refreshed model provider list", response);
                 setCategories(convertModelProviderCategoriesToSidePanelCategories(response.categories as Category[]));
                 setSidePanelView(SidePanelView.MODEL_PROVIDER_LIST);
                 setShowSidePanel(true);
@@ -318,8 +314,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
     };
 
     const handleVectorStoreAdded = async () => {
-        console.log(">>> Vector store added, navigating back to vector store list");
-
         // Try to navigate back to VECTOR_STORE_LIST in the stack
         const foundInStack = popNavigationStackUntilView(SidePanelView.VECTOR_STORE_LIST);
 
@@ -330,7 +324,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                     position: targetRef.current.startLine,
                     filePath: model?.fileName,
                 });
-                console.log(">>> Refreshed vector store list", response);
                 setCategories(
                     convertVectorStoreCategoriesToSidePanelCategories(response.categories as Category[])
                 );
@@ -348,8 +341,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
     };
 
     const handleEmbeddingProviderAdded = async () => {
-        console.log(">>> Embedding provider added, navigating back to embedding provider list");
-
         // Try to navigate back to EMBEDDING_PROVIDER_LIST in the stack
         const foundInStack = popNavigationStackUntilView(SidePanelView.EMBEDDING_PROVIDER_LIST);
 
@@ -360,7 +351,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                     position: targetRef.current.startLine,
                     filePath: model?.fileName,
                 });
-                console.log(">>> Refreshed embedding provider list", response);
                 setCategories(
                     convertEmbeddingProviderCategoriesToSidePanelCategories(response.categories as Category[])
                 );
@@ -378,8 +368,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
     };
 
     const handleVectorKnowledgeBaseAdded = async () => {
-        console.log(">>> Vector knowledge base added, navigating back to vector knowledge base list");
-
         // Try to navigate back to VECTOR_KNOWLEDGE_BASE_LIST in the stack
         const foundInStack = popNavigationStackUntilView(SidePanelView.VECTOR_KNOWLEDGE_BASE_LIST);
 
@@ -390,7 +378,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                     position: targetRef.current.startLine,
                     filePath: model?.fileName,
                 });
-                console.log(">>> Refreshed vector knowledge base list", response);
                 setCategories(
                     convertFunctionCategoriesToSidePanelCategories(
                         response.categories as Category[],
@@ -411,8 +398,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
     };
 
     const handleDataLoaderAdded = async () => {
-        console.log(">>> Data loader added, navigating back to data loader list");
-
         // Try to navigate back to DATA_LOADER_LIST in the stack
         const foundInStack = popNavigationStackUntilView(SidePanelView.DATA_LOADER_LIST);
 
@@ -423,7 +408,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                     position: targetRef.current.startLine,
                     filePath: model?.fileName,
                 });
-                console.log(">>> Refreshed data loader list", response);
                 setCategories(convertDataLoaderCategoriesToSidePanelCategories(response.categories as Category[]));
                 setSidePanelView(SidePanelView.DATA_LOADER_LIST);
                 setShowSidePanel(true);
@@ -439,8 +423,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
     };
 
     const handleChunkerAdded = async () => {
-        console.log(">>> Chunker added, navigating back to chunker list");
-
         // Try to navigate back to CHUNKER_LIST in the stack
         const foundInStack = popNavigationStackUntilView(SidePanelView.CHUNKER_LIST);
 
@@ -451,7 +433,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                     position: targetRef.current.startLine,
                     filePath: model?.fileName,
                 });
-                console.log(">>> Refreshed chunker list", response);
                 setCategories(convertChunkerCategoriesToSidePanelCategories(response.categories as Category[]));
                 setSidePanelView(SidePanelView.CHUNKER_LIST);
                 setShowSidePanel(true);
@@ -555,8 +536,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
     useEffect(() => {
         if (model && selectedNodeRef.current?.codedata?.lineRange?.startLine && sidePanelView === SidePanelView.FORM) {
             const matchingNode = findNodeByStartLine(model, selectedNodeRef.current.codedata.lineRange.startLine);
-            console.log(">>> Matching node", matchingNode);
-
             // Only update refs if we found a matching node and it's different from the current one
             if (matchingNode && matchingNode.id !== selectedNodeRef.current.id) {
                 selectedNodeRef.current = matchingNode;
@@ -669,7 +648,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
         if (hasDraft) {
             const restoredModel = cancelDraft();
             if (restoredModel) {
-                console.log(">>> handleOnCloseSidePanel: restoring original model", restoredModel);
                 setModel(restoredModel);
             }
             setSuggestedModel(undefined);
@@ -691,7 +669,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
             position: target.startLine,
             filePath: model?.fileName || parent?.codedata?.lineRange.fileName,
         };
-        console.log(">>> get available node request", getNodeRequest);
         // show side panel with available nodes
         setShowProgressIndicator(true);
         // Add draft node to model using hook
@@ -752,10 +729,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
     const handleOnAddNode = (parent: FlowNode | Branch, target: LineRange) => {
         // clear previous click if had
         if (topNodeRef.current || targetRef.current) {
-            console.log(">>> Clearing previous click", {
-                topNodeRef: topNodeRef.current,
-                targetRef: targetRef.current,
-            });
             closeSidePanelAndFetchUpdatedFlowModel();
             return;
         }
@@ -972,7 +945,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
     };
 
     const handleOnSelectNode = (nodeId: string, metadata?: any, fileName?: string) => {
-        console.log(">>> on select node", { nodeId, metadata, fileName });
         selectedNodeMetadata.current = { nodeId, metadata, fileName: model?.fileName || fileName };
         const { node, category } = metadata as { node: AvailableNode; category?: string };
 
@@ -991,7 +963,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                         searchKind: "FUNCTION",
                     })
                     .then((response) => {
-                        console.log(">>> List of functions", response);
                         setCategories(
                             convertFunctionCategoriesToSidePanelCategories(
                                 response.categories as Category[],
@@ -1042,7 +1013,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                         searchKind: "NP_FUNCTION",
                     })
                     .then((response) => {
-                        console.log(">>> List of np functions", response);
                         setCategories(
                             convertFunctionCategoriesToSidePanelCategories(
                                 response.categories as Category[],
@@ -1066,7 +1036,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                         filePath: model?.fileName || fileName,
                     })
                     .then((response) => {
-                        console.log(">>> List of model providers", response);
                         setCategories(
                             convertFunctionCategoriesToSidePanelCategories(
                                 response.categories as Category[],
@@ -1090,7 +1059,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                         filePath: model?.fileName || fileName,
                     })
                     .then((response) => {
-                        console.log(">>> List of vector stores", response);
                         setCategories(
                             convertFunctionCategoriesToSidePanelCategories(
                                 response.categories as Category[],
@@ -1114,7 +1082,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                         filePath: model?.fileName || fileName,
                     })
                     .then((response) => {
-                        console.log(">>> List of embedding providers", response);
                         setCategories(
                             convertFunctionCategoriesToSidePanelCategories(
                                 response.categories as Category[],
@@ -1138,7 +1105,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                         filePath: model?.fileName || fileName,
                     })
                     .then((response) => {
-                        console.log(">>> List of vector knowledge bases", response);
                         setCategories(
                             convertFunctionCategoriesToSidePanelCategories(
                                 response.categories as Category[],
@@ -1162,7 +1128,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                         filePath: model?.fileName || fileName,
                     })
                     .then((response) => {
-                        console.log(">>> List of data loaders", response);
                         setCategories(convertDataLoaderCategoriesToSidePanelCategories(response.categories as Category[]));
                         setSidePanelView(SidePanelView.DATA_LOADER_LIST);
                         setShowSidePanel(true);
@@ -1181,7 +1146,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                         filePath: model?.fileName || fileName,
                     })
                     .then((response) => {
-                        console.log(">>> List of chunkers", response);
                         setCategories(convertChunkerCategoriesToSidePanelCategories(response.categories as Category[]));
                         setSidePanelView(SidePanelView.CHUNKER_LIST);
                         setShowSidePanel(true);
@@ -1193,7 +1157,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
 
             default:
                 // default node
-                console.log(">>> on select panel node", { nodeId, metadata });
                 selectedClientName.current = category;
                 setShowProgressIndicator(true);
                 rpcClient
@@ -1204,7 +1167,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                         id: node.codedata,
                     })
                     .then((response) => {
-                        console.log(">>> FlowNode template", response);
                         selectedNodeRef.current = response.flowNode;
                         nodeTemplateRef.current = response.flowNode;
                         showEditForm.current = false;
@@ -1275,7 +1237,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                     flowNode: updatedNode,
                 })
                 .then((response) => {
-                    console.log(">>> Updated source code", response);
                     if (response.codedata) {
                         if (options?.postUpdateCallBack) {
                             options.postUpdateCallBack();
@@ -1319,7 +1280,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                 isFunctionNodeUpdate: dataMapperMode !== DataMapperDisplayMode.NONE,
             })
             .then(async (response) => {
-                console.log(">>> Updated source code", response);
                 if (response.artifacts.length > 0) {
                     if (updatedNode?.codedata?.symbol === GET_DEFAULT_MODEL_PROVIDER) {
                         await rpcClient.getAIAgentRpcClient().configureDefaultModelProvider();
@@ -1350,14 +1310,12 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
     };
 
     const handleOnDeleteNode = async (node: FlowNode) => {
-        console.log(">>> on delete node", node);
         setShowProgressIndicator(true);
 
         const deleteNodeResponse = await rpcClient.getBIDiagramRpcClient().deleteFlowNode({
             filePath: model.fileName,
             flowNode: node,
         });
-        console.log(">>> Updated source code after delete", deleteNodeResponse);
         if (deleteNodeResponse.artifacts.length === 0) {
             console.error(">>> Error updating source code", deleteNodeResponse);
         }
@@ -1381,7 +1339,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
     };
 
     const handleOnAddComment = (comment: string, target: LineRange) => {
-        console.log(">>> on add comment", { comment, target });
         const updatedNode: FlowNode = {
             id: "40715",
             metadata: {
@@ -1431,7 +1388,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
     };
 
     const handleOnEditNode = (node: FlowNode) => {
-        console.log(">>> on edit node", node);
         setSelectedNodeId(node.id);
         selectedNodeRef.current = node;
         if (suggestedText.current) {
@@ -1625,7 +1581,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
     };
 
     const handleOnAddNewModelProvider = () => {
-        console.log(">>> Adding new model provider");
         isCreatingNewModelProvider.current = true;
         setShowProgressIndicator(true);
         setShowProgressSpinner(true);
@@ -1644,7 +1599,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                 searchKind: "MODEL_PROVIDER",
             })
             .then((response) => {
-                console.log(">>> Available model provider types", response);
                 setCategories(convertModelProviderCategoriesToSidePanelCategories(response.categories as Category[]));
                 setSidePanelView(SidePanelView.MODEL_PROVIDERS);
                 setShowSidePanel(true);
@@ -1657,7 +1611,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
     };
 
     const handleOnAddNewVectorStore = () => {
-        console.log(">>> Adding new vector store");
         isCreatingNewVectorStore.current = true;
         setShowProgressIndicator(true);
         setShowProgressSpinner(true);
@@ -1676,7 +1629,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                 searchKind: "VECTOR_STORE",
             })
             .then((response) => {
-                console.log(">>> Available vector store types", response);
                 setCategories(convertVectorStoreCategoriesToSidePanelCategories(response.categories as Category[]));
                 setSidePanelView(SidePanelView.VECTOR_STORES);
                 setShowSidePanel(true);
@@ -1689,7 +1641,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
     };
 
     const handleOnAddNewEmbeddingProvider = () => {
-        console.log(">>> Adding new embedding provider");
         isCreatingNewEmbeddingProvider.current = true;
         setShowProgressIndicator(true);
         setShowProgressSpinner(true);
@@ -1708,7 +1659,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                 searchKind: "EMBEDDING_PROVIDER",
             })
             .then((response) => {
-                console.log(">>> Available embedding provider types", response);
                 setCategories(
                     convertEmbeddingProviderCategoriesToSidePanelCategories(response.categories as Category[])
                 );
@@ -1723,7 +1673,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
     };
 
     const handleOnAddNewVectorKnowledgeBase = () => {
-        console.log(">>> Adding new vector knowledge base");
         isCreatingNewVectorKnowledgeBase.current = true;
         setShowProgressIndicator(true);
         setShowProgressSpinner(true);
@@ -1745,7 +1694,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                 id: updatedMetadata.node.codedata,
             })
             .then((response) => {
-                console.log(">>> Vector Knowledge Base template", response);
                 selectedNodeRef.current = response.flowNode;
                 showEditForm.current = false;
                 setSidePanelView(SidePanelView.FORM);
@@ -1759,7 +1707,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
     };
 
     const handleOnAddNewDataLoader = () => {
-        console.log(">>> Adding new data loader");
         isCreatingNewDataLoader.current = true;
         setShowProgressIndicator(true);
         setShowProgressSpinner(true);
@@ -1778,7 +1725,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                 searchKind: "DATA_LOADER",
             })
             .then((response) => {
-                console.log(">>> Available data loader types", response);
                 setCategories(convertDataLoaderCategoriesToSidePanelCategories(response.categories as Category[]));
                 setSidePanelView(SidePanelView.DATA_LOADERS);
                 setShowSidePanel(true);
@@ -1791,7 +1737,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
     };
 
     const handleOnAddNewChunker = () => {
-        console.log(">>> Adding new chunker");
         isCreatingNewChunker.current = true;
         setShowProgressIndicator(true);
         setShowProgressSpinner(true);
@@ -1810,7 +1755,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                 searchKind: "CHUNKER",
             })
             .then((response) => {
-                console.log(">>> Available chunker types", response);
                 setCategories(convertChunkerCategoriesToSidePanelCategories(response.categories as Category[]));
                 setSidePanelView(SidePanelView.CHUNKERS);
                 setShowSidePanel(true);
@@ -1884,7 +1828,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
     };
 
     const handleOpenView = async (filePath: string, position: NodePosition, identifier?: string) => {
-        console.log(">>> open view: ", { filePath, position });
         const context: VisualizerLocation = {
             documentUri: filePath,
             position: position,
@@ -1906,14 +1849,11 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
     };
 
     const handleEditAgent = () => {
-        console.log(">>> Edit agent called", selectedNodeRef.current);
         // TODO: implement the edit agent logic
     };
 
     // AI Agent callback handlers
     const handleOnEditAgentModel = async (agentCallNode: FlowNode) => {
-        console.log(">>> Edit agent model called", agentCallNode);
-
         const moduleNodes = await rpcClient.getBIDiagramRpcClient().getModuleNodes();
         const agentNode = moduleNodes.flowModel.connections.find((node) => node.properties.variable.value === agentCallNode.properties.connection.value);
         if (!agentNode) {
@@ -1928,7 +1868,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
     };
 
     const handleOnSelectMemoryManager = (node: FlowNode) => {
-        console.log(">>> Select memory manager called", node);
         selectedNodeRef.current = node;
         showEditForm.current = true;
         setSidePanelView(SidePanelView.AGENT_MEMORY_MANAGER);
@@ -1936,7 +1875,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
     };
 
     const handleOnDeleteMemoryManager = async (node: FlowNode) => {
-        console.log(">>> Delete memory manager called", node);
         selectedNodeRef.current = node;
         setShowProgressIndicator(true);
         try {
@@ -1953,7 +1891,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                             filePath: agentFilePath,
                             flowNode: memoryNode,
                         });
-                        console.log(">>> deleted memory manager node", memoryNode);
                     }
                 }
             }
@@ -1983,7 +1920,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
             const agentResponse = await rpcClient
                 .getBIDiagramRpcClient()
                 .getSourceCode({ filePath: agentFilePath, flowNode: agentNode });
-            console.log(">>> response getSourceCode after tool deletion", { agentResponse });
         } catch (error) {
             console.error("Error deleting memory manager:", error);
             alert("Failed to remove memory manager. Please try again.");
@@ -1994,7 +1930,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
     };
 
     const handleOnAddTool = (node: FlowNode) => {
-        console.log(">>> Add tool called", node);
         selectedNodeRef.current = node;
         selectedClientName.current = "Add Tool";
 
@@ -2009,7 +1944,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
     };
 
     const handleOnAddMcpServer = (node: FlowNode) => {
-        console.log(">>> Add MCP Server called", node);
         selectedNodeRef.current = node;
         selectedClientName.current = "Add MCP Server";
 
@@ -2043,7 +1977,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
     };
 
     const handleOnSelectTool = async (tool: ToolData, node: FlowNode) => {
-        console.log(">>> Edit tool called", { node, tool });
         selectedNodeRef.current = node;
         selectedClientName.current = tool.name;
         showEditForm.current = true;
@@ -2072,7 +2005,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
     };
 
     const handleOnSelectMcpToolkit = async (tool: ToolData, node: FlowNode) => {
-        console.log(">>> Edit mcp toolkit called", { node, tool });
         selectedNodeRef.current = node;
         selectedClientName.current = tool.name;
         showEditForm.current = true;
@@ -2085,7 +2017,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
             console.error("Project components not found");
             return;
         }
-        console.log(">>> Project info for mcp toolkit", projectComponents);
         setTimeout(() => {
             const toolCategories: PanelCategory[] = [
                 {
@@ -2121,8 +2052,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
     };
 
     const handleOnDeleteTool = async (tool: ToolData, node: FlowNode) => {
-        console.log(">>> Delete tool called", tool, node);
-
         selectedNodeRef.current = node;
         setShowProgressIndicator(true);
         try {
@@ -2136,12 +2065,10 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                     .getBIDiagramRpcClient()
                     .getSourceCode({ filePath: agentFilePath, flowNode: updateAgentNode });
                 onSave?.();
-                console.log(">>> response getSourceCode after tool deletion", { agentResponse });
             } else {
                 const agentResponse = await rpcClient
                     .getBIDiagramRpcClient()
                     .getSourceCode({ filePath: agentFilePath, flowNode: updatedAgentNode });
-                console.log(">>> response getSourceCode after tool deletion", { agentResponse });
             }
         } catch (error) {
             console.error("Error deleting tool:", error);
@@ -2153,7 +2080,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
     };
 
     const handleOnGoToTool = async (tool: ToolData, node: FlowNode) => {
-        console.log(">>> Go to tool called", tool, node);
         setShowProgressIndicator(true);
         const agentFilePath = await getAgentFilePath(rpcClient);
         // get project components to find the function
@@ -2186,13 +2112,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
     };
 
     const flowModel = originalModel && suggestedModel ? suggestedModel : model;
-    console.log(">>> readonly", {
-        showProgressSpinner,
-        showProgressIndicator,
-        hasDraft,
-        isDraftProcessing,
-        readonly: showProgressSpinner || showProgressIndicator || hasDraft,
-    })
     const memoizedDiagramProps = useMemo(
         () => ({
             model: flowModel,

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
@@ -1218,6 +1218,7 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
             console.log(">>> No updated node found");
             updatedNode = selectedNodeRef.current;
             debouncedGetFlowModel();
+            return;
         }
         setShowProgressIndicator(true);
         setShowProgressSpinner(true);

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FormGenerator/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FormGenerator/index.tsx
@@ -359,16 +359,6 @@ export const FormGenerator = forwardRef<FormExpressionEditorRef, FormProps>(func
             enrichedNodeProperties = enrichFormTemplatePropertiesWithValues(formProperties, formTemplateProperties);
             console.log(">>> Form properties", { formProperties, formTemplateProperties, enrichedNodeProperties });
         }
-        if (Object.keys(formProperties).length === 0) {
-            // update node position
-            node.codedata.lineRange = {
-                ...targetLineRange,
-                fileName: fileName,
-            };
-            // add node to source code
-            onSubmit();
-            return;
-        }
 
         // hide connection property if node is a REMOTE_ACTION_CALL or RESOURCE_ACTION_CALL node
         if (node.codedata.node === "REMOTE_ACTION_CALL" || node.codedata.node === "RESOURCE_ACTION_CALL") {
@@ -1296,7 +1286,7 @@ export const FormGenerator = forwardRef<FormExpressionEditorRef, FormProps>(func
     // default form
     return (
         <EditorContext.Provider value={{ stack, push: pushTypeStack, pop: popTypeStack, peek: peekTypeStack, replaceTop: replaceTop }}>
-            {fields && fields.length > 0 && (
+            {fields && (
                 <Form
                     ref={ref}
                     formFields={fields}

--- a/workspaces/ballerina/bi-diagram/src/components/Diagram.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/Diagram.tsx
@@ -30,7 +30,7 @@ import {
     resetDiagramZoomAndPosition,
 } from "../utils/diagram";
 import { DiagramCanvas } from "./DiagramCanvas";
-import { Flow, NodeModel, FlowNode, Branch, LineRange, NodePosition, ToolData } from "../utils/types";
+import { Flow, NodeModel, FlowNode, Branch, LineRange, NodePosition, ToolData, DraftNodeConfig } from "../utils/types";
 import { NodeFactoryVisitor } from "../visitors/NodeFactoryVisitor";
 import { NodeLinkModel } from "./NodeLink";
 import { OverlayLayerModel } from "./OverlayLayer";
@@ -58,6 +58,7 @@ export interface DiagramProps {
     onConnectionSelect?: (connectionName: string) => void;
     goToSource?: (node: FlowNode) => void;
     openView?: (filePath: string, position: NodePosition) => void;
+    draftNode?: DraftNodeConfig;
     // agent node callbacks
     agentNode?: {
         onModelSelect: (node: FlowNode) => void;
@@ -98,6 +99,7 @@ export function Diagram(props: DiagramProps) {
         onConnectionSelect,
         goToSource,
         openView,
+        draftNode,
         agentNode,
         aiNodes,
         suggestions,
@@ -305,6 +307,7 @@ export function Diagram(props: DiagramProps) {
         onConnectionSelect: onConnectionSelect,
         goToSource: goToSource,
         openView: openView,
+        draftNode: draftNode,
         agentNode: agentNode,
         aiNodes: aiNodes,
         suggestions: suggestions,

--- a/workspaces/ballerina/bi-diagram/src/components/Diagram.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/Diagram.tsx
@@ -59,6 +59,7 @@ export interface DiagramProps {
     goToSource?: (node: FlowNode) => void;
     openView?: (filePath: string, position: NodePosition) => void;
     draftNode?: DraftNodeConfig;
+    selectedNodeId?: string;
     // agent node callbacks
     agentNode?: {
         onModelSelect: (node: FlowNode) => void;
@@ -100,6 +101,7 @@ export function Diagram(props: DiagramProps) {
         goToSource,
         openView,
         draftNode,
+        selectedNodeId,
         agentNode,
         aiNodes,
         suggestions,
@@ -308,6 +310,7 @@ export function Diagram(props: DiagramProps) {
         goToSource: goToSource,
         openView: openView,
         draftNode: draftNode,
+        selectedNodeId: selectedNodeId,
         agentNode: agentNode,
         aiNodes: aiNodes,
         suggestions: suggestions,

--- a/workspaces/ballerina/bi-diagram/src/components/DiagramContext.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/DiagramContext.tsx
@@ -70,6 +70,7 @@ export interface DiagramContextState {
         showSpinner?: boolean;
         description?: string;
     };
+    selectedNodeId?: string;
     agentNode: {
         onModelSelect: (node: FlowNode) => void;
         onAddTool: (node: FlowNode) => void;
@@ -121,6 +122,7 @@ export const DiagramContext = React.createContext<DiagramContextState>({
         showSpinner: false,
         description: "",
     },
+    selectedNodeId: undefined,
     agentNode: {
         onModelSelect: () => {},
         onAddTool: () => {},

--- a/workspaces/ballerina/bi-diagram/src/components/DiagramContext.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/DiagramContext.tsx
@@ -65,6 +65,11 @@ export interface DiagramContextState {
     onConnectionSelect?: (connectionName: string) => void;
     goToSource: (node: FlowNode) => void;
     openView: (filePath: string, position: NodePosition) => void;
+    draftNode?: {
+        override: boolean;
+        showSpinner?: boolean;
+        description?: string;
+    };
     agentNode: {
         onModelSelect: (node: FlowNode) => void;
         onAddTool: (node: FlowNode) => void;
@@ -111,6 +116,11 @@ export const DiagramContext = React.createContext<DiagramContextState>({
     addBreakpoint: () => {},
     removeBreakpoint: () => {},
     openView: () => {},
+    draftNode: {
+        override: true,
+        showSpinner: false,
+        description: "",
+    },
     agentNode: {
         onModelSelect: () => {},
         onAddTool: () => {},

--- a/workspaces/ballerina/bi-diagram/src/components/NodeLink/NodeLinkWidget.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/NodeLink/NodeLinkWidget.tsx
@@ -44,7 +44,7 @@ const fadeInZoomIn = keyframes`
 `;
 
 export const NodeLinkWidget: React.FC<NodeLinkWidgetProps> = ({ link, engine }) => {
-    const { onAddNode, onAddNodePrompt, onAddComment, setLockCanvas } = useDiagramContext();
+    const { onAddNode, onAddNodePrompt, onAddComment, setLockCanvas, readOnly } = useDiagramContext();
 
     const [isHovered, setIsHovered] = useState(false);
     const [isCommentButtonHovered, setIsCommentButtonHovered] = useState(false);
@@ -62,7 +62,11 @@ export const NodeLinkWidget: React.FC<NodeLinkWidgetProps> = ({ link, engine }) 
     const showAddButton = link.showAddButton && !link.disabled;
     const shouldHighlight =
         showAddButton && (isHovered || link.showButtonAlways || isPromptBoxOpen || isCommentBoxOpen);
-    const linkColor = link.disabled ? ThemeColors.OUTLINE_VARIANT : isHovered ? ThemeColors.SECONDARY : ThemeColors.PRIMARY;
+    const linkColor = link.disabled
+        ? ThemeColors.OUTLINE_VARIANT
+        : isHovered && !readOnly
+        ? ThemeColors.SECONDARY
+        : ThemeColors.PRIMARY;
 
     const addButtonPosition = link.getAddButtonPosition();
 
@@ -183,7 +187,7 @@ export const NodeLinkWidget: React.FC<NodeLinkWidgetProps> = ({ link, engine }) 
                     </div>
                 </foreignObject>
             )}
-            {showAddButton && onAddNode && (
+            {showAddButton && onAddNode && !readOnly && (
                 <foreignObject x={addButtonPosition.x - 35} y={addButtonPosition.y - 10} width="70" height="20">
                     <div
                         css={css`

--- a/workspaces/ballerina/bi-diagram/src/components/nodes/AgentCallNode/AgentCallNodeWidget.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/nodes/AgentCallNode/AgentCallNodeWidget.tsx
@@ -440,7 +440,6 @@ export function AgentCallNodeWidget(props: AgentCallNodeWidgetProps) {
     };
 
     const onDeleteTool = (tool: ToolData) => {
-        console.log(">>> onDeleteTool", tool);
         agentNode?.onDeleteTool && agentNode.onDeleteTool(tool, model.node);
         handleToolMenuClose();
     };

--- a/workspaces/ballerina/bi-diagram/src/components/nodes/AgentCallNode/AgentCallNodeWidget.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/nodes/AgentCallNode/AgentCallNodeWidget.tsx
@@ -75,7 +75,7 @@ export namespace NodeStyles {
             props.hasError
                 ? ThemeColors.ERROR
                 : props.hovered && !props.disabled && !props.readOnly
-                ? ThemeColors.HIGHLIGHT
+                ? ThemeColors.SECONDARY
                 : ThemeColors.OUTLINE_VARIANT};
         border-radius: 10px;
         background-color: ${(props: NodeStyleProp) =>
@@ -258,7 +258,7 @@ export namespace NodeStyles {
         &:hover {
             background-color: ${ThemeColors.SURFACE_BRIGHT};
             border-color: ${(props: { readOnly: boolean }) =>
-                props.readOnly ? ThemeColors.OUTLINE_VARIANT : ThemeColors.HIGHLIGHT};
+                props.readOnly ? ThemeColors.OUTLINE_VARIANT : ThemeColors.SECONDARY};
         }
     `;
 
@@ -272,7 +272,7 @@ export namespace NodeStyles {
         cursor: ${(props: { readOnly: boolean }) => (props.readOnly ? "default" : "pointer")};
         &:hover {
             border-color: ${(props: { readOnly: boolean }) =>
-                props.readOnly ? ThemeColors.OUTLINE_VARIANT : ThemeColors.HIGHLIGHT};
+                props.readOnly ? ThemeColors.OUTLINE_VARIANT : ThemeColors.SECONDARY};
         }
     `;
 
@@ -675,7 +675,7 @@ export function AgentCallNodeWidget(props: AgentCallNodeWidgetProps) {
                         css={css`
                             cursor: ${readOnly ? "default" : "pointer"};
                             &:hover {
-                                stroke: ${ThemeColors.HIGHLIGHT};
+                                stroke: ${ThemeColors.SECONDARY};
                             }
                         `}
                     />
@@ -714,13 +714,13 @@ export function AgentCallNodeWidget(props: AgentCallNodeWidgetProps) {
                         css={css`
                             cursor: ${readOnly ? "default" : "pointer"};
                             &:hover circle {
-                                stroke: ${ThemeColors.HIGHLIGHT};
+                                stroke: ${ThemeColors.SECONDARY};
                             }
                             &:hover foreignObject .connector-icon path {
-                                fill: ${ThemeColors.HIGHLIGHT};
+                                fill: ${ThemeColors.SECONDARY};
                             }
                             &:hover text {
-                                fill: ${ThemeColors.HIGHLIGHT};
+                                fill: ${ThemeColors.SECONDARY};
                             }
                             &:hover .tool-tooltip {
                                 opacity: 1;
@@ -905,7 +905,7 @@ export function AgentCallNodeWidget(props: AgentCallNodeWidgetProps) {
                         css={css`
                             cursor: ${readOnly ? "not-allowed" : "pointer"};
                             &:hover path:last-of-type {
-                                fill: ${ThemeColors.HIGHLIGHT};
+                                fill: ${ThemeColors.SECONDARY};
                             }
                             &:hover + .custom-tooltip {
                                 opacity: 1;

--- a/workspaces/ballerina/bi-diagram/src/components/nodes/AgentCallNode/AgentCallNodeWidget.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/nodes/AgentCallNode/AgentCallNodeWidget.tsx
@@ -59,6 +59,7 @@ export namespace NodeStyles {
         hasError: boolean;
         readOnly: boolean;
         isActiveBreakpoint: boolean;
+        isSelected?: boolean;
     };
     export const Box = styled.div<NodeStyleProp>`
         display: flex;
@@ -74,6 +75,8 @@ export namespace NodeStyles {
         border-color: ${(props: NodeStyleProp) =>
             props.hasError
                 ? ThemeColors.ERROR
+                : props.isSelected && !props.disabled
+                ? ThemeColors.SECONDARY
                 : props.hovered && !props.disabled && !props.readOnly
                 ? ThemeColors.SECONDARY
                 : ThemeColors.OUTLINE_VARIANT};
@@ -307,8 +310,10 @@ export interface NodeWidgetProps extends Omit<AgentCallNodeWidgetProps, "childre
 
 export function AgentCallNodeWidget(props: AgentCallNodeWidgetProps) {
     const { model, engine, onClick } = props;
-    const { onNodeSelect, goToSource, onDeleteNode, removeBreakpoint, addBreakpoint, agentNode, readOnly } =
+    const { onNodeSelect, goToSource, onDeleteNode, removeBreakpoint, addBreakpoint, agentNode, readOnly, selectedNodeId } =
         useDiagramContext();
+
+    const isSelected = selectedNodeId === model.node.id;
 
     const [isBoxHovered, setIsBoxHovered] = useState(false);
     const [anchorEl, setAnchorEl] = useState<HTMLElement | SVGSVGElement>(null);
@@ -409,6 +414,7 @@ export function AgentCallNodeWidget(props: AgentCallNodeWidgetProps) {
 
     const handleOnMenuClose = () => {
         setAnchorEl(null);
+        setIsBoxHovered(false);
     };
 
     const handleToolMenuClick = (event: React.MouseEvent<HTMLElement | SVGSVGElement>, tool: ToolData) => {
@@ -520,6 +526,7 @@ export function AgentCallNodeWidget(props: AgentCallNodeWidgetProps) {
                 hasError={hasError}
                 readOnly={readOnly}
                 isActiveBreakpoint={isActiveBreakpoint}
+                isSelected={isSelected}
                 onMouseEnter={() => setIsBoxHovered(true)}
                 onMouseLeave={() => setIsBoxHovered(false)}
             >
@@ -675,7 +682,7 @@ export function AgentCallNodeWidget(props: AgentCallNodeWidgetProps) {
                         css={css`
                             cursor: ${readOnly ? "default" : "pointer"};
                             &:hover {
-                                stroke: ${ThemeColors.SECONDARY};
+                                stroke: ${readOnly ? ThemeColors.OUTLINE_VARIANT : ThemeColors.SECONDARY};
                             }
                         `}
                     />

--- a/workspaces/ballerina/bi-diagram/src/components/nodes/AgentCallNode/AgentCallNodeWidget.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/nodes/AgentCallNode/AgentCallNodeWidget.tsx
@@ -46,16 +46,18 @@ import { BreakpointMenu } from "../../BreakNodeMenu/BreakNodeMenu";
 import { NodeMetadata } from "@wso2/ballerina-core";
 
 export namespace NodeStyles {
-    export const Node = styled.div`
+    export const Node = styled.div<{ readOnly: boolean }>`
         display: flex;
         flex-direction: row;
         align-items: flex-start;
+        cursor: ${(props: { readOnly: boolean }) => (props.readOnly ? "default" : "pointer")};
     `;
 
     export type NodeStyleProp = {
         disabled: boolean;
         hovered: boolean;
         hasError: boolean;
+        readOnly: boolean;
         isActiveBreakpoint: boolean;
     };
     export const Box = styled.div<NodeStyleProp>`
@@ -72,9 +74,9 @@ export namespace NodeStyles {
         border-color: ${(props: NodeStyleProp) =>
             props.hasError
                 ? ThemeColors.ERROR
-                : props.hovered && !props.disabled
-                    ? ThemeColors.HIGHLIGHT
-                    : ThemeColors.OUTLINE_VARIANT};
+                : props.hovered && !props.disabled && !props.readOnly
+                ? ThemeColors.HIGHLIGHT
+                : ThemeColors.OUTLINE_VARIANT};
         border-radius: 10px;
         background-color: ${(props: NodeStyleProp) =>
             props?.isActiveBreakpoint ? ThemeColors.DEBUGGER_BREAKPOINT_BACKGROUND : ThemeColors.SURFACE_DIM};
@@ -182,21 +184,21 @@ export namespace NodeStyles {
         font-style: italic;
     `;
 
-    export const InstructionsRow = styled.div`
+    export const InstructionsRow = styled.div<{ readOnly: boolean }>`
         flex: 1;
         overflow: hidden;
         align-items: flex-start;
         margin-bottom: 6px;
-        cursor: pointer;
+        cursor: ${(props: { readOnly: boolean }) => (props.readOnly ? "default" : "pointer")};
     `;
 
-    export const Row = styled.div`
+    export const Row = styled.div<{ readOnly: boolean }>`
         display: flex;
         flex-direction: row;
         justify-content: space-between;
         align-items: center;
         width: 100%;
-        cursor: pointer;
+        cursor: ${(props: { readOnly: boolean }) => (props.readOnly ? "default" : "pointer")};
     `;
 
     export const Column = styled.div`
@@ -239,7 +241,7 @@ export namespace NodeStyles {
         gap: 8px;
     `;
 
-    export const MemoryButton = styled.div`
+    export const MemoryButton = styled.div<{ readOnly: boolean }>`
         display: flex;
         align-items: center;
         justify-content: center;
@@ -252,22 +254,25 @@ export namespace NodeStyles {
         color: ${ThemeColors.ON_SURFACE};
         font-size: 14px;
         font-family: "GilmerRegular";
-        cursor: pointer;
+        cursor: ${(props: { readOnly: boolean }) => (props.readOnly ? "default" : "pointer")};
         &:hover {
             background-color: ${ThemeColors.SURFACE_BRIGHT};
-            border-color: ${ThemeColors.HIGHLIGHT};
+            border-color: ${(props: { readOnly: boolean }) =>
+                props.readOnly ? ThemeColors.OUTLINE_VARIANT : ThemeColors.HIGHLIGHT};
         }
     `;
 
-    export const MemoryCard = styled.div`
+    export const MemoryCard = styled.div<{ readOnly: boolean }>`
         width: 100%;
         padding: 8px 6px 8px 12px;
         border: 1px solid ${ThemeColors.OUTLINE_VARIANT};
         border-radius: 4px;
         background-color: transparent;
         color: ${ThemeColors.ON_SURFACE};
+        cursor: ${(props: { readOnly: boolean }) => (props.readOnly ? "default" : "pointer")};
         &:hover {
-            border-color: ${ThemeColors.HIGHLIGHT};
+            border-color: ${(props: { readOnly: boolean }) =>
+                props.readOnly ? ThemeColors.OUTLINE_VARIANT : ThemeColors.HIGHLIGHT};
         }
     `;
 
@@ -298,7 +303,7 @@ interface AgentCallNodeWidgetProps {
     onClick?: (node: FlowNode) => void;
 }
 
-export interface NodeWidgetProps extends Omit<AgentCallNodeWidgetProps, "children"> { }
+export interface NodeWidgetProps extends Omit<AgentCallNodeWidgetProps, "children"> {}
 
 export function AgentCallNodeWidget(props: AgentCallNodeWidgetProps) {
     const { model, engine, onClick } = props;
@@ -323,6 +328,9 @@ export function AgentCallNodeWidget(props: AgentCallNodeWidgetProps) {
     }, [model.node.suggested]);
 
     const handleOnClick = (event: React.MouseEvent<HTMLDivElement>) => {
+        if (readOnly) {
+            return;
+        }
         if (event.metaKey) {
             onGoToSource();
         } else {
@@ -337,25 +345,33 @@ export function AgentCallNodeWidget(props: AgentCallNodeWidgetProps) {
     };
 
     const onModelEditClick = () => {
-        console.log(">>> onModelEditClick", model.node);
+        if (readOnly) {
+            return;
+        }
         agentNode?.onModelSelect && agentNode.onModelSelect(model.node);
         setAnchorEl(null);
     };
 
     const onMemoryManagerClick = () => {
-        console.log(">>> onMemoryManagerClick", model.node);
+        if (readOnly) {
+            return;
+        }
         agentNode?.onSelectMemoryManager && agentNode.onSelectMemoryManager(model.node);
         setMemoryMenuAnchorEl(null);
     };
 
     const onMemoryManagerDeleteClick = () => {
-        console.log(">>> onMemoryManagerDeleteClick", model.node);
+        if (readOnly) {
+            return;
+        }
         agentNode?.onDeleteMemoryManager && agentNode.onDeleteMemoryManager(model.node);
         setMemoryMenuAnchorEl(null);
     };
 
     const onToolClick = (tool: ToolData) => {
-        console.log(">>> on Tool Click", tool);
+        if (readOnly) {
+            return;
+        }
         const toolType = tool.type ?? "";
         if (toolType === "MCP Server") {
             agentNode?.onSelectMcpToolkit && agentNode.onSelectMcpToolkit(tool, model.node);
@@ -367,14 +383,10 @@ export function AgentCallNodeWidget(props: AgentCallNodeWidgetProps) {
     };
 
     const onAddToolClick = () => {
-        console.log(">>> onAddToolClick", model.node);
+        if (readOnly) {
+            return;
+        }
         agentNode?.onAddTool && agentNode.onAddTool(model.node);
-        setAnchorEl(null);
-    };
-
-    const onAddMcpServerClick = () => {
-        console.log(">>> onAddMcpServerClick", model.node);
-        agentNode?.onAddMcpServer && agentNode.onAddMcpServer(model.node);
         setAnchorEl(null);
     };
 
@@ -389,6 +401,9 @@ export function AgentCallNodeWidget(props: AgentCallNodeWidgetProps) {
     };
 
     const handleOnMenuClick = (event: React.MouseEvent<HTMLElement | SVGSVGElement>) => {
+        if (readOnly) {
+            return;
+        }
         setAnchorEl(event.currentTarget);
     };
 
@@ -397,6 +412,9 @@ export function AgentCallNodeWidget(props: AgentCallNodeWidgetProps) {
     };
 
     const handleToolMenuClick = (event: React.MouseEvent<HTMLElement | SVGSVGElement>, tool: ToolData) => {
+        if (readOnly) {
+            return;
+        }
         event.stopPropagation();
         setToolAnchorEl(event.currentTarget);
         setSelectedTool(tool);
@@ -407,13 +425,10 @@ export function AgentCallNodeWidget(props: AgentCallNodeWidgetProps) {
         setSelectedTool(null);
     };
 
-    const onEditTool = (tool: ToolData) => {
-        console.log(">>> onEditTool", tool);
-        onToolClick(tool);
-    };
-
     const onImplementTool = (tool: ToolData) => {
-        console.log(">>> onImplementTool", tool);
+        if (readOnly) {
+            return;
+        }
         agentNode?.goToTool && agentNode.goToTool(tool, model.node);
         handleToolMenuClose();
     };
@@ -435,6 +450,9 @@ export function AgentCallNodeWidget(props: AgentCallNodeWidgetProps) {
     };
 
     const handleOnMemoryMenuClick = (event: React.MouseEvent<HTMLElement | SVGSVGElement>) => {
+        if (readOnly) {
+            return;
+        }
         event.stopPropagation();
         setMemoryMenuAnchorEl(event.currentTarget);
     };
@@ -495,11 +513,12 @@ export function AgentCallNodeWidget(props: AgentCallNodeWidgetProps) {
     }
 
     return (
-        <NodeStyles.Node data-testid="agent-call-node">
+        <NodeStyles.Node data-testid="agent-call-node" readOnly={readOnly}>
             <NodeStyles.Box
                 disabled={disabled}
                 hovered={isBoxHovered}
                 hasError={hasError}
+                readOnly={readOnly}
                 isActiveBreakpoint={isActiveBreakpoint}
                 onMouseEnter={() => setIsBoxHovered(true)}
                 onMouseLeave={() => setIsBoxHovered(false)}
@@ -518,22 +537,26 @@ export function AgentCallNodeWidget(props: AgentCallNodeWidgetProps) {
                 )}
                 <NodeStyles.TopPortWidget port={model.getPort("in")!} engine={engine} />
                 <NodeStyles.Column style={{ height: `${model.node.viewState?.ch}px` }}>
-                    <NodeStyles.Row>
+                    <NodeStyles.Row readOnly={readOnly}>
                         <NodeStyles.Icon onClick={handleOnClick}>
                             <NodeIcon type={model.node.codedata.node} size={24} />
                         </NodeStyles.Icon>
-                        <NodeStyles.Row>
+                        <NodeStyles.Row readOnly={readOnly}>
                             <NodeStyles.Header onClick={handleOnClick}>
                                 <NodeStyles.Title>{nodeTitle}</NodeStyles.Title>
-                                <NodeStyles.Description>{model.node.properties.variable?.value as ReactNode}</NodeStyles.Description>
+                                <NodeStyles.Description>
+                                    {model.node.properties.variable?.value as ReactNode}
+                                </NodeStyles.Description>
                             </NodeStyles.Header>
                             <NodeStyles.ActionButtonGroup>
                                 {hasError && <DiagnosticsPopUp node={model.node} />}
-                                {!readOnly && (
-                                    <NodeStyles.MenuButton appearance="icon" onClick={handleOnMenuClick}>
-                                        <MoreVertIcon />
-                                    </NodeStyles.MenuButton>
-                                )}
+                                <NodeStyles.MenuButton
+                                    buttonSx={readOnly ? { cursor: "not-allowed" } : {}}
+                                    appearance="icon"
+                                    onClick={handleOnMenuClick}
+                                >
+                                    <MoreVertIcon />
+                                </NodeStyles.MenuButton>
                             </NodeStyles.ActionButtonGroup>
                         </NodeStyles.Row>
                         <Popover
@@ -561,26 +584,27 @@ export function AgentCallNodeWidget(props: AgentCallNodeWidgetProps) {
                     </NodeStyles.Row>
 
                     <NodeStyles.MemoryContainer>
-                        <NodeStyles.Row>
+                        <NodeStyles.Row readOnly={readOnly}>
                             {nodeMetadata?.memory ? (
-                                <NodeStyles.MemoryCard onClick={onMemoryManagerClick}>
-                                    <NodeStyles.Row>
+                                <NodeStyles.MemoryCard readOnly={readOnly} onClick={onMemoryManagerClick}>
+                                    <NodeStyles.Row readOnly={readOnly}>
                                         <div style={{ flex: 1 }}>
                                             <NodeStyles.MemoryTitle>Memory</NodeStyles.MemoryTitle>
                                             <NodeStyles.MemoryMeta>
-                                                {nodeMetadata?.memory?.type ||
-                                                    "MessageWindowChatMemory"}
+                                                {nodeMetadata?.memory?.type || "MessageWindowChatMemory"}
                                             </NodeStyles.MemoryMeta>
                                         </div>
-                                        {!readOnly && (
-                                            <NodeStyles.MenuButton appearance="icon" onClick={handleOnMemoryMenuClick}>
-                                                <MoreVertIcon />
-                                            </NodeStyles.MenuButton>
-                                        )}
+                                        <NodeStyles.MenuButton
+                                            buttonSx={readOnly ? { cursor: "not-allowed" } : {}}
+                                            appearance="icon"
+                                            onClick={handleOnMemoryMenuClick}
+                                        >
+                                            <MoreVertIcon />
+                                        </NodeStyles.MenuButton>
                                     </NodeStyles.Row>
                                 </NodeStyles.MemoryCard>
                             ) : (
-                                <NodeStyles.MemoryButton onClick={onMemoryManagerClick}>
+                                <NodeStyles.MemoryButton readOnly={readOnly} onClick={onMemoryManagerClick}>
                                     <Icon name="bi-plus" sx={{ fontSize: "16px", marginRight: "4px" }} />
                                     Add Memory
                                 </NodeStyles.MemoryButton>
@@ -606,23 +630,21 @@ export function AgentCallNodeWidget(props: AgentCallNodeWidgetProps) {
                     </NodeStyles.MemoryContainer>
 
                     {nodeMetadata?.agent?.role ? (
-                        <NodeStyles.Row onClick={handleOnClick}>
+                        <NodeStyles.Row readOnly={readOnly} onClick={handleOnClick}>
                             <NodeStyles.Role>{nodeMetadata?.agent?.role}</NodeStyles.Role>
                         </NodeStyles.Row>
                     ) : (
-                        <NodeStyles.Row onClick={handleOnClick}>
+                        <NodeStyles.Row readOnly={readOnly} onClick={handleOnClick}>
                             <NodeStyles.RolePlaceholder>Define agent's role</NodeStyles.RolePlaceholder>
                         </NodeStyles.Row>
                     )}
 
                     {nodeMetadata?.agent?.instructions ? (
-                        <NodeStyles.InstructionsRow onClick={handleOnClick}>
-                            <NodeStyles.Instructions>
-                                {nodeMetadata.agent.instructions}
-                            </NodeStyles.Instructions>
+                        <NodeStyles.InstructionsRow readOnly={readOnly} onClick={handleOnClick}>
+                            <NodeStyles.Instructions>{nodeMetadata.agent.instructions}</NodeStyles.Instructions>
                         </NodeStyles.InstructionsRow>
                     ) : (
-                        <NodeStyles.InstructionsRow onClick={handleOnClick}>
+                        <NodeStyles.InstructionsRow readOnly={readOnly} onClick={handleOnClick}>
                             <NodeStyles.InstructionsPlaceholder>
                                 Provide specific instructions on how the agent should behave.
                             </NodeStyles.InstructionsPlaceholder>
@@ -651,7 +673,7 @@ export function AgentCallNodeWidget(props: AgentCallNodeWidgetProps) {
                         opacity={disabled ? 0.7 : 1}
                         onClick={onModelEditClick}
                         css={css`
-                            cursor: pointer;
+                            cursor: ${readOnly ? "default" : "pointer"};
                             &:hover {
                                 stroke: ${ThemeColors.HIGHLIGHT};
                             }
@@ -685,11 +707,12 @@ export function AgentCallNodeWidget(props: AgentCallNodeWidgetProps) {
                 {tools.map((tool: ToolData, index: number) => (
                     <g
                         key={index}
-                        transform={`translate(0, ${(index + 1) * (NODE_HEIGHT + AGENT_NODE_TOOL_GAP) + AGENT_NODE_TOOL_SECTION_GAP
-                            })`}
+                        transform={`translate(0, ${
+                            (index + 1) * (NODE_HEIGHT + AGENT_NODE_TOOL_GAP) + AGENT_NODE_TOOL_SECTION_GAP
+                        })`}
                         onClick={() => onToolClick(tool)}
                         css={css`
-                            cursor: pointer;
+                            cursor: ${readOnly ? "default" : "pointer"};
                             &:hover circle {
                                 stroke: ${ThemeColors.HIGHLIGHT};
                             }
@@ -866,12 +889,13 @@ export function AgentCallNodeWidget(props: AgentCallNodeWidgetProps) {
 
                 {/* Add "Add new tool" button below all tools */}
                 <g
-                    transform={`translate(-11, ${tools.length > 0
-                        ? (tools.length + 1) * (NODE_HEIGHT + AGENT_NODE_TOOL_GAP) + AGENT_NODE_TOOL_SECTION_GAP
-                        : NODE_HEIGHT + AGENT_NODE_TOOL_SECTION_GAP
-                        })`}
+                    transform={`translate(-11, ${
+                        tools.length > 0
+                            ? (tools.length + 1) * (NODE_HEIGHT + AGENT_NODE_TOOL_GAP) + AGENT_NODE_TOOL_SECTION_GAP
+                            : NODE_HEIGHT + AGENT_NODE_TOOL_SECTION_GAP
+                    })`}
                     onClick={onAddToolClick}
-                    style={{ cursor: "pointer" }}
+                    style={{ cursor: readOnly ? "default" : "pointer" }}
                 >
                     <svg
                         xmlns="http://www.w3.org/2000/svg"
@@ -879,7 +903,7 @@ export function AgentCallNodeWidget(props: AgentCallNodeWidgetProps) {
                         height="20"
                         viewBox="0 0 24 24"
                         css={css`
-                            cursor: pointer;
+                            cursor: ${readOnly ? "not-allowed" : "pointer"};
                             &:hover path:last-of-type {
                                 fill: ${ThemeColors.HIGHLIGHT};
                             }

--- a/workspaces/ballerina/bi-diagram/src/components/nodes/ApiCallNode/ApiCallNodeWidget.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/nodes/ApiCallNode/ApiCallNodeWidget.tsx
@@ -69,7 +69,7 @@ export namespace NodeStyles {
             props.hasError
                 ? ThemeColors.ERROR
                 : props.hovered && !props.disabled && !props.readOnly
-                ? ThemeColors.HIGHLIGHT
+                ? ThemeColors.SECONDARY
                 : ThemeColors.OUTLINE_VARIANT};
         border-radius: 10px;
         background-color: ${(props: NodeStyleProp) =>
@@ -296,7 +296,7 @@ export function ApiCallNodeWidget(props: ApiCallNodeWidgetProps) {
     const hasError = nodeHasError(model.node);
 
     const arrowColor =
-        disabled || readOnly ? ThemeColors.ON_SURFACE : isBoxHovered ? ThemeColors.HIGHLIGHT : ThemeColors.ON_SURFACE;
+        disabled || readOnly ? ThemeColors.ON_SURFACE : isBoxHovered ? ThemeColors.SECONDARY : ThemeColors.ON_SURFACE;
 
     return (
         <NodeStyles.Node readOnly={readOnly}>
@@ -386,7 +386,7 @@ export function ApiCallNodeWidget(props: ApiCallNodeWidgetProps) {
                     cy="24"
                     r="22"
                     fill={ThemeColors.SURFACE_DIM}
-                    stroke={isCircleHovered && !disabled ? ThemeColors.HIGHLIGHT : ThemeColors.OUTLINE_VARIANT}
+                    stroke={isCircleHovered && !disabled ? ThemeColors.SECONDARY : ThemeColors.OUTLINE_VARIANT}
                     strokeWidth={1.5}
                     strokeDasharray={disabled ? "5 5" : "none"}
                     opacity={disabled ? 0.7 : 1}

--- a/workspaces/ballerina/bi-diagram/src/components/nodes/ApiCallNode/ApiCallNodeWidget.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/nodes/ApiCallNode/ApiCallNodeWidget.tsx
@@ -53,6 +53,7 @@ export namespace NodeStyles {
         hasError: boolean;
         readOnly: boolean;
         isActiveBreakpoint: boolean;
+        isSelected?: boolean;
     };
     export const Box = styled.div<NodeStyleProp>`
         display: flex;
@@ -68,6 +69,8 @@ export namespace NodeStyles {
         border-color: ${(props: NodeStyleProp) =>
             props.hasError
                 ? ThemeColors.ERROR
+                : props.isSelected && !props.disabled
+                ? ThemeColors.SECONDARY
                 : props.hovered && !props.disabled && !props.readOnly
                 ? ThemeColors.SECONDARY
                 : ThemeColors.OUTLINE_VARIANT};
@@ -207,8 +210,10 @@ export interface NodeWidgetProps extends Omit<ApiCallNodeWidgetProps, "children"
 
 export function ApiCallNodeWidget(props: ApiCallNodeWidgetProps) {
     const { model, engine, onClick } = props;
-    const { onNodeSelect, onConnectionSelect, goToSource, onDeleteNode, removeBreakpoint, addBreakpoint, readOnly } =
+    const { onNodeSelect, onConnectionSelect, goToSource, onDeleteNode, removeBreakpoint, addBreakpoint, readOnly, selectedNodeId } =
         useDiagramContext();
+
+    const isSelected = selectedNodeId === model.node.id;
 
     const [isBoxHovered, setIsBoxHovered] = useState(false);
     const [isCircleHovered, setIsCircleHovered] = useState(false);
@@ -269,6 +274,7 @@ export function ApiCallNodeWidget(props: ApiCallNodeWidgetProps) {
 
     const handleOnMenuClose = () => {
         setAnchorEl(null);
+        setIsBoxHovered(false);
     };
 
     const onAddBreakpoint = () => {
@@ -306,6 +312,7 @@ export function ApiCallNodeWidget(props: ApiCallNodeWidgetProps) {
                 hasError={hasError}
                 readOnly={readOnly}
                 isActiveBreakpoint={isActiveBreakpoint}
+                isSelected={isSelected}
                 onMouseEnter={() => setIsBoxHovered(true)}
                 onMouseLeave={() => setIsBoxHovered(false)}
             >

--- a/workspaces/ballerina/bi-diagram/src/components/nodes/ApiCallNode/ApiCallNodeWidget.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/nodes/ApiCallNode/ApiCallNodeWidget.tsx
@@ -40,17 +40,18 @@ import { getNodeTitle, nodeHasError } from "../../../utils/node";
 import { BreakpointMenu } from "../../BreakNodeMenu/BreakNodeMenu";
 
 export namespace NodeStyles {
-    export const Node = styled.div`
+    export const Node = styled.div<{ readOnly: boolean }>`
         display: flex;
         flex-direction: row;
         align-items: flex-start;
-        cursor: pointer;
+        cursor: ${(props: { readOnly: boolean }) => (props.readOnly ? "default" : "pointer")};
     `;
 
     export type NodeStyleProp = {
         disabled: boolean;
         hovered: boolean;
         hasError: boolean;
+        readOnly: boolean;
         isActiveBreakpoint: boolean;
     };
     export const Box = styled.div<NodeStyleProp>`
@@ -65,11 +66,16 @@ export namespace NodeStyles {
         border: ${(props: NodeStyleProp) => (props.disabled ? DRAFT_NODE_BORDER_WIDTH : NODE_BORDER_WIDTH)}px;
         border-style: ${(props: NodeStyleProp) => (props.disabled ? "dashed" : "solid")};
         border-color: ${(props: NodeStyleProp) =>
-            props.hasError ? ThemeColors.ERROR : props.hovered && !props.disabled ? ThemeColors.HIGHLIGHT : ThemeColors.OUTLINE_VARIANT};
+            props.hasError
+                ? ThemeColors.ERROR
+                : props.hovered && !props.disabled && !props.readOnly
+                ? ThemeColors.HIGHLIGHT
+                : ThemeColors.OUTLINE_VARIANT};
         border-radius: 10px;
         background-color: ${(props: NodeStyleProp) =>
             props?.isActiveBreakpoint ? ThemeColors.DEBUGGER_BREAKPOINT_BACKGROUND : ThemeColors.SURFACE_DIM};
         color: ${ThemeColors.ON_SURFACE};
+        cursor: ${(props: NodeStyleProp) => (props.readOnly ? "default" : "pointer")};
     `;
 
     export const Header = styled.div<{}>`
@@ -220,6 +226,9 @@ export function ApiCallNodeWidget(props: ApiCallNodeWidgetProps) {
     }, [model.node.suggested]);
 
     const handleOnClick = (event: React.MouseEvent<HTMLDivElement>) => {
+        if (readOnly) {
+            return;
+        }
         if (event.metaKey) {
             onGoToSource();
         } else {
@@ -234,6 +243,9 @@ export function ApiCallNodeWidget(props: ApiCallNodeWidgetProps) {
     };
 
     const onConnectionClick = () => {
+        if (readOnly) {
+            return;
+        }
         onConnectionSelect && onConnectionSelect(model.node.properties?.connection?.value as string);
         setAnchorEl(null);
     };
@@ -249,6 +261,9 @@ export function ApiCallNodeWidget(props: ApiCallNodeWidgetProps) {
     };
 
     const handleOnMenuClick = (event: React.MouseEvent<HTMLElement | SVGSVGElement>) => {
+        if (readOnly) {
+            return;
+        }
         setAnchorEl(event.currentTarget);
     };
 
@@ -280,12 +295,16 @@ export function ApiCallNodeWidget(props: ApiCallNodeWidgetProps) {
     const nodeTitle = getNodeTitle(model.node);
     const hasError = nodeHasError(model.node);
 
+    const arrowColor =
+        disabled || readOnly ? ThemeColors.ON_SURFACE : isBoxHovered ? ThemeColors.HIGHLIGHT : ThemeColors.ON_SURFACE;
+
     return (
-        <NodeStyles.Node>
+        <NodeStyles.Node readOnly={readOnly}>
             <NodeStyles.Box
                 disabled={disabled}
                 hovered={isBoxHovered}
                 hasError={hasError}
+                readOnly={readOnly}
                 isActiveBreakpoint={isActiveBreakpoint}
                 onMouseEnter={() => setIsBoxHovered(true)}
                 onMouseLeave={() => setIsBoxHovered(false)}
@@ -310,15 +329,19 @@ export function ApiCallNodeWidget(props: ApiCallNodeWidgetProps) {
                     <NodeStyles.Row>
                         <NodeStyles.Header onClick={handleOnClick}>
                             <NodeStyles.Title>{nodeTitle}</NodeStyles.Title>
-                            <NodeStyles.Description>{model.node.properties.variable?.value as ReactNode}</NodeStyles.Description>
+                            <NodeStyles.Description>
+                                {model.node.properties.variable?.value as ReactNode}
+                            </NodeStyles.Description>
                         </NodeStyles.Header>
                         <NodeStyles.ActionButtonGroup>
                             {hasError && <DiagnosticsPopUp node={model.node} />}
-                            {!readOnly && (
-                                <NodeStyles.MenuButton appearance="icon" onClick={handleOnMenuClick}>
-                                    <MoreVertIcon />
-                                </NodeStyles.MenuButton>
-                            )}
+                            <NodeStyles.MenuButton
+                                buttonSx={readOnly ? { cursor: "not-allowed" } : {}}
+                                appearance="icon"
+                                onClick={handleOnMenuClick}
+                            >
+                                <MoreVertIcon />
+                            </NodeStyles.MenuButton>
                         </NodeStyles.ActionButtonGroup>
                     </NodeStyles.Row>
                     {/* <NodeStyles.StyledButton appearance="icon" onClick={handleOnMenuClick}>
@@ -355,7 +378,7 @@ export function ApiCallNodeWidget(props: ApiCallNodeWidgetProps) {
                 height={NODE_HEIGHT + LABEL_HEIGHT}
                 viewBox="0 0 130 70"
                 onClick={onConnectionClick}
-                onMouseEnter={() => setIsCircleHovered(true)}
+                onMouseEnter={() => !readOnly && setIsCircleHovered(true)}
                 onMouseLeave={() => setIsCircleHovered(false)}
             >
                 <circle
@@ -365,7 +388,7 @@ export function ApiCallNodeWidget(props: ApiCallNodeWidgetProps) {
                     fill={ThemeColors.SURFACE_DIM}
                     stroke={isCircleHovered && !disabled ? ThemeColors.HIGHLIGHT : ThemeColors.OUTLINE_VARIANT}
                     strokeWidth={1.5}
-                    strokeDasharray={disabled  ? "5 5" : "none"}
+                    strokeDasharray={disabled ? "5 5" : "none"}
                     opacity={disabled ? 0.7 : 1}
                 />
                 <text
@@ -378,10 +401,20 @@ export function ApiCallNodeWidget(props: ApiCallNodeWidgetProps) {
                 >
                     {(model.node.properties.connection.value as string)?.length > 16
                         ? `${(model.node.properties.connection.value as string).slice(0, 16)}...`
-                        : model.node.properties.connection.value as ReactNode}
+                        : (model.node.properties.connection.value as ReactNode)}
                 </text>
                 <foreignObject x="68" y="12" width="24" height="24" fill={ThemeColors.ON_SURFACE}>
-                    <ConnectorIcon url={model.node.metadata.icon} style={{ width: 24, height: 24, fontSize: 24 }} codedata={model.node?.codedata} />
+                    <ConnectorIcon
+                        url={model.node.metadata.icon}
+                        style={{
+                            width: 24,
+                            height: 24,
+                            fontSize: 24,
+                            cursor: readOnly ? "default" : "pointer",
+                            pointerEvents: readOnly ? "none" : "auto",
+                        }}
+                        codedata={model.node?.codedata}
+                    />
                 </foreignObject>
                 <line
                     x1="0"
@@ -389,7 +422,7 @@ export function ApiCallNodeWidget(props: ApiCallNodeWidgetProps) {
                     x2="57"
                     y2="25"
                     style={{
-                        stroke: disabled ? ThemeColors.ON_SURFACE : isBoxHovered ? ThemeColors.HIGHLIGHT : ThemeColors.ON_SURFACE,
+                        stroke: arrowColor,
                         strokeWidth: 1.5,
                         strokeDasharray: isClassCall ? "5 5" : "none",
                         markerEnd: isClassCall ? "none" : `url(#${model.node.id}-arrow-head)`,
@@ -405,10 +438,7 @@ export function ApiCallNodeWidget(props: ApiCallNodeWidgetProps) {
                         orient="auto"
                         id={`${model.node.id}-arrow-head`}
                     >
-                        <polygon
-                            points="0,4 0,0 4,2"
-                            fill={disabled ? ThemeColors.ON_SURFACE : isBoxHovered ? ThemeColors.HIGHLIGHT : ThemeColors.ON_SURFACE}
-                        ></polygon>
+                        <polygon points="0,4 0,0 4,2" fill={arrowColor}></polygon>
                     </marker>
                 </defs>
             </svg>

--- a/workspaces/ballerina/bi-diagram/src/components/nodes/ApiCallNode/ApiCallNodeWidget.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/nodes/ApiCallNode/ApiCallNodeWidget.tsx
@@ -230,6 +230,10 @@ export function ApiCallNodeWidget(props: ApiCallNodeWidgetProps) {
         }
     }, [model.node.suggested]);
 
+    useEffect(() => {
+        model.setSelected(isSelected);
+    }, [isSelected]);
+
     const handleOnClick = (event: React.MouseEvent<HTMLDivElement>) => {
         if (readOnly) {
             return;

--- a/workspaces/ballerina/bi-diagram/src/components/nodes/BaseNode/BaseNodeWidget.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/nodes/BaseNode/BaseNodeWidget.tsx
@@ -44,6 +44,7 @@ export namespace NodeStyles {
         hasError: boolean;
         readOnly: boolean;
         isActiveBreakpoint?: boolean;
+        isSelected?: boolean;
     };
     export const Node = styled.div<NodeStyleProp>`
         display: flex;
@@ -62,6 +63,8 @@ export namespace NodeStyles {
         border-color: ${(props: NodeStyleProp) =>
             props.hasError
                 ? ThemeColors.ERROR
+                : props.isSelected && !props.disabled
+                ? ThemeColors.SECONDARY
                 : props.hovered && !props.disabled && !props.readOnly
                 ? ThemeColors.SECONDARY
                 : ThemeColors.OUTLINE_VARIANT};
@@ -173,8 +176,10 @@ export interface NodeWidgetProps extends Omit<BaseNodeWidgetProps, "children"> {
 
 export function BaseNodeWidget(props: BaseNodeWidgetProps) {
     const { model, engine, onClick } = props;
-    const { onNodeSelect, goToSource, openView, onDeleteNode, removeBreakpoint, addBreakpoint, readOnly } =
+    const { onNodeSelect, goToSource, openView, onDeleteNode, removeBreakpoint, addBreakpoint, readOnly, selectedNodeId } =
         useDiagramContext();
+
+    const isSelected = selectedNodeId === model.node.id;
 
     const [isHovered, setIsHovered] = useState(false);
     const [menuAnchorEl, setMenuAnchorEl] = useState<HTMLElement | SVGSVGElement>(null);
@@ -250,6 +255,7 @@ export function BaseNodeWidget(props: BaseNodeWidgetProps) {
 
     const handleOnMenuClose = () => {
         setMenuAnchorEl(null);
+        setIsHovered(false);
     };
 
     const openDataMapper = async () => {
@@ -338,6 +344,7 @@ export function BaseNodeWidget(props: BaseNodeWidgetProps) {
             hasError={hasError}
             readOnly={readOnly}
             isActiveBreakpoint={isActiveBreakpoint}
+            isSelected={isSelected}
             onMouseEnter={() => setIsHovered(true)}
             onMouseLeave={() => setIsHovered(false)}
         >

--- a/workspaces/ballerina/bi-diagram/src/components/nodes/BaseNode/BaseNodeWidget.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/nodes/BaseNode/BaseNodeWidget.tsx
@@ -63,7 +63,7 @@ export namespace NodeStyles {
             props.hasError
                 ? ThemeColors.ERROR
                 : props.hovered && !props.disabled && !props.readOnly
-                ? ThemeColors.HIGHLIGHT
+                ? ThemeColors.SECONDARY
                 : ThemeColors.OUTLINE_VARIANT};
         border-radius: 10px;
         cursor: ${(props: NodeStyleProp) => (props.readOnly ? "default" : "pointer")};

--- a/workspaces/ballerina/bi-diagram/src/components/nodes/CommentNode/CommentNodeWidget.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/nodes/CommentNode/CommentNodeWidget.tsx
@@ -193,6 +193,7 @@ export function CommentNodeWidget(props: CommentNodeWidgetProps) {
 
     const handleOnMenuClose = () => {
         setAnchorEl(null);
+        setIsHovered(false);
     };
 
     const menuItems: Item[] = [

--- a/workspaces/ballerina/bi-diagram/src/components/nodes/DraftNode/DraftNodeWidget.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/nodes/DraftNode/DraftNodeWidget.tsx
@@ -82,24 +82,32 @@ export interface NodeWidgetProps extends Omit<DraftNodeWidgetProps, "children"> 
 
 export function DraftNodeWidget(props: DraftNodeWidgetProps) {
     const { model, engine } = props;
-    const { suggestions } = useDiagramContext();
+    const { draftNode, suggestions } = useDiagramContext();
+    console.log(">>> DraftNodeWidget context", { draftNode, suggestions } );
 
-    const generatingSuggestion = suggestions?.fetching;
-
-    return (
-        <NodeStyles.Node>
-            <NodeStyles.TopPortWidget port={model.getPort("in")!} engine={engine} />
-            {!generatingSuggestion && (
-                <NodeStyles.Row>
-                    <NodeStyles.Description>Select node from node panel.</NodeStyles.Description>
-                </NodeStyles.Row>
-            )}
-            {generatingSuggestion && (
+    // special case draft node if suggestions are fetching
+    if (suggestions?.fetching && !draftNode.override) {
+        return (
+            <NodeStyles.Node>
+                <NodeStyles.TopPortWidget port={model.getPort("in")!} engine={engine} />
                 <NodeStyles.Row>
                     <ProgressRing sx={{ width: 14 }} />
                     <NodeStyles.Description>Generating next suggestion...</NodeStyles.Description>
                 </NodeStyles.Row>
-            )}
+                <NodeStyles.BottomPortWidget port={model.getPort("out")!} engine={engine} />
+            </NodeStyles.Node>
+        );
+    }
+
+    return (
+        <NodeStyles.Node>
+            <NodeStyles.TopPortWidget port={model.getPort("in")!} engine={engine} />
+            <NodeStyles.Row>
+                {draftNode?.showSpinner && <ProgressRing sx={{ width: 14 }} />}
+                <NodeStyles.Description>
+                    {draftNode?.description || "Select node from node panel."}
+                </NodeStyles.Description>
+            </NodeStyles.Row>
             <NodeStyles.BottomPortWidget port={model.getPort("out")!} engine={engine} />
         </NodeStyles.Node>
     );

--- a/workspaces/ballerina/bi-diagram/src/components/nodes/DraftNode/DraftNodeWidget.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/nodes/DraftNode/DraftNodeWidget.tsx
@@ -83,7 +83,6 @@ export interface NodeWidgetProps extends Omit<DraftNodeWidgetProps, "children"> 
 export function DraftNodeWidget(props: DraftNodeWidgetProps) {
     const { model, engine } = props;
     const { draftNode, suggestions } = useDiagramContext();
-    console.log(">>> DraftNodeWidget context", { draftNode, suggestions } );
 
     // special case draft node if suggestions are fetching
     if (suggestions?.fetching && !draftNode.override) {

--- a/workspaces/ballerina/bi-diagram/src/components/nodes/DraftNode/DraftNodeWidget.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/nodes/DraftNode/DraftNodeWidget.tsx
@@ -38,9 +38,9 @@ export namespace NodeStyles {
         width: ${DRAFT_NODE_WIDTH}px;
         min-height: ${DRAFT_NODE_HEIGHT}px;
         padding: 0 ${NODE_PADDING}px;
-        border: ${DRAFT_NODE_BORDER_WIDTH}px dashed ${ThemeColors.PRIMARY};
+        border: ${DRAFT_NODE_BORDER_WIDTH}px dashed ${ThemeColors.SECONDARY};
         border-radius: 10px;
-        background-color: ${ThemeColors.PRIMARY_CONTAINER};
+        background-color: ${ThemeColors.SECONDARY_CONTAINER};
         color: ${ThemeColors.ON_SURFACE};
     `;
 

--- a/workspaces/ballerina/bi-diagram/src/components/nodes/EmptyNode/EmptyNodeWidget.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/nodes/EmptyNode/EmptyNodeWidget.tsx
@@ -28,12 +28,13 @@ import AddCommentPopup from "../../AddCommentPopup";
 import AddPromptPopup from "../../AddPromptPopup";
 
 namespace S {
-    export const Node = styled.div<{}>`
+    export const Node = styled.div<{ readOnly: boolean }>`
         display: flex;
         justify-content: center;
         align-items: center;
         width: ${EMPTY_NODE_WIDTH}px;
         height: ${EMPTY_NODE_WIDTH}px;
+        cursor: ${(props: { readOnly: boolean }) => (props.readOnly ? "default" : "pointer")};
     `;
 
     export type CircleStyleProp = {
@@ -50,7 +51,7 @@ namespace S {
         border: 2px solid ${(props: CircleStyleProp) => (props.show ? ThemeColors.PRIMARY : "transparent")};
         background-color: ${(props: CircleStyleProp) => (props.show ? ThemeColors.PRIMARY_CONTAINER : "transparent")};
         border-radius: 50%;
-        cursor: ${(props: CircleStyleProp) => (props.clickable ? "pointer" : "default")};
+        cursor: ${(props: CircleStyleProp) => (props.clickable ? "pointer" : "not-allowed")};
     `;
 
     export const TopPortWidget = styled(PortWidget)`
@@ -80,7 +81,7 @@ interface EmptyNodeWidgetProps {
 
 export function EmptyNodeWidget(props: EmptyNodeWidgetProps) {
     const { node, engine } = props;
-    const { onAddNode, onAddNodePrompt } = useDiagramContext();
+    const { onAddNode, onAddNodePrompt, readOnly } = useDiagramContext();
 
     const [isHovered, setIsHovered] = useState(false);
     const [isCommentButtonHovered, setIsCommentButtonHovered] = useState(false);
@@ -92,6 +93,9 @@ export function EmptyNodeWidget(props: EmptyNodeWidgetProps) {
     const isPromptBoxOpen = Boolean(promptAnchorEl);
 
     const handleAddNode = () => {
+        if (readOnly) {
+            return;
+        }
         const topNode = node.getTopNode();
         if (!topNode) {
             console.error(">>> EmptyNodeWidget: handleAddNode: top node not found");
@@ -106,6 +110,9 @@ export function EmptyNodeWidget(props: EmptyNodeWidgetProps) {
     };
 
     const handleAddPrompt = (event: React.MouseEvent<HTMLElement | SVGSVGElement>) => {
+        if (readOnly) {
+            return;
+        }
         if (!onAddNodePrompt) {
             console.error(">>> EmptyNodeWidget: handleAddPrompt: onAddNodePrompt not found");
             return;
@@ -125,6 +132,9 @@ export function EmptyNodeWidget(props: EmptyNodeWidgetProps) {
     };
 
     const handleAddComment = (event: React.MouseEvent<HTMLElement | SVGSVGElement>) => {
+        if (readOnly) {
+            return;
+        }
         setCommentAnchorEl(event.currentTarget);
     };
 
@@ -134,8 +144,12 @@ export function EmptyNodeWidget(props: EmptyNodeWidgetProps) {
     };
 
     return (
-        <S.Node onMouseEnter={() => setIsHovered(true)} onMouseLeave={() => setIsHovered(false)}>
-            <S.Circle show={node.isVisible()} clickable={node.showButton}>
+        <S.Node
+            readOnly={readOnly}
+            onMouseEnter={() => !readOnly && setIsHovered(true)}
+            onMouseLeave={() => setIsHovered(false)}
+        >
+            <S.Circle show={node.isVisible()} clickable={node.showButton && !readOnly}>
                 <S.TopPortWidget port={node.getPort("in")!} engine={engine} />
                 {node.showButton && (
                     <div
@@ -176,11 +190,11 @@ export function EmptyNodeWidget(props: EmptyNodeWidgetProps) {
                             height="20"
                             viewBox="0 0 24 24"
                             onClick={handleAddNode}
-                            onMouseEnter={() => setIsNodeButtonHovered(true)}
+                            onMouseEnter={() => !readOnly && setIsNodeButtonHovered(true)}
                             onMouseLeave={() => setIsNodeButtonHovered(false)}
-                            css={css`
-                                cursor: pointer;
-                            `}
+                            // css={css`
+                            //     cursor: pointer;
+                            // `}
                         >
                             <path
                                 fill={ThemeColors.SURFACE_BRIGHT}

--- a/workspaces/ballerina/bi-diagram/src/components/nodes/ErrorNode/ErrorNodeWidget.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/nodes/ErrorNode/ErrorNodeWidget.tsx
@@ -114,6 +114,7 @@ export namespace NodeStyles {
         hasError: boolean;
         isActiveBreakpoint?: boolean;
         disabled: boolean;
+        isSelected?: boolean;
     };
     export const Box = styled.div<NodeStyleProp>`
         display: flex;
@@ -125,6 +126,8 @@ export namespace NodeStyles {
         border-color: ${(props: NodeStyleProp) =>
             props.hasError
                 ? ThemeColors.ERROR
+                : (props.isSelected || props.selected) && !props.disabled
+                ? ThemeColors.SECONDARY
                 : props.hovered && !props.disabled
                 ? ThemeColors.SECONDARY
                 : ThemeColors.OUTLINE_VARIANT};
@@ -181,7 +184,10 @@ export function ErrorNodeWidget(props: ErrorNodeWidgetProps) {
         readOnly,
         expandedErrorHandler,
         toggleErrorHandlerExpansion,
+        selectedNodeId,
     } = useDiagramContext();
+
+    const isSelected = selectedNodeId === model.node.id;
 
     const [isHovered, setIsHovered] = React.useState(false);
     const [anchorEl, setAnchorEl] = useState<HTMLElement | SVGSVGElement>(null);
@@ -241,6 +247,7 @@ export function ErrorNodeWidget(props: ErrorNodeWidgetProps) {
 
     const handleOnMenuClose = () => {
         setAnchorEl(null);
+        setIsHovered(false);
     };
 
     const menuItems: Item[] = [
@@ -275,6 +282,7 @@ export function ErrorNodeWidget(props: ErrorNodeWidgetProps) {
                         hasError={hasError}
                         isActiveBreakpoint={isActiveBreakpoint}
                         disabled={disabled}
+                        isSelected={isSelected}
                     >
                         {hasBreakpoint && (
                             <div

--- a/workspaces/ballerina/bi-diagram/src/components/nodes/ErrorNode/ErrorNodeWidget.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/nodes/ErrorNode/ErrorNodeWidget.tsx
@@ -123,7 +123,11 @@ export namespace NodeStyles {
         border: ${(props: NodeStyleProp) => (props.disabled ? DRAFT_NODE_BORDER_WIDTH : NODE_BORDER_WIDTH)}px;
         border-style: ${(props: NodeStyleProp) => (props.disabled ? "dashed" : "solid")};
         border-color: ${(props: NodeStyleProp) =>
-            props.hasError ? ThemeColors.ERROR : props.hovered && !props.disabled ? ThemeColors.HIGHLIGHT : ThemeColors.OUTLINE_VARIANT};
+            props.hasError
+                ? ThemeColors.ERROR
+                : props.hovered && !props.disabled
+                ? ThemeColors.HIGHLIGHT
+                : ThemeColors.OUTLINE_VARIANT};
         border-radius: 8px;
         background-color: ${(props: NodeStyleProp) =>
             props?.isActiveBreakpoint ? ThemeColors.DEBUGGER_BREAKPOINT_BACKGROUND : ThemeColors.SURFACE_DIM};
@@ -229,6 +233,9 @@ export function ErrorNodeWidget(props: ErrorNodeWidgetProps) {
     };
 
     const handleOnMenuClick = (event: React.MouseEvent<HTMLElement | SVGSVGElement>) => {
+        if (readOnly) {
+            return;
+        }
         setAnchorEl(event.currentTarget);
     };
 
@@ -288,11 +295,13 @@ export function ErrorNodeWidget(props: ErrorNodeWidgetProps) {
                 </NodeStyles.Column>
                 <NodeStyles.Header>
                     <NodeStyles.Title>Error Handler</NodeStyles.Title>
-                    {!readOnly && (
-                        <NodeStyles.StyledButton appearance="icon" onClick={handleOnMenuClick}>
-                            <MoreVertIcon />
-                        </NodeStyles.StyledButton>
-                    )}
+                    <NodeStyles.StyledButton
+                        buttonSx={readOnly ? { cursor: "not-allowed" } : {}}
+                        appearance="icon"
+                        onClick={handleOnMenuClick}
+                    >
+                        <MoreVertIcon />
+                    </NodeStyles.StyledButton>
                 </NodeStyles.Header>
                 {hasError && (
                     <NodeStyles.ErrorIcon>

--- a/workspaces/ballerina/bi-diagram/src/components/nodes/ErrorNode/ErrorNodeWidget.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/nodes/ErrorNode/ErrorNodeWidget.tsx
@@ -126,7 +126,7 @@ export namespace NodeStyles {
             props.hasError
                 ? ThemeColors.ERROR
                 : props.hovered && !props.disabled
-                ? ThemeColors.HIGHLIGHT
+                ? ThemeColors.SECONDARY
                 : ThemeColors.OUTLINE_VARIANT};
         border-radius: 8px;
         background-color: ${(props: NodeStyleProp) =>

--- a/workspaces/ballerina/bi-diagram/src/components/nodes/IfNode/IfNodeWidget.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/nodes/IfNode/IfNodeWidget.tsx
@@ -251,7 +251,7 @@ export function IfNodeWidget(props: IfNodeWidgetProps) {
                                 hasError
                                     ? ThemeColors.ERROR
                                     : isHovered && !disabled && !readOnly
-                                    ? ThemeColors.HIGHLIGHT
+                                    ? ThemeColors.SECONDARY
                                     : ThemeColors.OUTLINE_VARIANT
                             }
                             strokeWidth={NODE_BORDER_WIDTH}

--- a/workspaces/ballerina/bi-diagram/src/components/nodes/IfNode/IfNodeWidget.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/nodes/IfNode/IfNodeWidget.tsx
@@ -28,11 +28,13 @@ import { MoreVertIcon } from "../../../resources";
 import { DiagnosticsPopUp } from "../../DiagnosticsPopUp";
 import { nodeHasError } from "../../../utils/node";
 import { BreakpointMenu } from "../../BreakNodeMenu/BreakNodeMenu";
+import NodeIcon from "../../NodeIcon";
 
 export namespace NodeStyles {
     export type NodeStyleProp = {
         disabled: boolean;
         hovered: boolean;
+        readOnly: boolean;
     };
     export const Node = styled.div<NodeStyleProp>`
         display: flex;
@@ -40,7 +42,7 @@ export namespace NodeStyles {
         justify-content: space-between;
         align-items: center;
         color: ${ThemeColors.ON_SURFACE};
-        cursor: pointer;
+        cursor: ${(props: NodeStyleProp) => (props.readOnly ? "default" : "pointer")};
     `;
 
     export const Header = styled.div<{}>`
@@ -148,6 +150,9 @@ export function IfNodeWidget(props: IfNodeWidgetProps) {
     }, [model.node.suggested]);
 
     const handleOnClick = (event: React.MouseEvent<HTMLDivElement>) => {
+        if (readOnly) {
+            return;
+        }
         if (event.metaKey) {
             onGoToSource();
         } else {
@@ -172,6 +177,9 @@ export function IfNodeWidget(props: IfNodeWidgetProps) {
     };
 
     const handleOnMenuClick = (event: React.MouseEvent<HTMLElement | SVGSVGElement>) => {
+        if (readOnly) {
+            return;
+        }
         setAnchorEl(event.currentTarget);
     };
 
@@ -206,6 +214,7 @@ export function IfNodeWidget(props: IfNodeWidgetProps) {
         <NodeStyles.Node
             disabled={disabled}
             hovered={isHovered}
+            readOnly={readOnly}
             onMouseEnter={() => setIsHovered(true)}
             onMouseLeave={() => setIsHovered(false)}
         >
@@ -233,11 +242,15 @@ export function IfNodeWidget(props: IfNodeWidgetProps) {
                             height={NODE_HEIGHT}
                             rx="5"
                             ry="5"
-                            fill={isActiveBreakpoint ? ThemeColors.DEBUGGER_BREAKPOINT_BACKGROUND : ThemeColors.SURFACE_DIM}
+                            fill={
+                                isActiveBreakpoint
+                                    ? ThemeColors.DEBUGGER_BREAKPOINT_BACKGROUND
+                                    : ThemeColors.SURFACE_DIM
+                            }
                             stroke={
                                 hasError
                                     ? ThemeColors.ERROR
-                                    : isHovered && !disabled
+                                    : isHovered && !disabled && !readOnly
                                     ? ThemeColors.HIGHLIGHT
                                     : ThemeColors.OUTLINE_VARIANT
                             }
@@ -246,14 +259,9 @@ export function IfNodeWidget(props: IfNodeWidgetProps) {
                             opacity={disabled ? 0.7 : 1}
                             transform="rotate(45 28 28)"
                         />
-                        <svg x="20" y="15" width="30" height="30" viewBox="0 0 24 24">
-                            <path
-                                fill={ThemeColors.ON_SURFACE}
-                                transform="rotate(180)"
-                                transform-origin="50% 50%"
-                                d="m14.85 4.85l1.44 1.44l-2.88 2.88l1.42 1.42l2.88-2.88l1.44 1.44a.5.5 0 0 0 .85-.36V4.5c0-.28-.22-.5-.5-.5h-4.29a.5.5 0 0 0-.36.85M8.79 4H4.5c-.28 0-.5.22-.5.5v4.29c0 .45.54.67.85.35L6.29 7.7L11 12.4V19c0 .55.45 1 1 1s1-.45 1-1v-7c0-.26-.11-.52-.29-.71l-5-5.01l1.44-1.44c.31-.3.09-.84-.36-.84"
-                            />
-                        </svg>
+                        <foreignObject x="22" y="18" width="26" height="26" viewBox="0 0 16 16">
+                            <NodeIcon type={model.node.codedata.node} size={24} />
+                        </foreignObject>
                     </svg>
                     <NodeStyles.BottomPortWidget port={model.getPort("out")!} engine={engine} />
                 </NodeStyles.Column>
@@ -268,11 +276,13 @@ export function IfNodeWidget(props: IfNodeWidgetProps) {
                         <DiagnosticsPopUp node={model.node} />
                     </NodeStyles.ErrorIcon>
                 )}
-                {!readOnly && (
-                    <NodeStyles.StyledButton appearance="icon" onClick={handleOnMenuClick}>
-                        <MoreVertIcon />
-                    </NodeStyles.StyledButton>
-                )}
+                <NodeStyles.StyledButton
+                    buttonSx={readOnly ? { cursor: "not-allowed" } : {}}
+                    appearance="icon"
+                    onClick={handleOnMenuClick}
+                >
+                    <MoreVertIcon />
+                </NodeStyles.StyledButton>
                 <Popover
                     open={isMenuOpen}
                     anchorEl={anchorEl}

--- a/workspaces/ballerina/bi-diagram/src/components/nodes/IfNode/IfNodeWidget.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/nodes/IfNode/IfNodeWidget.tsx
@@ -135,7 +135,10 @@ export interface NodeWidgetProps extends Omit<IfNodeWidgetProps, "children"> {}
 
 export function IfNodeWidget(props: IfNodeWidgetProps) {
     const { model, engine, onClick } = props;
-    const { onNodeSelect, goToSource, onDeleteNode, addBreakpoint, removeBreakpoint, readOnly } = useDiagramContext();
+    const { onNodeSelect, goToSource, onDeleteNode, addBreakpoint, removeBreakpoint, readOnly, selectedNodeId } =
+        useDiagramContext();
+
+    const isSelected = selectedNodeId === model.node.id;
 
     const [isHovered, setIsHovered] = useState(false);
     const [anchorEl, setAnchorEl] = useState<HTMLElement | SVGSVGElement>(null);
@@ -185,6 +188,7 @@ export function IfNodeWidget(props: IfNodeWidgetProps) {
 
     const handleOnMenuClose = () => {
         setAnchorEl(null);
+        setIsHovered(false);
     };
 
     const onAddBreakpoint = () => {
@@ -250,6 +254,8 @@ export function IfNodeWidget(props: IfNodeWidgetProps) {
                             stroke={
                                 hasError
                                     ? ThemeColors.ERROR
+                                    : isSelected && !disabled
+                                    ? ThemeColors.SECONDARY
                                     : isHovered && !disabled && !readOnly
                                     ? ThemeColors.SECONDARY
                                     : ThemeColors.OUTLINE_VARIANT

--- a/workspaces/ballerina/bi-diagram/src/components/nodes/IfNode/MatchNodeWidget.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/nodes/IfNode/MatchNodeWidget.tsx
@@ -28,6 +28,7 @@ import { DiagnosticsPopUp } from "../../DiagnosticsPopUp";
 import { nodeHasError } from "../../../utils/node";
 import { BreakpointMenu } from "../../BreakNodeMenu/BreakNodeMenu";
 import { NodeStyles } from "./IfNodeWidget";
+import NodeIcon from "../../NodeIcon";
 
 interface MatchNodeWidgetProps {
     model: IfNodeModel;
@@ -54,6 +55,9 @@ export function MatchNodeWidget(props: MatchNodeWidgetProps) {
     }, [model.node.suggested]);
 
     const handleOnClick = (event: React.MouseEvent<HTMLDivElement>) => {
+        if (readOnly) {
+            return;
+        }
         if (event.metaKey) {
             onGoToSource();
         } else {
@@ -78,6 +82,9 @@ export function MatchNodeWidget(props: MatchNodeWidgetProps) {
     };
 
     const handleOnMenuClick = (event: React.MouseEvent<HTMLElement | SVGSVGElement>) => {
+        if (readOnly) {
+            return;
+        }
         setAnchorEl(event.currentTarget);
     };
 
@@ -117,6 +124,7 @@ export function MatchNodeWidget(props: MatchNodeWidgetProps) {
         <NodeStyles.Node
             disabled={disabled}
             hovered={isHovered}
+            readOnly={readOnly}
             onMouseEnter={() => setIsHovered(true)}
             onMouseLeave={() => setIsHovered(false)}
         >
@@ -152,7 +160,7 @@ export function MatchNodeWidget(props: MatchNodeWidgetProps) {
                             stroke={
                                 hasError
                                     ? ThemeColors.ERROR
-                                    : isHovered && !disabled
+                                    : isHovered && !disabled && !readOnly
                                     ? ThemeColors.HIGHLIGHT
                                     : ThemeColors.OUTLINE_VARIANT
                             }
@@ -161,14 +169,9 @@ export function MatchNodeWidget(props: MatchNodeWidgetProps) {
                             opacity={disabled ? 0.7 : 1}
                             transform="rotate(45 28 28)"
                         />
-                        <svg x="22" y="18" width="26" height="26" viewBox="0 0 16 16">
-                            <path
-                                fill={ThemeColors.ON_SURFACE}
-                                fillRule="evenodd"
-                                d="M13.25 12a.75.75 0 1 0 0 1.5a.75.75 0 0 0 0-1.5m-.75-1.372a2.251 2.251 0 1 0 1.5 0v-.378a3 3 0 0 0-3-3H8.75V5.372a2.25 2.25 0 1 0-1.5 0V7.25H5a3 3 0 0 0-3 3v.378a2.251 2.251 0 1 0 1.5 0v-.378A1.5 1.5 0 0 1 5 8.75h2.25v1.878a2.251 2.251 0 1 0 1.5 0V8.75H11a1.5 1.5 0 0 1 1.5 1.5zM2.75 12a.75.75 0 1 0 0 1.5a.75.75 0 0 0 0-1.5m4.5.75a.75.75 0 1 1 1.5 0a.75.75 0 0 1-1.5 0M8 2.5A.75.75 0 1 0 8 4a.75.75 0 0 0 0-1.5"
-                                clipRule="evenodd"
-                            />
-                        </svg>
+                        <foreignObject x="22" y="18" width="26" height="26" viewBox="0 0 16 16">
+                            <NodeIcon type={model.node.codedata.node} size={24} />
+                        </foreignObject>
                     </svg>
                     <NodeStyles.BottomPortWidget port={model.getPort("out")!} engine={engine} />
                 </NodeStyles.Column>
@@ -181,11 +184,13 @@ export function MatchNodeWidget(props: MatchNodeWidgetProps) {
                         <DiagnosticsPopUp node={model.node} />
                     </NodeStyles.ErrorIcon>
                 )}
-                {!readOnly && (
-                    <NodeStyles.StyledButton appearance="icon" onClick={handleOnMenuClick}>
-                        <MoreVertIcon />
-                    </NodeStyles.StyledButton>
-                )}
+                <NodeStyles.StyledButton
+                    buttonSx={readOnly ? { cursor: "not-allowed" } : {}}
+                    appearance="icon"
+                    onClick={handleOnMenuClick}
+                >
+                    <MoreVertIcon />
+                </NodeStyles.StyledButton>
                 <Popover
                     open={isMenuOpen}
                     anchorEl={anchorEl}

--- a/workspaces/ballerina/bi-diagram/src/components/nodes/IfNode/MatchNodeWidget.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/nodes/IfNode/MatchNodeWidget.tsx
@@ -161,7 +161,7 @@ export function MatchNodeWidget(props: MatchNodeWidgetProps) {
                                 hasError
                                     ? ThemeColors.ERROR
                                     : isHovered && !disabled && !readOnly
-                                    ? ThemeColors.HIGHLIGHT
+                                    ? ThemeColors.SECONDARY
                                     : ThemeColors.OUTLINE_VARIANT
                             }
                             strokeWidth={NODE_BORDER_WIDTH}

--- a/workspaces/ballerina/bi-diagram/src/components/nodes/IfNode/MatchNodeWidget.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/nodes/IfNode/MatchNodeWidget.tsx
@@ -40,7 +40,9 @@ export interface NodeWidgetProps extends Omit<MatchNodeWidgetProps, "children"> 
 
 export function MatchNodeWidget(props: MatchNodeWidgetProps) {
     const { model, engine, onClick } = props;
-    const { onNodeSelect, goToSource, onDeleteNode, addBreakpoint, removeBreakpoint, readOnly } = useDiagramContext();
+    const { onNodeSelect, goToSource, onDeleteNode, addBreakpoint, removeBreakpoint, readOnly, selectedNodeId } = useDiagramContext();
+
+    const isSelected = selectedNodeId === model.node.id;
 
     const [isHovered, setIsHovered] = useState(false);
     const [anchorEl, setAnchorEl] = useState<HTMLElement | SVGSVGElement>(null);
@@ -90,6 +92,7 @@ export function MatchNodeWidget(props: MatchNodeWidgetProps) {
 
     const handleOnMenuClose = () => {
         setAnchorEl(null);
+        setIsHovered(false);
     };
 
     const onAddBreakpoint = () => {
@@ -160,6 +163,8 @@ export function MatchNodeWidget(props: MatchNodeWidgetProps) {
                             stroke={
                                 hasError
                                     ? ThemeColors.ERROR
+                                    : isSelected && !disabled
+                                    ? ThemeColors.SECONDARY
                                     : isHovered && !disabled && !readOnly
                                     ? ThemeColors.SECONDARY
                                     : ThemeColors.OUTLINE_VARIANT

--- a/workspaces/ballerina/bi-diagram/src/components/nodes/PromptNode/PromptNodeWidget.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/nodes/PromptNode/PromptNodeWidget.tsx
@@ -46,6 +46,7 @@ export namespace NodeStyles {
         hovered: boolean;
         hasError: boolean;
         isActiveBreakpoint?: boolean;
+        isSelected?: boolean;
     };
     export const Node = styled.div<NodeStyleProp>`
         display: flex;
@@ -62,7 +63,13 @@ export namespace NodeStyles {
         border: ${(props: NodeStyleProp) => (props.disabled ? DRAFT_NODE_BORDER_WIDTH : NODE_BORDER_WIDTH)}px;
         border-style: ${(props: NodeStyleProp) => (props.disabled ? "dashed" : "solid")};
         border-color: ${(props: NodeStyleProp) =>
-            props.hasError ? ThemeColors.ERROR : props.hovered && !props.disabled ? ThemeColors.SECONDARY : ThemeColors.OUTLINE_VARIANT};
+            props.hasError
+                ? ThemeColors.ERROR
+                : props.isSelected && !props.disabled
+                ? ThemeColors.SECONDARY
+                : props.hovered && !props.disabled
+                ? ThemeColors.SECONDARY
+                : ThemeColors.OUTLINE_VARIANT};
         border-radius: 10px;
     `;
 
@@ -215,7 +222,10 @@ export function PromptNodeWidget(props: PromptNodeWidgetProps) {
         onNodeSave,
         expressionContext,
         aiNodes,
+        selectedNodeId,
     } = useDiagramContext();
+
+    const isSelected = selectedNodeId === model.node.id;
     const {
         completions,
         triggerCharacters,
@@ -435,6 +445,7 @@ export function PromptNodeWidget(props: PromptNodeWidgetProps) {
                 disabled={model.node.suggested}
                 hasError={hasError}
                 isActiveBreakpoint={isActiveBreakpoint}
+                isSelected={isSelected}
                 onMouseEnter={() => setIsHovered(true)}
                 onMouseLeave={() => setIsHovered(false)}
             >

--- a/workspaces/ballerina/bi-diagram/src/components/nodes/PromptNode/PromptNodeWidget.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/nodes/PromptNode/PromptNodeWidget.tsx
@@ -62,7 +62,7 @@ export namespace NodeStyles {
         border: ${(props: NodeStyleProp) => (props.disabled ? DRAFT_NODE_BORDER_WIDTH : NODE_BORDER_WIDTH)}px;
         border-style: ${(props: NodeStyleProp) => (props.disabled ? "dashed" : "solid")};
         border-color: ${(props: NodeStyleProp) =>
-            props.hasError ? ThemeColors.ERROR : props.hovered && !props.disabled ? ThemeColors.HIGHLIGHT : ThemeColors.OUTLINE_VARIANT};
+            props.hasError ? ThemeColors.ERROR : props.hovered && !props.disabled ? ThemeColors.SECONDARY : ThemeColors.OUTLINE_VARIANT};
         border-radius: 10px;
     `;
 
@@ -186,7 +186,7 @@ export namespace NodeStyles {
     export const StyledCircle = styled.circle`
         cursor: pointer;
         &:hover {
-            stroke: ${ThemeColors.HIGHLIGHT};
+            stroke: ${ThemeColors.SECONDARY};
         }
     `;
 }

--- a/workspaces/ballerina/bi-diagram/src/components/nodes/WhileNode/WhileNodeWidget.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/nodes/WhileNode/WhileNodeWidget.tsx
@@ -38,13 +38,13 @@ import { BreakpointMenu } from "../../BreakNodeMenu/BreakNodeMenu";
 import { NodeIcon } from "../../NodeIcon";
 
 export namespace NodeStyles {
-    export const Node = styled.div<{ isEditable: boolean }>`
+    export const Node = styled.div<{ readOnly: boolean }>`
         display: flex;
         flex-direction: column;
         justify-content: space-between;
         color: ${ThemeColors.ON_SURFACE};
         color: ${ThemeColors.ON_SURFACE};
-        cursor: ${(props) => (props.isEditable ? "pointer" : "default")};
+        cursor: ${(props: { readOnly: boolean }) => (props.readOnly ? "default" : "pointer")};
     `;
 
     export const Header = styled.div<{}>`
@@ -126,6 +126,7 @@ export namespace NodeStyles {
         selected: boolean;
         hovered: boolean;
         hasError: boolean;
+        readOnly: boolean;
         isActiveBreakpoint?: boolean;
         disabled: boolean;
     };
@@ -139,7 +140,7 @@ export namespace NodeStyles {
         border-color: ${(props: NodeStyleProp) =>
             props.hasError
                 ? ThemeColors.ERROR
-                : props.hovered && !props.disabled
+                : props.hovered && !props.disabled && !props.readOnly
                 ? ThemeColors.HIGHLIGHT
                 : ThemeColors.OUTLINE_VARIANT};
         border-radius: 8px;
@@ -147,6 +148,7 @@ export namespace NodeStyles {
             props?.isActiveBreakpoint ? ThemeColors.DEBUGGER_BREAKPOINT_BACKGROUND : ThemeColors.SURFACE_DIM};
         width: ${WHILE_NODE_WIDTH}px;
         height: ${WHILE_NODE_WIDTH}px;
+        cursor: ${(props: NodeStyleProp) => (props.readOnly ? "default" : "pointer")};
     `;
 
     export const Hr = styled.hr`
@@ -203,6 +205,9 @@ export function WhileNodeWidget(props: WhileNodeWidgetProps) {
     const isEditable = model.node.codedata.node !== "LOCK";
 
     const handleOnClick = (event: React.MouseEvent<HTMLDivElement>) => {
+        if (readOnly) {
+            return;
+        }
         if (event.metaKey) {
             onGoToSource();
         } else {
@@ -237,6 +242,9 @@ export function WhileNodeWidget(props: WhileNodeWidgetProps) {
     };
 
     const handleOnMenuClick = (event: React.MouseEvent<HTMLElement | SVGSVGElement>) => {
+        if (readOnly) {
+            return;
+        }
         setAnchorEl(event.currentTarget);
     };
 
@@ -260,7 +268,7 @@ export function WhileNodeWidget(props: WhileNodeWidgetProps) {
     const nodeViewState = model.node.viewState;
 
     return (
-        <NodeStyles.Node isEditable={isEditable}>
+        <NodeStyles.Node readOnly={isEditable || readOnly}>
             <NodeStyles.Row>
                 <NodeStyles.Column>
                     <NodeStyles.Box
@@ -270,6 +278,7 @@ export function WhileNodeWidget(props: WhileNodeWidgetProps) {
                         selected={model.isSelected()}
                         hovered={isEditable && isHovered}
                         hasError={hasError}
+                        readOnly={readOnly}
                         isActiveBreakpoint={isActiveBreakpoint}
                         disabled={disabled}
                     >
@@ -293,14 +302,18 @@ export function WhileNodeWidget(props: WhileNodeWidgetProps) {
                 <NodeStyles.Header>
                     <NodeStyles.Title>{model.node.metadata.label || model.node.codedata.node}</NodeStyles.Title>
                     {model.node.properties?.condition && (
-                        <NodeStyles.Description>{model.node.properties.condition?.value as ReactNode}</NodeStyles.Description>
+                        <NodeStyles.Description>
+                            {model.node.properties.condition?.value as ReactNode}
+                        </NodeStyles.Description>
                     )}
                 </NodeStyles.Header>
-                {!readOnly && (
-                    <NodeStyles.StyledButton appearance="icon" onClick={handleOnMenuClick}>
-                        <MoreVertIcon />
-                    </NodeStyles.StyledButton>
-                )}
+                <NodeStyles.StyledButton
+                    buttonSx={readOnly ? { cursor: "not-allowed" } : {}}
+                    appearance="icon"
+                    onClick={handleOnMenuClick}
+                >
+                    <MoreVertIcon />
+                </NodeStyles.StyledButton>
                 {hasError && (
                     <NodeStyles.ErrorIcon>
                         <DiagnosticsPopUp node={model.node} />

--- a/workspaces/ballerina/bi-diagram/src/components/nodes/WhileNode/WhileNodeWidget.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/nodes/WhileNode/WhileNodeWidget.tsx
@@ -129,6 +129,7 @@ export namespace NodeStyles {
         readOnly: boolean;
         isActiveBreakpoint?: boolean;
         disabled: boolean;
+        isSelected?: boolean;
     };
     export const Box = styled.div<NodeStyleProp>`
         display: flex;
@@ -140,6 +141,8 @@ export namespace NodeStyles {
         border-color: ${(props: NodeStyleProp) =>
             props.hasError
                 ? ThemeColors.ERROR
+                : (props.isSelected || props.selected) && !props.disabled
+                ? ThemeColors.SECONDARY
                 : props.hovered && !props.disabled && !props.readOnly
                 ? ThemeColors.SECONDARY
                 : ThemeColors.OUTLINE_VARIANT};
@@ -188,7 +191,9 @@ export interface NodeWidgetProps extends Omit<WhileNodeWidgetProps, "children"> 
 
 export function WhileNodeWidget(props: WhileNodeWidgetProps) {
     const { model, engine, onClick } = props;
-    const { onNodeSelect, goToSource, onDeleteNode, addBreakpoint, removeBreakpoint, readOnly } = useDiagramContext();
+    const { onNodeSelect, goToSource, onDeleteNode, addBreakpoint, removeBreakpoint, readOnly, selectedNodeId } = useDiagramContext();
+
+    const isSelected = selectedNodeId === model.node.id;
 
     const [isHovered, setIsHovered] = React.useState(false);
     const [anchorEl, setAnchorEl] = useState<HTMLElement | SVGSVGElement>(null);
@@ -250,6 +255,7 @@ export function WhileNodeWidget(props: WhileNodeWidgetProps) {
 
     const handleOnMenuClose = () => {
         setAnchorEl(null);
+        setIsHovered(false);
     };
 
     const menuItems: Item[] = [
@@ -281,6 +287,7 @@ export function WhileNodeWidget(props: WhileNodeWidgetProps) {
                         readOnly={readOnly}
                         isActiveBreakpoint={isActiveBreakpoint}
                         disabled={disabled}
+                        isSelected={isSelected}
                     >
                         {hasBreakpoint && (
                             <div

--- a/workspaces/ballerina/bi-diagram/src/components/nodes/WhileNode/WhileNodeWidget.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/nodes/WhileNode/WhileNodeWidget.tsx
@@ -141,7 +141,7 @@ export namespace NodeStyles {
             props.hasError
                 ? ThemeColors.ERROR
                 : props.hovered && !props.disabled && !props.readOnly
-                ? ThemeColors.HIGHLIGHT
+                ? ThemeColors.SECONDARY
                 : ThemeColors.OUTLINE_VARIANT};
         border-radius: 8px;
         background-color: ${(props: NodeStyleProp) =>

--- a/workspaces/ballerina/bi-diagram/src/components/nodes/WhileNode/WhileNodeWidget.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/nodes/WhileNode/WhileNodeWidget.tsx
@@ -207,6 +207,10 @@ export function WhileNodeWidget(props: WhileNodeWidgetProps) {
         }
     }, [model.node.suggested]);
 
+    useEffect(() => {
+        model.setSelected(isSelected);
+    }, [isSelected]);
+
     const isEditable = model.node.codedata.node !== "LOCK";
 
     const handleOnClick = (event: React.MouseEvent<HTMLDivElement>) => {

--- a/workspaces/ballerina/bi-diagram/src/index.tsx
+++ b/workspaces/ballerina/bi-diagram/src/index.tsx
@@ -25,7 +25,7 @@ export { ConnectorIcon } from "./components/ConnectorIcon";
 export { AIModelIcon } from "./components/AIModelIcon";
 
 // types
-export type { FlowNodeStyle } from "./utils/types";
+export type { FlowNodeStyle, DraftNodeConfig } from "./utils/types";
 
 // traversing utils
 export { traverseFlow, traverseNode } from "@wso2/ballerina-core";

--- a/workspaces/ballerina/bi-diagram/src/utils/types.ts
+++ b/workspaces/ballerina/bi-diagram/src/utils/types.ts
@@ -62,3 +62,9 @@ export type {
 } from "@wso2/ballerina-core";
 
 export type FlowNodeStyle = "default" | "ballerina-statements";
+
+export type DraftNodeConfig = {
+    override: boolean; // Override the draft node contents with showSpinner and description
+    showSpinner: boolean;
+    description: string;
+}

--- a/workspaces/ballerina/bi-diagram/src/visitors/AddNodeVisitor.ts
+++ b/workspaces/ballerina/bi-diagram/src/visitors/AddNodeVisitor.ts
@@ -42,7 +42,6 @@ export class AddNodeVisitor implements BaseVisitor {
         // check flow nodes if one of them is target node, then add new node after the target node
         this.flow.nodes.forEach((flowNode) => {
             if (this.topNode && flowNode.id === this.topNode.id) {
-                console.log(">>> add new node", { target: flowNode, new: this.newNode });
                 const index = this.flow.nodes.indexOf(flowNode);
                 this.flow.nodes.splice(index + 1, 0, this.newNode);
                 this.skipChildrenVisit = true;
@@ -64,7 +63,6 @@ export class AddNodeVisitor implements BaseVisitor {
             } else {
                 branch.children.forEach((child) => {
                     if (this.topNode && child.id === this.topNode.id) {
-                        console.log(">>> do-error add new node", { target: child, new: this.newNode });
                         const index = branch.children.indexOf(child);
                         branch.children.splice(index + 1, 0, this.newNode);
                         this.skipChildrenVisit = true;
@@ -82,14 +80,12 @@ export class AddNodeVisitor implements BaseVisitor {
         // check branches and if one of branches has target node, then add new node after the target node
         node.branches.forEach((branch) => {
             if (this.topBranch && isEqual(branch.codedata, this.topBranch.codedata)) {
-                console.log(">>> if add new node to first", { target: branch, new: this.newNode });
                 // add new node to branch first children
                 branch.children.unshift(this.newNode);
                 this.skipChildrenVisit = true;
             } else {
                 branch.children.forEach((child) => {
                     if (this.topNode && child.id === this.topNode.id) {
-                        console.log(">>> if add new node to end", { target: child, new: this.newNode });
                         const index = branch.children.indexOf(child);
                         branch.children.splice(index + 1, 0, this.newNode);
                         this.skipChildrenVisit = true;

--- a/workspaces/ballerina/bi-diagram/src/visitors/RemoveNodeVisitor.ts
+++ b/workspaces/ballerina/bi-diagram/src/visitors/RemoveNodeVisitor.ts
@@ -34,7 +34,6 @@ export class RemoveNodeVisitor implements BaseVisitor {
     beginVisitEventStart(node: FlowNode, parent?: FlowNode): void {
         this.flow.nodes.forEach((flowNode) => {
             if (flowNode.id === this.nodeId) {
-                console.log(">>> http-api remove node", { target: flowNode });
                 const index = this.flow.nodes.indexOf(flowNode);
                 this.flow.nodes.splice(index, 1);
                 this.skipChildrenVisit = true;
@@ -50,7 +49,6 @@ export class RemoveNodeVisitor implements BaseVisitor {
         node.branches.forEach((branch) => {
             branch.children.forEach((child) => {
                 if (child.id === this.nodeId) {
-                    console.log(">>> do-error remove node", { target: child });
                     const index = branch.children.indexOf(child);
                     branch.children.splice(index, 1);
                     this.skipChildrenVisit = true;

--- a/workspaces/common-libs/ui-toolkit/src/components/SplitView/SplitView.tsx
+++ b/workspaces/common-libs/ui-toolkit/src/components/SplitView/SplitView.tsx
@@ -95,14 +95,14 @@ export function SplitView(props: SplitViewProps) {
     return (
         <Container sx={sx}>
             {children.map((child, index) => (
-                <>
-                    <DynamicDiv key={index} sx={dynamicContainerSx} width={widths[index]} lastChild={index === children.length - 1}>
+                <React.Fragment key={`split-${index}`}>
+                    <DynamicDiv sx={dynamicContainerSx} width={widths[index]} lastChild={index === children.length - 1}>
                         {child}
                     </DynamicDiv>
                     {index < children.length - 1 && (
-                        <Resizer key={`resizer-${index}`} onMouseDown={e => handleMouseDown(index, e)} />
+                        <Resizer onMouseDown={e => handleMouseDown(index, e)} />
                     )}
-                </>
+                </React.Fragment>
             ))}
         </Container>
     );


### PR DESCRIPTION
### Purpose

Fixes a race condition where quickly adding nodes causes the connecting flow lines to disappear. Also, improves the read-only mode experience by hiding all interactive elements.

### Changes

* **Fix:** Prevents the flow line disappearance issue by serializing node addition requests or implementing a more robust state update mechanism.
* **Improvement:** In read-only mode, the following elements are now hidden:
    * All **plus buttons** (add node actions).
    * All **more-vert menu** actions on nodes.
* **Improvement:** The diagram now correctly switches to read-only mode immediately when the **node panel** opens, preventing the user from interacting with the diagram while selecting a new node type.
* **Feature:** Adds a new **"Saving Node..." loader** overlay to the draft node while the new node is being saved to the backend. This provides better user feedback during the asynchronous creation process.


https://github.com/user-attachments/assets/6a9e338a-b840-4c2e-a450-c6223eb18013



These fixes prevent users from clicking multiple "add node" points on the diagram while a node addition process is already underway.