### PR TITLE
Fix Incorrect Type Check in `getOwnRecordRefs` for Internal Record Types

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/features/ai/service/libs/funcs.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/service/libs/funcs.ts
@@ -26,6 +26,10 @@ import { langClient } from "../../activator";
 import { getGenerationMode } from "../utils";
 import { AIPanelAbortController } from "../../../../../src/rpc-managers/ai-panel/utils";
 
+// Constants for type definitions
+const TYPE_RECORD = 'Record';
+const TYPE_CONSTRUCTOR = 'Constructor';
+
 
 export async function selectRequiredFunctions(prompt: string, selectedLibNames: string[], generationType: GenerationType): Promise<Library[]> {
     const selectedLibs: Library[] = await getMaximizedSelectedLibs(selectedLibNames, generationType);
@@ -259,7 +263,7 @@ function filteredFunctions(functions: (RemoteFunction | ResourceFunction)[]): (M
             };
             output.push(res);
         } else { // RemoteFunction
-            if (item.type !== "Constructor") {
+            if (item.type !== TYPE_CONSTRUCTOR) {
                 const rem: MinifiedRemoteFunction = {
                     name: item.name,
                     parameters: item.parameters.map(param => param.name),
@@ -410,7 +414,7 @@ function selectFunctions(originalFunctions: RemoteFunction[] | undefined, funcRe
 
 function getConstructor(functions: (RemoteFunction | ResourceFunction)[]): RemoteFunction | null {
     for (const func of functions) {
-        if ('type' in func && func.type === "Constructor") {
+        if ('type' in func && func.type === TYPE_CONSTRUCTOR) {
             return func as RemoteFunction;
         }
     }
@@ -491,7 +495,7 @@ function getOwnRecordRefs(functions: AbstractFunction[], allTypeDefs: TypeDefini
         
         processedTypes.add(typeDef.name);
         
-        if (typeDef.type === 'record') {
+        if (typeDef.type === TYPE_RECORD) {
             const recordDef = typeDef as RecordTypeDefinition;
             for (const field of recordDef.fields) {
                 const foundTypes = addInternalRecord(field.type, ownRecords, allTypeDefs);
@@ -596,7 +600,7 @@ function getExternalTypeDefRefs(
     
     // Check type definition fields
     for (const typeDef of allTypeDefs) {
-        if (typeDef.type === 'Record') {
+        if (typeDef.type === TYPE_RECORD) {
             const recordDef = typeDef as RecordTypeDefinition;
             for (const field of recordDef.fields) {
                 addExternalRecord(field.type, externalRecords);


### PR DESCRIPTION
Fixes bug in `getOwnRecordRefs` (`funcs.ts`) where `typeDef.type === 'record'` (lowercase) skips internal record processing. Updated to `typeDef.type === 'Record'` (uppercase) to include internal records.

- Fixes https://github.com/wso2/product-ballerina-integrator/issues/1402