### PR TITLE
Add validation to check if AI Chat Agent with same name exists

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/AIChatAgent/AIChatAgentWizard.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/AIChatAgent/AIChatAgentWizard.tsx
@@ -17,7 +17,7 @@
  */
 
 import { useEffect, useRef, useState } from 'react';
-import { AvailableNode, CDModel, CodeData, EVENT_TYPE } from '@wso2/ballerina-core';
+import { CDModel, CodeData, EVENT_TYPE } from '@wso2/ballerina-core';
 import { View, ViewContent, TextField, Button, Typography } from '@wso2/ui-toolkit';
 import styled from '@emotion/styled';
 import { useRpcContext } from '@wso2/ballerina-rpc-client';
@@ -102,12 +102,14 @@ export function AIChatAgentWizard(props: AIChatAgentWizardProps) {
             setNameError("Name can only contain letters, numbers, and underscores");
             return false;
         }
-        const isNameExists = designModelRef.current.services.some(
-            service => service.absolutePath?.trim() === `/${name}`
-        );
-        if (isNameExists) {
-            setNameError("An AI Chat Agent with this name already exists. Please choose a different name.");
-            return false;
+        if (designModelRef.current) {
+            const isNameExists = designModelRef.current.services.some(
+                service => service.absolutePath?.trim() === `/${name}`
+            );
+            if (isNameExists) {
+                setNameError("An AI Chat Agent with this name already exists. Please choose a different name.");
+                return false;
+            }
         }
         setNameError("");
         return true;


### PR DESCRIPTION
## Purpose

Fixes https://github.com/wso2/product-ballerina-integrator/issues/1466

This PR adds a validation check to prevent creating a Chat Agent Service with a name that already exists in the project.

https://github.com/user-attachments/assets/becce81a-a393-4ff5-a53a-97db168833e0

## Goals

The goal of this fix is to improve the robustness and user experience of the Chat Agent creation process by ensuring that duplicate service names are not allowed.

## Approach

Using the `getDesignModel` API, the existing services in the current project are retrieved. Before creating a new Chat Agent Service, the logic checks if a service with the same name already exists. If a duplicate is detected, an appropriate error message is displayed to the user, prompting them to use a different name.
 
## UI Component Development
> Specify the reason if following are not followed.
- [ ] Added reusable UI components to the ui-toolkit. Follow the [intructions](./workspaces/common-libs/ui-toolkit/README.md) when adding the componenent.
- [ ] Use ui-toolkit components wherever possible. Run `npm run storybook` from the root directory to view current components.
- [ ] Matches with the native VSCode look and feel.

## Manage Icons
> Specify the reason if following are not followed.
- [ ] Added Icons to the font-wso2-vscode. Follow the [instructions](./workspaces/common-libs/font-wso2-vscode/README.md).

## User stories

As a user creating a new Chat Agent Service,
I want to be notified if a service with the same name already exists,
So that I can avoid naming conflicts and prevent system errors during initialization.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.