### PR TITLE
Fix Mi Helperpane width 

### DIFF
--- a/workspaces/ballerina/type-editor/src/TypeHelper/index.tsx
+++ b/workspaces/ballerina/type-editor/src/TypeHelper/index.tsx
@@ -24,8 +24,8 @@ import styled from '@emotion/styled';
 import { Transition } from '@headlessui/react';
 import {
     ARROW_HEIGHT,
+    BI_HELPER_PANE_WIDTH,
     CompletionItemKind,
-    HELPER_PANE_WIDTH,
     Position
 } from '@wso2/ui-toolkit';
 
@@ -201,8 +201,8 @@ export const TypeHelper = forwardRef<HTMLDivElement, TypeHelperProps>((props, re
         if (typeFieldRef.current) {
             const rect = typeFieldRef.current.getBoundingClientRect();
             let left = 0;
-            if (rect.width < HELPER_PANE_WIDTH && window.innerWidth - rect.left < HELPER_PANE_WIDTH) {
-                left = rect.right - HELPER_PANE_WIDTH - 2; // 2px for alignment correction padding
+            if (rect.width < BI_HELPER_PANE_WIDTH && window.innerWidth - rect.left < BI_HELPER_PANE_WIDTH) {
+                left = rect.right - BI_HELPER_PANE_WIDTH - 2; // 2px for alignment correction padding
             }
             else {
                 left = rect.left;

--- a/workspaces/common-libs/ui-toolkit/src/components/ExpressionEditor/constants/form.ts
+++ b/workspaces/common-libs/ui-toolkit/src/components/ExpressionEditor/constants/form.ts
@@ -18,7 +18,7 @@
 
 /* Helper pane related */
 /* All these values are in pixels */
-export const HELPER_PANE_WIDTH = 200;
+export const HELPER_PANE_WIDTH = 350;
 export const BI_HELPER_PANE_WIDTH = 200;
 export const HELPER_PANE_HEIGHT = 400;
 export const VERTICAL_HELPERPANE_HEIGHT = 300;


### PR DESCRIPTION
## Purpose
This PR fixes an issue with the **Helper Pane width** in the **MI (Micro Integrator)** editor.  
Previously, the width was being incorrectly set due to an outdated constant that overrode the responsive layout behavior.  

Resolves: _(https://github.com/wso2/product-ballerina-integrator/issues/1433)_

---

## Goals
- Restore the intended **Helper Pane width** behavior.  
- Ensure consistent layout alignment across all editors by resetting the old width constant used specifically for the MI editor.  

---

## Approach
- Changed the constant value to the correct value that was used before expression editor changes.  
