### PR TITLE
Add snapshot tests for sequence-diagram package

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1722,12 +1722,36 @@ importers:
         specifier: 18.2.0
         version: 18.2.0(react@18.2.0)
     devDependencies:
+      '@babel/core':
+        specifier: ~7.27.1
+        version: 7.27.7
+      '@babel/preset-env':
+        specifier: ~7.27.2
+        version: 7.27.2(@babel/core@7.27.7)
+      '@babel/preset-react':
+        specifier: ~7.27.1
+        version: 7.27.1(@babel/core@7.27.7)
+      '@babel/preset-typescript':
+        specifier: ~7.27.1
+        version: 7.27.1(@babel/core@7.27.7)
       '@storybook/react':
         specifier: ^6.3.7
         version: 6.5.16(@babel/core@7.27.7)(@types/webpack@5.28.5)(encoding@0.1.13)(eslint@9.26.0(jiti@2.5.1))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(require-from-string@2.0.2)(type-fest@4.41.0)(typescript@5.8.3)(webpack-dev-server@5.2.2(webpack@5.101.0))(webpack-hot-middleware@2.26.1)
+      '@testing-library/dom':
+        specifier: ~10.4.0
+        version: 10.4.1
+      '@testing-library/jest-dom':
+        specifier: ~6.6.3
+        version: 6.6.4
+      '@testing-library/react':
+        specifier: ~16.3.0
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.2.0)(@types/react@18.2.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/dagre':
         specifier: ~0.7.52
         version: 0.7.53
+      '@types/jest':
+        specifier: 29.5.14
+        version: 29.5.14
       '@types/lodash':
         specifier: ~4.17.16
         version: 4.17.17
@@ -1737,9 +1761,15 @@ importers:
       '@types/react-dom':
         specifier: 18.2.0
         version: 18.2.0
+      '@types/react-test-renderer':
+        specifier: ~19.1.0
+        version: 19.1.0
       '@typescript-eslint/eslint-plugin':
         specifier: ~8.32.1
         version: 8.32.1(@typescript-eslint/parser@8.33.1(eslint@9.26.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.26.0(jiti@2.5.1))(typescript@5.8.3)
+      babel-jest:
+        specifier: 29.7.0
+        version: 29.7.0(@babel/core@7.27.7)
       copyfiles:
         specifier: ^2.4.1
         version: 2.4.1
@@ -1752,9 +1782,27 @@ importers:
       eslint-plugin-unused-imports:
         specifier: ~4.1.4
         version: 4.1.4(@typescript-eslint/eslint-plugin@8.32.1(@typescript-eslint/parser@8.33.1(eslint@9.26.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.26.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.26.0(jiti@2.5.1))
+      identity-obj-proxy:
+        specifier: ~3.0.0
+        version: 3.0.0
+      jest:
+        specifier: 29.7.0
+        version: 29.7.0(@types/node@22.15.35)(babel-plugin-macros@3.1.0)
+      jest-environment-jsdom:
+        specifier: 29.7.0
+        version: 29.7.0
       prettier:
         specifier: ~3.5.3
         version: 3.5.3
+      pretty-format:
+        specifier: ~29.7.0
+        version: 29.7.0
+      react-test-renderer:
+        specifier: ~19.1.0
+        version: 19.1.1(react@18.2.0)
+      ts-jest:
+        specifier: 29.3.4
+        version: 29.3.4(@babel/core@7.27.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.27.7))(jest@29.7.0(@types/node@22.15.35)(babel-plugin-macros@3.1.0))(typescript@5.8.3)
       typescript:
         specifier: 5.8.3
         version: 5.8.3
@@ -24169,7 +24217,10 @@ snapshots:
       jest-runner: 25.5.4
       jest-runtime: 25.5.4
     transitivePeerDependencies:
+      - bufferutil
+      - canvas
       - supports-color
+      - utf-8-validate
 
   '@jest/test-sequencer@29.7.0':
     dependencies:

--- a/workspaces/ballerina/sequence-diagram/babel.config.js
+++ b/workspaces/ballerina/sequence-diagram/babel.config.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+module.exports = {
+    presets: [
+        ['@babel/preset-env', { targets: { node: 'current' } }],
+        '@babel/preset-typescript',
+        ['@babel/preset-react', { runtime: 'automatic' }],
+    ],
+};

--- a/workspaces/ballerina/sequence-diagram/jest.config.js
+++ b/workspaces/ballerina/sequence-diagram/jest.config.js
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+module.exports = {
+    preset: 'ts-jest/presets/js-with-ts',
+    testEnvironment: 'jsdom',
+    transform: {
+        '^.+\\.(js|jsx)$': 'babel-jest',
+        '^.+\\.(ts|tsx)$': 'ts-jest',
+    },
+    globals: {
+        'ts-jest': {
+            isolatedModules: true,
+            tsconfig: {
+                jsx: 'react',
+                esModuleInterop: true,
+                allowSyntheticDefaultImports: true,
+            }
+        },
+    },
+    moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+    testMatch: ['**/?(*.)+(spec|test).ts?(x)'],
+    moduleNameMapper: {
+        '^@vscode/codicons/dist/codicon\\.css$': '<rootDir>/../../../node_modules/.pnpm/identity-obj-proxy@3.0.0/node_modules/identity-obj-proxy',
+        '\\.css$': '<rootDir>/../../../node_modules/.pnpm/identity-obj-proxy@3.0.0/node_modules/identity-obj-proxy',
+        '\\.(less|sass|scss)$': '<rootDir>/../../../node_modules/.pnpm/identity-obj-proxy@3.0.0/node_modules/identity-obj-proxy',
+        '\\.(svg|png|jpg|jpeg|gif)$': '<rootDir>/../../../node_modules/.pnpm/identity-obj-proxy@3.0.0/node_modules/identity-obj-proxy',
+        '^react$': '<rootDir>/../../../node_modules/.pnpm/react@18.2.0/node_modules/react/index.js',
+        '^react-dom$': '<rootDir>/../../../node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/index.js',
+        '^@wso2/ui-toolkit$': '<rootDir>/../../common-libs/ui-toolkit/src/index.ts',
+        '^@wso2/ballerina-core$': '<rootDir>/../ballerina-core/src/index.ts',
+        '^@wso2/ballerina-rpc-client$': '<rootDir>/../ballerina-rpc-client/src/index.ts',
+        '^@wso2/syntax-tree$': '<rootDir>/../syntax-tree/src/index.ts',
+    },
+    setupFilesAfterEnv: [
+        '<rootDir>/src/test/jest.env.ts',
+    ],
+    setupFiles: ['<rootDir>/src/test/matchMedia.ts'],
+    transformIgnorePatterns: [
+        '<rootDir>/node_modules/(?!(@wso2)/)' // Only transform @wso2 packages
+    ],
+    moduleDirectories: ['node_modules', '<rootDir>/../../../node_modules'],
+    collectCoverageFrom: [
+        'src/**/*.{ts,tsx}',
+        '!src/**/*.d.ts',
+        '!src/**/*.stories.{ts,tsx}',
+        '!src/test/**/*'
+    ]
+};

--- a/workspaces/ballerina/sequence-diagram/package.json
+++ b/workspaces/ballerina/sequence-diagram/package.json
@@ -9,6 +9,9 @@
     "types": "lib/index.d.ts",
     "scripts": {
         "start": "tsc && node dist/index.js",
+        "test": "jest --coverage",
+        "test:watch": "jest --watch",
+        "test:updateSnapshots": "jest --updateSnapshot",
         "build": "tsc --pretty && npm run copy:assets && pnpm run postbuild",
         "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
         "lint:fix": "eslint src --ext .js,.jsx,.ts,.tsx --fix",
@@ -51,6 +54,22 @@
         "eslint": "~9.26.0",
         "@typescript-eslint/eslint-plugin": "~8.32.1",
         "eslint-plugin-react-hooks": "~5.2.0",
-        "eslint-plugin-unused-imports": "~4.1.4"
+        "eslint-plugin-unused-imports": "~4.1.4",
+        "jest": "29.7.0",
+        "ts-jest": "29.3.4",
+        "@types/jest": "29.5.14",
+        "@testing-library/jest-dom": "~6.6.3",
+        "@testing-library/react": "~16.3.0",
+        "@testing-library/dom": "~10.4.0",
+        "jest-environment-jsdom": "29.7.0",
+        "@babel/core": "~7.27.1",
+        "@babel/preset-env": "~7.27.2",
+        "@babel/preset-react": "~7.27.1",
+        "@babel/preset-typescript": "~7.27.1",
+        "babel-jest": "29.7.0",
+        "react-test-renderer": "~19.1.0",
+        "@types/react-test-renderer": "~19.1.0",
+        "pretty-format": "~29.7.0",
+        "identity-obj-proxy": "~3.0.0"
     }
 }

--- a/workspaces/ballerina/sequence-diagram/src/stories/sample-with-return.json
+++ b/workspaces/ballerina/sequence-diagram/src/stories/sample-with-return.json
@@ -1,0 +1,197 @@
+{
+    "participants": [
+        {
+            "id": "33785",
+            "name": "httpClient",
+            "kind": "ENDPOINT",
+            "moduleName": "test_sample",
+            "location": {
+                "fileName": "connections.bal",
+                "startLine": {
+                    "line": 2,
+                    "offset": 0
+                },
+                "endLine": {
+                    "line": 2,
+                    "offset": 57
+                }
+            },
+            "viewState": {
+                "bBox": {
+                    "x": 440,
+                    "y": 0,
+                    "h": 40,
+                    "w": 160
+                },
+                "xIndex": 2,
+                "lifelineHeight": 99
+            }
+        },
+        {
+            "id": "37174",
+            "name": "get",
+            "kind": "FUNCTION",
+            "moduleName": "test_sample",
+            "nodes": [
+                {
+                    "interactionType": "ENDPOINT_CALL",
+                    "targetId": "33785",
+                    "kind": "INTERACTION",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "value": "get"
+                        },
+                        "expr": {
+                            "type": "http:Client",
+                            "value": "httpClient"
+                        },
+                        "params": [
+                            {
+                                "type": "string",
+                                "value": "\"path\""
+                            }
+                        ],
+                        "value": {
+                            "type": "json|http:ClientError",
+                            "value": "var1"
+                        }
+                    },
+                    "location": {
+                        "fileName": "main.bal",
+                        "startLine": {
+                            "line": 7,
+                            "offset": 30
+                        },
+                        "endLine": {
+                            "line": 7,
+                            "offset": 53
+                        }
+                    },
+                    "viewStates": [
+                        {
+                            "callNodeId": "participant-37174",
+                            "bBox": {
+                                "x": 0,
+                                "y": 0,
+                                "h": 0,
+                                "w": 0
+                            },
+                            "points": {
+                                "start": {
+                                    "bBox": {
+                                        "x": 220,
+                                        "y": 68,
+                                        "h": 20,
+                                        "w": 20
+                                    },
+                                    "participantId": "37174"
+                                },
+                                "end": {
+                                    "bBox": {
+                                        "x": 440,
+                                        "y": 68,
+                                        "h": 20,
+                                        "w": 20
+                                    },
+                                    "participantId": "33785"
+                                },
+                                "returnStart": {
+                                    "bBox": {
+                                        "x": 440,
+                                        "y": 96,
+                                        "h": 20,
+                                        "w": 20
+                                    },
+                                    "participantId": "33785"
+                                },
+                                "returnEnd": {
+                                    "bBox": {
+                                        "x": 220,
+                                        "y": 96,
+                                        "h": 20,
+                                        "w": 20
+                                    },
+                                    "participantId": "37174"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "kind": "RETURN",
+                    "branches": [],
+                    "properties": {
+                        "value": {
+                            "type": "http:BadRequest"
+                        }
+                    },
+                    "location": {
+                        "fileName": "main.bal",
+                        "startLine": {
+                            "line": 8,
+                            "offset": 12
+                        },
+                        "endLine": {
+                            "line": 11,
+                            "offset": 14
+                        }
+                    }
+                },
+                {
+                    "kind": "RETURN",
+                    "branches": [],
+                    "properties": {
+                        "value": {
+                            "type": "annotations:error"
+                        }
+                    },
+                    "location": {
+                        "fileName": "main.bal",
+                        "startLine": {
+                            "line": 14,
+                            "offset": 12
+                        },
+                        "endLine": {
+                            "line": 14,
+                            "offset": 49
+                        }
+                    }
+                }
+            ],
+            "location": {
+                "fileName": "main.bal",
+                "startLine": {
+                    "line": 5,
+                    "offset": 4
+                },
+                "endLine": {
+                    "line": 16,
+                    "offset": 5
+                }
+            },
+            "viewState": {
+                "bBox": {
+                    "x": 220,
+                    "y": 0,
+                    "h": 40,
+                    "w": 160
+                },
+                "xIndex": 1,
+                "lifelineHeight": 99
+            }
+        }
+    ],
+    "location": {
+        "fileName": "/Users/gayanka/dev/wso2/test/test_sample/main.bal",
+        "startLine": {
+            "line": 5,
+            "offset": 4
+        },
+        "endLine": {
+            "line": 16,
+            "offset": 5
+        }
+    },
+    "others": []
+}

--- a/workspaces/ballerina/sequence-diagram/src/test/Diagram.test.tsx
+++ b/workspaces/ballerina/sequence-diagram/src/test/Diagram.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from "react";
+import { prettyDOM, waitFor } from "@testing-library/dom";
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { Diagram } from "../components/Diagram";
+import { Flow } from "../utils/types";
+
+// Import sample data
+import model1 from "../stories/endpoint_call1.json";
+import model2 from "../stories/function_call1.json";
+import model3 from "../stories/function_call2.json";
+import model4 from "../stories/function_call3.json";
+import model5 from "../stories/if_node1.json";
+import model6 from "../stories/if_node4.json";
+import model7 from "../stories/if_node5.json";
+import model8 from "../stories/if_node8.json";
+import model9 from "../stories/while_node1.json";
+import model10 from "../stories/sample-with-return.json";
+
+async function renderAndCheckSnapshot(model: Flow, testName: string) {
+    const mockProps = {
+        onClickParticipant: jest.fn(),
+        onAddParticipant: jest.fn(),
+        onReady: jest.fn(),
+    };
+
+    const dom = render(<Diagram model={model} {...mockProps} />);
+
+    // Wait for diagram to render
+    await waitFor(
+        () => {
+            const diagramElements = dom.container.querySelectorAll('[class*="diagram"], svg, canvas');
+            expect(diagramElements.length).toBeGreaterThan(0);
+        },
+        { timeout: 10000 }
+    );
+
+    // Wait for progress ring to be removed (indicates diagram is fully rendered)
+    await waitFor(
+        () => {
+            const progressRing = dom.container.querySelector('vscode-progress-ring');
+            expect(progressRing).not.toBeInTheDocument();
+        },
+        { timeout: 5000 }
+    );
+
+    const prettyDom = prettyDOM(dom.container, 1000000, {
+        highlight: false,
+        filterNode(node) {
+            return true;
+        },
+    });
+
+    expect(prettyDom).toBeTruthy();
+
+    // Sanitization: remove dynamic IDs and non-deterministic attributes
+    function sanitizeDom(domString: string): string {
+        return domString
+            .replace(/\s+(marker-end|id|data-linkid|data-nodeid)="[^"]*"/g, "")
+            .replace(/\s+(appearance|aria-label|current-value)="[^"]*"/g, "")
+            .replace(/href="#[^"]*"/g, 'href="#DYNAMIC_ID"')
+            .replace(/<vscode-button\s+>/g, "<vscode-button>");
+    }
+    const sanitizedDom = sanitizeDom(prettyDom as string);
+    expect(sanitizedDom).toMatchSnapshot(testName);
+}
+
+describe("Sequence Diagram - Snapshot Tests", () => {
+    test("renders endpoint call diagram correctly", async () => {
+        await renderAndCheckSnapshot(model1 as Flow, "endpoint-call");
+    }, 15000);
+
+    test("renders function call 1 diagram correctly", async () => {
+        await renderAndCheckSnapshot(model2 as Flow, "function-call-1");
+    }, 15000);
+
+    test("renders function call 2 diagram correctly", async () => {
+        await renderAndCheckSnapshot(model3 as Flow, "function-call-2");
+    }, 15000);
+
+    test("renders function call 3 diagram correctly", async () => {
+        await renderAndCheckSnapshot(model4 as Flow, "function-call-3");
+    }, 15000);
+
+    test("renders if node 1 diagram correctly", async () => {
+        await renderAndCheckSnapshot(model5 as Flow, "if-node-1");
+    }, 15000);
+
+    test("renders if node 4 diagram correctly", async () => {
+        await renderAndCheckSnapshot(model6 as Flow, "if-node-4");
+    }, 15000);
+
+    test("renders if node 5 diagram correctly", async () => {
+        await renderAndCheckSnapshot(model7 as Flow, "if-node-5");
+    }, 15000);
+
+    test("renders if node 8 diagram correctly", async () => {
+        await renderAndCheckSnapshot(model8 as Flow, "if-node-8");
+    }, 15000);
+
+    test("renders while node diagram correctly", async () => {
+        await renderAndCheckSnapshot(model9 as Flow, "while-node");
+    }, 15000);
+
+    test("renders sample with return diagram correctly", async () => {
+        await renderAndCheckSnapshot(model10 as Flow, "sample-with-return");
+    }, 15000);
+});

--- a/workspaces/ballerina/sequence-diagram/src/test/__snapshots__/Diagram.test.tsx.snap
+++ b/workspaces/ballerina/sequence-diagram/src/test/__snapshots__/Diagram.test.tsx.snap
@@ -1,0 +1,7884 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Sequence Diagram - Snapshot Tests renders endpoint call diagram correctly: endpoint-call 1`] = `
+"<div>
+  <div
+    class="css-jqwdy0"
+  >
+    <div
+      class="css-1wrxmfn"
+    >
+      <div
+        class="css-cs29wk"
+      >
+        <i
+          class="fw-bi-fit-screen"
+        />
+      </div>
+    </div>
+    <div
+      class="css-8f9a5x"
+    >
+      <div
+        class="css-1wrxmfn"
+      >
+        <div
+          class="css-cs29wk"
+        >
+          <i
+            class="fw-bi-plus"
+          />
+        </div>
+      </div>
+      <div
+        class="css-1wrxmfn"
+      >
+        <div
+          class="css-cs29wk"
+        >
+          <i
+            class="fw-bi-minus"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="css-pf6ojx"
+    color="var(--vscode-foreground)"
+  >
+    <div
+      class="css-18f0176"
+    >
+      <svg
+        class="css-12q0bj3"
+        style="transform: translate(
+				400px,
+				300px)
+			scale(
+				1
+			);"
+      >
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              >
+                get
+              </textpath>
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              />
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              >
+                post
+              </textpath>
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              />
+            </text>
+          </g>
+        </g>
+      </svg>
+      <div
+        class="css-12q0bj3"
+        style="transform: translate(
+				400px,
+				300px)
+			scale(
+				1
+			);"
+      >
+        <div
+          class="node css-nlpftr"
+          style="top: 0px; left: 220px;"
+        >
+          <div
+            class="css-1mdm4mu"
+          >
+            <div
+              class="participant-background css-8musc0"
+            />
+            <div
+              class="css-13cluym"
+            >
+              <div
+                class="participant-head css-31ty19"
+                kind="FUNCTION"
+              >
+                <svg
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15.6 5.29c-1.1-.1-2.07.71-2.17 1.82L13.18 10H16v2h-3l-.44 5.07a3.986 3.986 0 0 1-4.33 3.63a4 4 0 0 1-3.06-1.87l1.5-1.5c.24.74.9 1.31 1.73 1.38c1.1.1 2.07-.71 2.17-1.82L11 12H8v-2h3.17l.27-3.07c.19-2.2 2.13-3.83 4.33-3.63c1.31.11 2.41.84 3.06 1.87l-1.5 1.5c-.24-.74-.9-1.31-1.73-1.38"
+                  />
+                </svg>
+                <div
+                  class="css-1j58mj5"
+                >
+                  getCall
+                </div>
+              </div>
+            </div>
+            <svg
+              height="209"
+              width="10"
+            >
+              <line
+                class="participant-line"
+                style="stroke-width: 2; transition: stroke 0.2s ease; opacity: 0.5;"
+                x1="5"
+                x2="5"
+                y1="0"
+                y2="209"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 0px; left: 440px;"
+        >
+          <div
+            class="css-1mdm4mu"
+          >
+            <div
+              class="participant-background css-8musc0"
+            />
+            <div
+              class="css-13cluym"
+            >
+              <div
+                class="participant-head css-474zhv"
+                kind="ENDPOINT"
+              >
+                <svg
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M7 17q-2.075 0-3.537-1.463T2 12t1.463-3.537T7 7h3q.425 0 .713.288T11 8t-.288.713T10 9H7q-1.25 0-2.125.875T4 12t.875 2.125T7 15h3q.425 0 .713.288T11 16t-.288.713T10 17zm2-4q-.425 0-.712-.288T8 12t.288-.712T9 11h6q.425 0 .713.288T16 12t-.288.713T15 13zm5 4q-.425 0-.712-.288T13 16t.288-.712T14 15h3q1.25 0 2.125-.875T20 12t-.875-2.125T17 9h-3q-.425 0-.712-.288T13 8t.288-.712T14 7h3q2.075 0 3.538 1.463T22 12t-1.463 3.538T17 17z"
+                  />
+                </svg>
+              </div>
+              <div
+                class="css-1itbc83"
+              >
+                cl
+              </div>
+            </div>
+            <svg
+              height="209"
+              width="10"
+            >
+              <line
+                class="participant-line"
+                style="stroke-width: 2; transition: stroke 0.2s ease; opacity: 0.5;"
+                x1="5"
+                x2="5"
+                y1="0"
+                y2="209"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 68px; left: 290px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 68px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 96px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 96px; left: 290px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 68px; left: 290px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 68px; left: 510px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 178px; left: 290px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 178px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 206px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 206px; left: 290px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 178px; left: 290px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 178px; left: 510px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 68px; left: 290px;"
+        >
+          <div
+            class="css-2w26pj"
+            height="158"
+            width="20"
+          >
+            <svg
+              height="158"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="158"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>"
+`;
+
+exports[`Sequence Diagram - Snapshot Tests renders function call 1 diagram correctly: function-call-1 1`] = `
+"<div>
+  <div
+    class="css-jqwdy0"
+  >
+    <div
+      class="css-1wrxmfn"
+    >
+      <div
+        class="css-cs29wk"
+      >
+        <i
+          class="fw-bi-fit-screen"
+        />
+      </div>
+    </div>
+    <div
+      class="css-8f9a5x"
+    >
+      <div
+        class="css-1wrxmfn"
+      >
+        <div
+          class="css-cs29wk"
+        >
+          <i
+            class="fw-bi-plus"
+          />
+        </div>
+      </div>
+      <div
+        class="css-1wrxmfn"
+      >
+        <div
+          class="css-cs29wk"
+        >
+          <i
+            class="fw-bi-minus"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="css-pf6ojx"
+    color="var(--vscode-foreground)"
+  >
+    <div
+      class="css-18f0176"
+    >
+      <svg
+        class="css-12q0bj3"
+        style="transform: translate(
+				400px,
+				300px)
+			scale(
+				1
+			);"
+      >
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              >
+                fn2 ()
+              </textpath>
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              />
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              >
+                fn3 (2)
+              </textpath>
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              />
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              >
+                fn3 (2)
+              </textpath>
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              />
+            </text>
+          </g>
+        </g>
+      </svg>
+      <div
+        class="css-12q0bj3"
+        style="transform: translate(
+				400px,
+				300px)
+			scale(
+				1
+			);"
+      >
+        <div
+          class="node css-nlpftr"
+          style="top: 0px; left: 220px;"
+        >
+          <div
+            class="css-1mdm4mu"
+          >
+            <div
+              class="participant-background css-8musc0"
+            />
+            <div
+              class="css-13cluym"
+            >
+              <div
+                class="participant-head css-31ty19"
+                kind="FUNCTION"
+              >
+                <svg
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15.6 5.29c-1.1-.1-2.07.71-2.17 1.82L13.18 10H16v2h-3l-.44 5.07a3.986 3.986 0 0 1-4.33 3.63a4 4 0 0 1-3.06-1.87l1.5-1.5c.24.74.9 1.31 1.73 1.38c1.1.1 2.07-.71 2.17-1.82L11 12H8v-2h3.17l.27-3.07c.19-2.2 2.13-3.83 4.33-3.63c1.31.11 2.41.84 3.06 1.87l-1.5 1.5c-.24-.74-.9-1.31-1.73-1.38"
+                  />
+                </svg>
+                <div
+                  class="css-1j58mj5"
+                >
+                  fn1
+                </div>
+              </div>
+            </div>
+            <svg
+              height="268"
+              width="10"
+            >
+              <line
+                class="participant-line"
+                style="stroke-width: 2; transition: stroke 0.2s ease; opacity: 0.5;"
+                x1="5"
+                x2="5"
+                y1="0"
+                y2="268"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 0px; left: 440px;"
+        >
+          <div
+            class="css-1mdm4mu"
+          >
+            <div
+              class="participant-background css-8musc0"
+            />
+            <div
+              class="css-13cluym"
+            >
+              <div
+                class="participant-head css-31ty19"
+                kind="FUNCTION"
+              >
+                <svg
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15.6 5.29c-1.1-.1-2.07.71-2.17 1.82L13.18 10H16v2h-3l-.44 5.07a3.986 3.986 0 0 1-4.33 3.63a4 4 0 0 1-3.06-1.87l1.5-1.5c.24.74.9 1.31 1.73 1.38c1.1.1 2.07-.71 2.17-1.82L11 12H8v-2h3.17l.27-3.07c.19-2.2 2.13-3.83 4.33-3.63c1.31.11 2.41.84 3.06 1.87l-1.5 1.5c-.24-.74-.9-1.31-1.73-1.38"
+                  />
+                </svg>
+                <div
+                  class="css-1j58mj5"
+                >
+                  fn2
+                </div>
+              </div>
+            </div>
+            <svg
+              height="268"
+              width="10"
+            >
+              <line
+                class="participant-line"
+                style="stroke-width: 2; transition: stroke 0.2s ease; opacity: 0.5;"
+                x1="5"
+                x2="5"
+                y1="0"
+                y2="268"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 0px; left: 660px;"
+        >
+          <div
+            class="css-1mdm4mu"
+          >
+            <div
+              class="participant-background css-8musc0"
+            />
+            <div
+              class="css-13cluym"
+            >
+              <div
+                class="participant-head css-31ty19"
+                kind="FUNCTION"
+              >
+                <svg
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15.6 5.29c-1.1-.1-2.07.71-2.17 1.82L13.18 10H16v2h-3l-.44 5.07a3.986 3.986 0 0 1-4.33 3.63a4 4 0 0 1-3.06-1.87l1.5-1.5c.24.74.9 1.31 1.73 1.38c1.1.1 2.07-.71 2.17-1.82L11 12H8v-2h3.17l.27-3.07c.19-2.2 2.13-3.83 4.33-3.63c1.31.11 2.41.84 3.06 1.87l-1.5 1.5c-.24-.74-.9-1.31-1.73-1.38"
+                  />
+                </svg>
+                <div
+                  class="css-1j58mj5"
+                >
+                  fn3
+                </div>
+              </div>
+            </div>
+            <svg
+              height="268"
+              width="10"
+            >
+              <line
+                class="participant-line"
+                style="stroke-width: 2; transition: stroke 0.2s ease; opacity: 0.5;"
+                x1="5"
+                x2="5"
+                y1="0"
+                y2="268"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 68px; left: 290px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 68px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 155px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 155px; left: 290px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 68px; left: 290px;"
+        >
+          <div
+            class="css-11nrhni"
+            height="107"
+            width="20"
+          >
+            <svg
+              height="107"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="107"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 68px; left: 510px;"
+        >
+          <div
+            class="css-11nrhni"
+            height="107"
+            width="20"
+          >
+            <svg
+              height="107"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="107"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 99px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 99px; left: 730px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 127px; left: 730px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 127px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 99px; left: 510px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 99px; left: 730px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 237px; left: 290px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 237px; left: 730px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 265px; left: 730px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 265px; left: 290px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 237px; left: 290px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 237px; left: 730px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 68px; left: 290px;"
+        >
+          <div
+            class="css-xyo0ws"
+            height="217"
+            width="20"
+          >
+            <svg
+              height="217"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="217"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>"
+`;
+
+exports[`Sequence Diagram - Snapshot Tests renders function call 2 diagram correctly: function-call-2 1`] = `
+"<div>
+  <div
+    class="css-jqwdy0"
+  >
+    <div
+      class="css-1wrxmfn"
+    >
+      <div
+        class="css-cs29wk"
+      >
+        <i
+          class="fw-bi-fit-screen"
+        />
+      </div>
+    </div>
+    <div
+      class="css-8f9a5x"
+    >
+      <div
+        class="css-1wrxmfn"
+      >
+        <div
+          class="css-cs29wk"
+        >
+          <i
+            class="fw-bi-plus"
+          />
+        </div>
+      </div>
+      <div
+        class="css-1wrxmfn"
+      >
+        <div
+          class="css-cs29wk"
+        >
+          <i
+            class="fw-bi-minus"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="css-pf6ojx"
+    color="var(--vscode-foreground)"
+  >
+    <div
+      class="css-18f0176"
+    >
+      <svg
+        class="css-12q0bj3"
+        style="transform: translate(
+				400px,
+				300px)
+			scale(
+				1
+			);"
+      >
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              >
+                fn3 (2)
+              </textpath>
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              />
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              >
+                fn2 ()
+              </textpath>
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              />
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              >
+                fn3 (2)
+              </textpath>
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              />
+            </text>
+          </g>
+        </g>
+      </svg>
+      <div
+        class="css-12q0bj3"
+        style="transform: translate(
+				400px,
+				300px)
+			scale(
+				1
+			);"
+      >
+        <div
+          class="node css-nlpftr"
+          style="top: 0px; left: 220px;"
+        >
+          <div
+            class="css-1mdm4mu"
+          >
+            <div
+              class="participant-background css-8musc0"
+            />
+            <div
+              class="css-13cluym"
+            >
+              <div
+                class="participant-head css-31ty19"
+                kind="FUNCTION"
+              >
+                <svg
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15.6 5.29c-1.1-.1-2.07.71-2.17 1.82L13.18 10H16v2h-3l-.44 5.07a3.986 3.986 0 0 1-4.33 3.63a4 4 0 0 1-3.06-1.87l1.5-1.5c.24.74.9 1.31 1.73 1.38c1.1.1 2.07-.71 2.17-1.82L11 12H8v-2h3.17l.27-3.07c.19-2.2 2.13-3.83 4.33-3.63c1.31.11 2.41.84 3.06 1.87l-1.5 1.5c-.24-.74-.9-1.31-1.73-1.38"
+                  />
+                </svg>
+                <div
+                  class="css-1j58mj5"
+                >
+                  fn1
+                </div>
+              </div>
+            </div>
+            <svg
+              height="268"
+              width="10"
+            >
+              <line
+                class="participant-line"
+                style="stroke-width: 2; transition: stroke 0.2s ease; opacity: 0.5;"
+                x1="5"
+                x2="5"
+                y1="0"
+                y2="268"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 0px; left: 440px;"
+        >
+          <div
+            class="css-1mdm4mu"
+          >
+            <div
+              class="participant-background css-8musc0"
+            />
+            <div
+              class="css-13cluym"
+            >
+              <div
+                class="participant-head css-31ty19"
+                kind="FUNCTION"
+              >
+                <svg
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15.6 5.29c-1.1-.1-2.07.71-2.17 1.82L13.18 10H16v2h-3l-.44 5.07a3.986 3.986 0 0 1-4.33 3.63a4 4 0 0 1-3.06-1.87l1.5-1.5c.24.74.9 1.31 1.73 1.38c1.1.1 2.07-.71 2.17-1.82L11 12H8v-2h3.17l.27-3.07c.19-2.2 2.13-3.83 4.33-3.63c1.31.11 2.41.84 3.06 1.87l-1.5 1.5c-.24-.74-.9-1.31-1.73-1.38"
+                  />
+                </svg>
+                <div
+                  class="css-1j58mj5"
+                >
+                  fn3
+                </div>
+              </div>
+            </div>
+            <svg
+              height="268"
+              width="10"
+            >
+              <line
+                class="participant-line"
+                style="stroke-width: 2; transition: stroke 0.2s ease; opacity: 0.5;"
+                x1="5"
+                x2="5"
+                y1="0"
+                y2="268"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 0px; left: 660px;"
+        >
+          <div
+            class="css-1mdm4mu"
+          >
+            <div
+              class="participant-background css-8musc0"
+            />
+            <div
+              class="css-13cluym"
+            >
+              <div
+                class="participant-head css-31ty19"
+                kind="FUNCTION"
+              >
+                <svg
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15.6 5.29c-1.1-.1-2.07.71-2.17 1.82L13.18 10H16v2h-3l-.44 5.07a3.986 3.986 0 0 1-4.33 3.63a4 4 0 0 1-3.06-1.87l1.5-1.5c.24.74.9 1.31 1.73 1.38c1.1.1 2.07-.71 2.17-1.82L11 12H8v-2h3.17l.27-3.07c.19-2.2 2.13-3.83 4.33-3.63c1.31.11 2.41.84 3.06 1.87l-1.5 1.5c-.24-.74-.9-1.31-1.73-1.38"
+                  />
+                </svg>
+                <div
+                  class="css-1j58mj5"
+                >
+                  fn2
+                </div>
+              </div>
+            </div>
+            <svg
+              height="268"
+              width="10"
+            >
+              <line
+                class="participant-line"
+                style="stroke-width: 2; transition: stroke 0.2s ease; opacity: 0.5;"
+                x1="5"
+                x2="5"
+                y1="0"
+                y2="268"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 68px; left: 290px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 68px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 96px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 96px; left: 290px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 68px; left: 290px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 68px; left: 510px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 178px; left: 290px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 178px; left: 730px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 265px; left: 730px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 265px; left: 290px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 178px; left: 290px;"
+        >
+          <div
+            class="css-11nrhni"
+            height="107"
+            width="20"
+          >
+            <svg
+              height="107"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="107"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 178px; left: 730px;"
+        >
+          <div
+            class="css-11nrhni"
+            height="107"
+            width="20"
+          >
+            <svg
+              height="107"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="107"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 209px; left: 730px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 209px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 237px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 237px; left: 730px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 209px; left: 730px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 209px; left: 510px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 68px; left: 290px;"
+        >
+          <div
+            class="css-xyo0ws"
+            height="217"
+            width="20"
+          >
+            <svg
+              height="217"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="217"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>"
+`;
+
+exports[`Sequence Diagram - Snapshot Tests renders function call 3 diagram correctly: function-call-3 1`] = `
+"<div>
+  <div
+    class="css-jqwdy0"
+  >
+    <div
+      class="css-1wrxmfn"
+    >
+      <div
+        class="css-cs29wk"
+      >
+        <i
+          class="fw-bi-fit-screen"
+        />
+      </div>
+    </div>
+    <div
+      class="css-8f9a5x"
+    >
+      <div
+        class="css-1wrxmfn"
+      >
+        <div
+          class="css-cs29wk"
+        >
+          <i
+            class="fw-bi-plus"
+          />
+        </div>
+      </div>
+      <div
+        class="css-1wrxmfn"
+      >
+        <div
+          class="css-cs29wk"
+        >
+          <i
+            class="fw-bi-minus"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="css-pf6ojx"
+    color="var(--vscode-foreground)"
+  >
+    <div
+      class="css-18f0176"
+    >
+      <svg
+        class="css-12q0bj3"
+        style="transform: translate(
+				400px,
+				300px)
+			scale(
+				1
+			);"
+      >
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              >
+                fn2 ()
+              </textpath>
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              />
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              >
+                fn3 (2)
+              </textpath>
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              />
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              >
+                fn2 ()
+              </textpath>
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              />
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              >
+                fn3 (2)
+              </textpath>
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              />
+            </text>
+          </g>
+        </g>
+      </svg>
+      <div
+        class="css-12q0bj3"
+        style="transform: translate(
+				400px,
+				300px)
+			scale(
+				1
+			);"
+      >
+        <div
+          class="node css-nlpftr"
+          style="top: 0px; left: 220px;"
+        >
+          <div
+            class="css-1mdm4mu"
+          >
+            <div
+              class="participant-background css-8musc0"
+            />
+            <div
+              class="css-13cluym"
+            >
+              <div
+                class="participant-head css-31ty19"
+                kind="FUNCTION"
+              >
+                <svg
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15.6 5.29c-1.1-.1-2.07.71-2.17 1.82L13.18 10H16v2h-3l-.44 5.07a3.986 3.986 0 0 1-4.33 3.63a4 4 0 0 1-3.06-1.87l1.5-1.5c.24.74.9 1.31 1.73 1.38c1.1.1 2.07-.71 2.17-1.82L11 12H8v-2h3.17l.27-3.07c.19-2.2 2.13-3.83 4.33-3.63c1.31.11 2.41.84 3.06 1.87l-1.5 1.5c-.24-.74-.9-1.31-1.73-1.38"
+                  />
+                </svg>
+                <div
+                  class="css-1j58mj5"
+                >
+                  fn1
+                </div>
+              </div>
+            </div>
+            <svg
+              height="327"
+              width="10"
+            >
+              <line
+                class="participant-line"
+                style="stroke-width: 2; transition: stroke 0.2s ease; opacity: 0.5;"
+                x1="5"
+                x2="5"
+                y1="0"
+                y2="327"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 0px; left: 440px;"
+        >
+          <div
+            class="css-1mdm4mu"
+          >
+            <div
+              class="participant-background css-8musc0"
+            />
+            <div
+              class="css-13cluym"
+            >
+              <div
+                class="participant-head css-31ty19"
+                kind="FUNCTION"
+              >
+                <svg
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15.6 5.29c-1.1-.1-2.07.71-2.17 1.82L13.18 10H16v2h-3l-.44 5.07a3.986 3.986 0 0 1-4.33 3.63a4 4 0 0 1-3.06-1.87l1.5-1.5c.24.74.9 1.31 1.73 1.38c1.1.1 2.07-.71 2.17-1.82L11 12H8v-2h3.17l.27-3.07c.19-2.2 2.13-3.83 4.33-3.63c1.31.11 2.41.84 3.06 1.87l-1.5 1.5c-.24-.74-.9-1.31-1.73-1.38"
+                  />
+                </svg>
+                <div
+                  class="css-1j58mj5"
+                >
+                  fn2
+                </div>
+              </div>
+            </div>
+            <svg
+              height="327"
+              width="10"
+            >
+              <line
+                class="participant-line"
+                style="stroke-width: 2; transition: stroke 0.2s ease; opacity: 0.5;"
+                x1="5"
+                x2="5"
+                y1="0"
+                y2="327"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 0px; left: 660px;"
+        >
+          <div
+            class="css-1mdm4mu"
+          >
+            <div
+              class="participant-background css-8musc0"
+            />
+            <div
+              class="css-13cluym"
+            >
+              <div
+                class="participant-head css-31ty19"
+                kind="FUNCTION"
+              >
+                <svg
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15.6 5.29c-1.1-.1-2.07.71-2.17 1.82L13.18 10H16v2h-3l-.44 5.07a3.986 3.986 0 0 1-4.33 3.63a4 4 0 0 1-3.06-1.87l1.5-1.5c.24.74.9 1.31 1.73 1.38c1.1.1 2.07-.71 2.17-1.82L11 12H8v-2h3.17l.27-3.07c.19-2.2 2.13-3.83 4.33-3.63c1.31.11 2.41.84 3.06 1.87l-1.5 1.5c-.24-.74-.9-1.31-1.73-1.38"
+                  />
+                </svg>
+                <div
+                  class="css-1j58mj5"
+                >
+                  fn3
+                </div>
+              </div>
+            </div>
+            <svg
+              height="327"
+              width="10"
+            >
+              <line
+                class="participant-line"
+                style="stroke-width: 2; transition: stroke 0.2s ease; opacity: 0.5;"
+                x1="5"
+                x2="5"
+                y1="0"
+                y2="327"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 68px; left: 290px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 68px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 155px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 155px; left: 290px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 68px; left: 290px;"
+        >
+          <div
+            class="css-11nrhni"
+            height="107"
+            width="20"
+          >
+            <svg
+              height="107"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="107"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 68px; left: 510px;"
+        >
+          <div
+            class="css-11nrhni"
+            height="107"
+            width="20"
+          >
+            <svg
+              height="107"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="107"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 99px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 99px; left: 730px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 127px; left: 730px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 127px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 99px; left: 510px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 99px; left: 730px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 237px; left: 290px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 237px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 324px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 324px; left: 290px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 237px; left: 290px;"
+        >
+          <div
+            class="css-11nrhni"
+            height="107"
+            width="20"
+          >
+            <svg
+              height="107"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="107"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 237px; left: 510px;"
+        >
+          <div
+            class="css-11nrhni"
+            height="107"
+            width="20"
+          >
+            <svg
+              height="107"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="107"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 268px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 268px; left: 730px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 296px; left: 730px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 296px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 268px; left: 510px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 268px; left: 730px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 68px; left: 290px;"
+        >
+          <div
+            class="css-a4e7ew"
+            height="276"
+            width="20"
+          >
+            <svg
+              height="276"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="276"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>"
+`;
+
+exports[`Sequence Diagram - Snapshot Tests renders if node 1 diagram correctly: if-node-1 1`] = `
+"<div>
+  <div
+    class="css-jqwdy0"
+  >
+    <div
+      class="css-1wrxmfn"
+    >
+      <div
+        class="css-cs29wk"
+      >
+        <i
+          class="fw-bi-fit-screen"
+        />
+      </div>
+    </div>
+    <div
+      class="css-8f9a5x"
+    >
+      <div
+        class="css-1wrxmfn"
+      >
+        <div
+          class="css-cs29wk"
+        >
+          <i
+            class="fw-bi-plus"
+          />
+        </div>
+      </div>
+      <div
+        class="css-1wrxmfn"
+      >
+        <div
+          class="css-cs29wk"
+        >
+          <i
+            class="fw-bi-minus"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="css-pf6ojx"
+    color="var(--vscode-foreground)"
+  >
+    <div
+      class="css-18f0176"
+    >
+      <svg
+        class="css-12q0bj3"
+        style="transform: translate(
+				400px,
+				300px)
+			scale(
+				1
+			);"
+      >
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              >
+                fn2 ()
+              </textpath>
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              />
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              >
+                fn3 ()
+              </textpath>
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              />
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              >
+                fn4 ()
+              </textpath>
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              />
+            </text>
+          </g>
+        </g>
+      </svg>
+      <div
+        class="css-12q0bj3"
+        style="transform: translate(
+				400px,
+				300px)
+			scale(
+				1
+			);"
+      >
+        <div
+          class="node css-nlpftr"
+          style="top: 0px; left: 220px;"
+        >
+          <div
+            class="css-1mdm4mu"
+          >
+            <div
+              class="participant-background css-8musc0"
+            />
+            <div
+              class="css-13cluym"
+            >
+              <div
+                class="participant-head css-31ty19"
+                kind="FUNCTION"
+              >
+                <svg
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15.6 5.29c-1.1-.1-2.07.71-2.17 1.82L13.18 10H16v2h-3l-.44 5.07a3.986 3.986 0 0 1-4.33 3.63a4 4 0 0 1-3.06-1.87l1.5-1.5c.24.74.9 1.31 1.73 1.38c1.1.1 2.07-.71 2.17-1.82L11 12H8v-2h3.17l.27-3.07c.19-2.2 2.13-3.83 4.33-3.63c1.31.11 2.41.84 3.06 1.87l-1.5 1.5c-.24-.74-.9-1.31-1.73-1.38"
+                  />
+                </svg>
+                <div
+                  class="css-1j58mj5"
+                >
+                  fn1
+                </div>
+              </div>
+            </div>
+            <svg
+              height="200"
+              width="10"
+            >
+              <line
+                class="participant-line"
+                style="stroke-width: 2; transition: stroke 0.2s ease; opacity: 0.5;"
+                x1="5"
+                x2="5"
+                y1="0"
+                y2="200"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 0px; left: 440px;"
+        >
+          <div
+            class="css-1mdm4mu"
+          >
+            <div
+              class="participant-background css-8musc0"
+            />
+            <div
+              class="css-13cluym"
+            >
+              <div
+                class="participant-head css-31ty19"
+                kind="FUNCTION"
+              >
+                <svg
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15.6 5.29c-1.1-.1-2.07.71-2.17 1.82L13.18 10H16v2h-3l-.44 5.07a3.986 3.986 0 0 1-4.33 3.63a4 4 0 0 1-3.06-1.87l1.5-1.5c.24.74.9 1.31 1.73 1.38c1.1.1 2.07-.71 2.17-1.82L11 12H8v-2h3.17l.27-3.07c.19-2.2 2.13-3.83 4.33-3.63c1.31.11 2.41.84 3.06 1.87l-1.5 1.5c-.24-.74-.9-1.31-1.73-1.38"
+                  />
+                </svg>
+                <div
+                  class="css-1j58mj5"
+                >
+                  longfunctionname
+                </div>
+              </div>
+            </div>
+            <svg
+              height="200"
+              width="10"
+            >
+              <line
+                class="participant-line"
+                style="stroke-width: 2; transition: stroke 0.2s ease; opacity: 0.5;"
+                x1="5"
+                x2="5"
+                y1="0"
+                y2="200"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 0px; left: 660px;"
+        >
+          <div
+            class="css-1mdm4mu"
+          >
+            <div
+              class="participant-background css-8musc0"
+            />
+            <div
+              class="css-13cluym"
+            >
+              <div
+                class="participant-head css-31ty19"
+                kind="FUNCTION"
+              >
+                <svg
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15.6 5.29c-1.1-.1-2.07.71-2.17 1.82L13.18 10H16v2h-3l-.44 5.07a3.986 3.986 0 0 1-4.33 3.63a4 4 0 0 1-3.06-1.87l1.5-1.5c.24.74.9 1.31 1.73 1.38c1.1.1 2.07-.71 2.17-1.82L11 12H8v-2h3.17l.27-3.07c.19-2.2 2.13-3.83 4.33-3.63c1.31.11 2.41.84 3.06 1.87l-1.5 1.5c-.24-.74-.9-1.31-1.73-1.38"
+                  />
+                </svg>
+                <div
+                  class="css-1j58mj5"
+                >
+                  fn3
+                </div>
+              </div>
+            </div>
+            <svg
+              height="200"
+              width="10"
+            >
+              <line
+                class="participant-line"
+                style="stroke-width: 2; transition: stroke 0.2s ease; opacity: 0.5;"
+                x1="5"
+                x2="5"
+                y1="0"
+                y2="200"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 0px; left: 880px;"
+        >
+          <div
+            class="css-1mdm4mu"
+          >
+            <div
+              class="participant-background css-8musc0"
+            />
+            <div
+              class="css-13cluym"
+            >
+              <div
+                class="participant-head css-31ty19"
+                kind="FUNCTION"
+              >
+                <svg
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15.6 5.29c-1.1-.1-2.07.71-2.17 1.82L13.18 10H16v2h-3l-.44 5.07a3.986 3.986 0 0 1-4.33 3.63a4 4 0 0 1-3.06-1.87l1.5-1.5c.24.74.9 1.31 1.73 1.38c1.1.1 2.07-.71 2.17-1.82L11 12H8v-2h3.17l.27-3.07c.19-2.2 2.13-3.83 4.33-3.63c1.31.11 2.41.84 3.06 1.87l-1.5 1.5c-.24-.74-.9-1.31-1.73-1.38"
+                  />
+                </svg>
+                <div
+                  class="css-1j58mj5"
+                >
+                  fn4
+                </div>
+              </div>
+            </div>
+            <svg
+              height="200"
+              width="10"
+            >
+              <line
+                class="participant-line"
+                style="stroke-width: 2; transition: stroke 0.2s ease; opacity: 0.5;"
+                x1="5"
+                x2="5"
+                y1="0"
+                y2="200"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 17px; left: 290px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 17px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 45px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 45px; left: 290px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 17px; left: 290px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 17px; left: 510px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 93px; left: 290px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 93px; left: 730px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 121px; left: 730px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 121px; left: 290px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 93px; left: 290px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 93px; left: 730px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 152px; left: 290px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 152px; left: 950px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 180px; left: 950px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 180px; left: 290px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 152px; left: 290px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 152px; left: 950px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>"
+`;
+
+exports[`Sequence Diagram - Snapshot Tests renders if node 4 diagram correctly: if-node-4 1`] = `
+"<div>
+  <div
+    class="css-jqwdy0"
+  >
+    <div
+      class="css-1wrxmfn"
+    >
+      <div
+        class="css-cs29wk"
+      >
+        <i
+          class="fw-bi-fit-screen"
+        />
+      </div>
+    </div>
+    <div
+      class="css-8f9a5x"
+    >
+      <div
+        class="css-1wrxmfn"
+      >
+        <div
+          class="css-cs29wk"
+        >
+          <i
+            class="fw-bi-plus"
+          />
+        </div>
+      </div>
+      <div
+        class="css-1wrxmfn"
+      >
+        <div
+          class="css-cs29wk"
+        >
+          <i
+            class="fw-bi-minus"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="css-pf6ojx"
+    color="var(--vscode-foreground)"
+  >
+    <div
+      class="css-18f0176"
+    >
+      <svg
+        class="css-12q0bj3"
+        style="transform: translate(
+				400px,
+				300px)
+			scale(
+				1
+			);"
+      >
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              >
+                fn2 ()
+              </textpath>
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              />
+            </text>
+          </g>
+        </g>
+      </svg>
+      <div
+        class="css-12q0bj3"
+        style="transform: translate(
+				400px,
+				300px)
+			scale(
+				1
+			);"
+      >
+        <div
+          class="node css-nlpftr"
+          style="top: 0px; left: 220px;"
+        >
+          <div
+            class="css-1mdm4mu"
+          >
+            <div
+              class="participant-background css-8musc0"
+            />
+            <div
+              class="css-13cluym"
+            >
+              <div
+                class="participant-head css-31ty19"
+                kind="FUNCTION"
+              >
+                <svg
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15.6 5.29c-1.1-.1-2.07.71-2.17 1.82L13.18 10H16v2h-3l-.44 5.07a3.986 3.986 0 0 1-4.33 3.63a4 4 0 0 1-3.06-1.87l1.5-1.5c.24.74.9 1.31 1.73 1.38c1.1.1 2.07-.71 2.17-1.82L11 12H8v-2h3.17l.27-3.07c.19-2.2 2.13-3.83 4.33-3.63c1.31.11 2.41.84 3.06 1.87l-1.5 1.5c-.24-.74-.9-1.31-1.73-1.38"
+                  />
+                </svg>
+                <div
+                  class="css-1j58mj5"
+                >
+                  fn1
+                </div>
+              </div>
+            </div>
+            <svg
+              height="200"
+              width="10"
+            >
+              <line
+                class="participant-line"
+                style="stroke-width: 2; transition: stroke 0.2s ease; opacity: 0.5;"
+                x1="5"
+                x2="5"
+                y1="0"
+                y2="200"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 0px; left: 440px;"
+        >
+          <div
+            class="css-1mdm4mu"
+          >
+            <div
+              class="participant-background css-8musc0"
+            />
+            <div
+              class="css-13cluym"
+            >
+              <div
+                class="participant-head css-31ty19"
+                kind="FUNCTION"
+              >
+                <svg
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15.6 5.29c-1.1-.1-2.07.71-2.17 1.82L13.18 10H16v2h-3l-.44 5.07a3.986 3.986 0 0 1-4.33 3.63a4 4 0 0 1-3.06-1.87l1.5-1.5c.24.74.9 1.31 1.73 1.38c1.1.1 2.07-.71 2.17-1.82L11 12H8v-2h3.17l.27-3.07c.19-2.2 2.13-3.83 4.33-3.63c1.31.11 2.41.84 3.06 1.87l-1.5 1.5c-.24-.74-.9-1.31-1.73-1.38"
+                  />
+                </svg>
+                <div
+                  class="css-1j58mj5"
+                >
+                  fn2
+                </div>
+              </div>
+            </div>
+            <svg
+              height="200"
+              width="10"
+            >
+              <line
+                class="participant-line"
+                style="stroke-width: 2; transition: stroke 0.2s ease; opacity: 0.5;"
+                x1="5"
+                x2="5"
+                y1="0"
+                y2="200"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 17px; left: 290px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 17px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 45px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 45px; left: 290px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 17px; left: 290px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 17px; left: 510px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>"
+`;
+
+exports[`Sequence Diagram - Snapshot Tests renders if node 5 diagram correctly: if-node-5 1`] = `
+"<div>
+  <div
+    class="css-jqwdy0"
+  >
+    <div
+      class="css-1wrxmfn"
+    >
+      <div
+        class="css-cs29wk"
+      >
+        <i
+          class="fw-bi-fit-screen"
+        />
+      </div>
+    </div>
+    <div
+      class="css-8f9a5x"
+    >
+      <div
+        class="css-1wrxmfn"
+      >
+        <div
+          class="css-cs29wk"
+        >
+          <i
+            class="fw-bi-plus"
+          />
+        </div>
+      </div>
+      <div
+        class="css-1wrxmfn"
+      >
+        <div
+          class="css-cs29wk"
+        >
+          <i
+            class="fw-bi-minus"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="css-pf6ojx"
+    color="var(--vscode-foreground)"
+  >
+    <div
+      class="css-18f0176"
+    >
+      <svg
+        class="css-12q0bj3"
+        style="transform: translate(
+				400px,
+				300px)
+			scale(
+				1
+			);"
+      >
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              >
+                fn2 ()
+              </textpath>
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              />
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              >
+                fn2 ()
+              </textpath>
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              />
+            </text>
+          </g>
+        </g>
+      </svg>
+      <div
+        class="css-12q0bj3"
+        style="transform: translate(
+				400px,
+				300px)
+			scale(
+				1
+			);"
+      >
+        <div
+          class="node css-nlpftr"
+          style="top: 0px; left: 220px;"
+        >
+          <div
+            class="css-1mdm4mu"
+          >
+            <div
+              class="participant-background css-8musc0"
+            />
+            <div
+              class="css-13cluym"
+            >
+              <div
+                class="participant-head css-31ty19"
+                kind="FUNCTION"
+              >
+                <svg
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15.6 5.29c-1.1-.1-2.07.71-2.17 1.82L13.18 10H16v2h-3l-.44 5.07a3.986 3.986 0 0 1-4.33 3.63a4 4 0 0 1-3.06-1.87l1.5-1.5c.24.74.9 1.31 1.73 1.38c1.1.1 2.07-.71 2.17-1.82L11 12H8v-2h3.17l.27-3.07c.19-2.2 2.13-3.83 4.33-3.63c1.31.11 2.41.84 3.06 1.87l-1.5 1.5c-.24-.74-.9-1.31-1.73-1.38"
+                  />
+                </svg>
+                <div
+                  class="css-1j58mj5"
+                >
+                  fn1
+                </div>
+              </div>
+            </div>
+            <svg
+              height="200"
+              width="10"
+            >
+              <line
+                class="participant-line"
+                style="stroke-width: 2; transition: stroke 0.2s ease; opacity: 0.5;"
+                x1="5"
+                x2="5"
+                y1="0"
+                y2="200"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 0px; left: 440px;"
+        >
+          <div
+            class="css-1mdm4mu"
+          >
+            <div
+              class="participant-background css-8musc0"
+            />
+            <div
+              class="css-13cluym"
+            >
+              <div
+                class="participant-head css-31ty19"
+                kind="FUNCTION"
+              >
+                <svg
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15.6 5.29c-1.1-.1-2.07.71-2.17 1.82L13.18 10H16v2h-3l-.44 5.07a3.986 3.986 0 0 1-4.33 3.63a4 4 0 0 1-3.06-1.87l1.5-1.5c.24.74.9 1.31 1.73 1.38c1.1.1 2.07-.71 2.17-1.82L11 12H8v-2h3.17l.27-3.07c.19-2.2 2.13-3.83 4.33-3.63c1.31.11 2.41.84 3.06 1.87l-1.5 1.5c-.24-.74-.9-1.31-1.73-1.38"
+                  />
+                </svg>
+                <div
+                  class="css-1j58mj5"
+                >
+                  fn2
+                </div>
+              </div>
+            </div>
+            <svg
+              height="200"
+              width="10"
+            >
+              <line
+                class="participant-line"
+                style="stroke-width: 2; transition: stroke 0.2s ease; opacity: 0.5;"
+                x1="5"
+                x2="5"
+                y1="0"
+                y2="200"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 17px; left: 290px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 17px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 45px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 45px; left: 290px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 17px; left: 290px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 17px; left: 510px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 110px; left: 290px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 110px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 138px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 138px; left: 290px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 110px; left: 290px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 110px; left: 510px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>"
+`;
+
+exports[`Sequence Diagram - Snapshot Tests renders if node 8 diagram correctly: if-node-8 1`] = `
+"<div>
+  <div
+    class="css-jqwdy0"
+  >
+    <div
+      class="css-1wrxmfn"
+    >
+      <div
+        class="css-cs29wk"
+      >
+        <i
+          class="fw-bi-fit-screen"
+        />
+      </div>
+    </div>
+    <div
+      class="css-8f9a5x"
+    >
+      <div
+        class="css-1wrxmfn"
+      >
+        <div
+          class="css-cs29wk"
+        >
+          <i
+            class="fw-bi-plus"
+          />
+        </div>
+      </div>
+      <div
+        class="css-1wrxmfn"
+      >
+        <div
+          class="css-cs29wk"
+        >
+          <i
+            class="fw-bi-minus"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="css-pf6ojx"
+    color="var(--vscode-foreground)"
+  >
+    <div
+      class="css-18f0176"
+    >
+      <svg
+        class="css-12q0bj3"
+        style="transform: translate(
+				400px,
+				300px)
+			scale(
+				1
+			);"
+      >
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              >
+                fn1 (true)
+              </textpath>
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              />
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              >
+                fn2 ()
+              </textpath>
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              />
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              >
+                fn2 ()
+              </textpath>
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              />
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              >
+                fn3 ()
+              </textpath>
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              />
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              >
+                fn4 ()
+              </textpath>
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              />
+            </text>
+          </g>
+        </g>
+      </svg>
+      <div
+        class="css-12q0bj3"
+        style="transform: translate(
+				400px,
+				300px)
+			scale(
+				1
+			);"
+      >
+        <div
+          class="node css-nlpftr"
+          style="top: 0px; left: 220px;"
+        >
+          <div
+            class="css-1mdm4mu"
+          >
+            <div
+              class="participant-background css-8musc0"
+            />
+            <div
+              class="css-13cluym"
+            >
+              <div
+                class="participant-head css-31ty19"
+                kind="FUNCTION"
+              >
+                <svg
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15.6 5.29c-1.1-.1-2.07.71-2.17 1.82L13.18 10H16v2h-3l-.44 5.07a3.986 3.986 0 0 1-4.33 3.63a4 4 0 0 1-3.06-1.87l1.5-1.5c.24.74.9 1.31 1.73 1.38c1.1.1 2.07-.71 2.17-1.82L11 12H8v-2h3.17l.27-3.07c.19-2.2 2.13-3.83 4.33-3.63c1.31.11 2.41.84 3.06 1.87l-1.5 1.5c-.24-.74-.9-1.31-1.73-1.38"
+                  />
+                </svg>
+                <div
+                  class="css-1j58mj5"
+                >
+                  fn0
+                </div>
+              </div>
+            </div>
+            <svg
+              height="403"
+              width="10"
+            >
+              <line
+                class="participant-line"
+                style="stroke-width: 2; transition: stroke 0.2s ease; opacity: 0.5;"
+                x1="5"
+                x2="5"
+                y1="0"
+                y2="403"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 0px; left: 440px;"
+        >
+          <div
+            class="css-1mdm4mu"
+          >
+            <div
+              class="participant-background css-8musc0"
+            />
+            <div
+              class="css-13cluym"
+            >
+              <div
+                class="participant-head css-31ty19"
+                kind="FUNCTION"
+              >
+                <svg
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15.6 5.29c-1.1-.1-2.07.71-2.17 1.82L13.18 10H16v2h-3l-.44 5.07a3.986 3.986 0 0 1-4.33 3.63a4 4 0 0 1-3.06-1.87l1.5-1.5c.24.74.9 1.31 1.73 1.38c1.1.1 2.07-.71 2.17-1.82L11 12H8v-2h3.17l.27-3.07c.19-2.2 2.13-3.83 4.33-3.63c1.31.11 2.41.84 3.06 1.87l-1.5 1.5c-.24-.74-.9-1.31-1.73-1.38"
+                  />
+                </svg>
+                <div
+                  class="css-1j58mj5"
+                >
+                  fn1
+                </div>
+              </div>
+            </div>
+            <svg
+              height="403"
+              width="10"
+            >
+              <line
+                class="participant-line"
+                style="stroke-width: 2; transition: stroke 0.2s ease; opacity: 0.5;"
+                x1="5"
+                x2="5"
+                y1="0"
+                y2="403"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 0px; left: 660px;"
+        >
+          <div
+            class="css-1mdm4mu"
+          >
+            <div
+              class="participant-background css-8musc0"
+            />
+            <div
+              class="css-13cluym"
+            >
+              <div
+                class="participant-head css-31ty19"
+                kind="FUNCTION"
+              >
+                <svg
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15.6 5.29c-1.1-.1-2.07.71-2.17 1.82L13.18 10H16v2h-3l-.44 5.07a3.986 3.986 0 0 1-4.33 3.63a4 4 0 0 1-3.06-1.87l1.5-1.5c.24.74.9 1.31 1.73 1.38c1.1.1 2.07-.71 2.17-1.82L11 12H8v-2h3.17l.27-3.07c.19-2.2 2.13-3.83 4.33-3.63c1.31.11 2.41.84 3.06 1.87l-1.5 1.5c-.24-.74-.9-1.31-1.73-1.38"
+                  />
+                </svg>
+                <div
+                  class="css-1j58mj5"
+                >
+                  fn2
+                </div>
+              </div>
+            </div>
+            <svg
+              height="403"
+              width="10"
+            >
+              <line
+                class="participant-line"
+                style="stroke-width: 2; transition: stroke 0.2s ease; opacity: 0.5;"
+                x1="5"
+                x2="5"
+                y1="0"
+                y2="403"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 0px; left: 880px;"
+        >
+          <div
+            class="css-1mdm4mu"
+          >
+            <div
+              class="participant-background css-8musc0"
+            />
+            <div
+              class="css-13cluym"
+            >
+              <div
+                class="participant-head css-31ty19"
+                kind="FUNCTION"
+              >
+                <svg
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15.6 5.29c-1.1-.1-2.07.71-2.17 1.82L13.18 10H16v2h-3l-.44 5.07a3.986 3.986 0 0 1-4.33 3.63a4 4 0 0 1-3.06-1.87l1.5-1.5c.24.74.9 1.31 1.73 1.38c1.1.1 2.07-.71 2.17-1.82L11 12H8v-2h3.17l.27-3.07c.19-2.2 2.13-3.83 4.33-3.63c1.31.11 2.41.84 3.06 1.87l-1.5 1.5c-.24-.74-.9-1.31-1.73-1.38"
+                  />
+                </svg>
+                <div
+                  class="css-1j58mj5"
+                >
+                  fn3
+                </div>
+              </div>
+            </div>
+            <svg
+              height="403"
+              width="10"
+            >
+              <line
+                class="participant-line"
+                style="stroke-width: 2; transition: stroke 0.2s ease; opacity: 0.5;"
+                x1="5"
+                x2="5"
+                y1="0"
+                y2="403"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 0px; left: 1100px;"
+        >
+          <div
+            class="css-1mdm4mu"
+          >
+            <div
+              class="participant-background css-8musc0"
+            />
+            <div
+              class="css-13cluym"
+            >
+              <div
+                class="participant-head css-31ty19"
+                kind="FUNCTION"
+              >
+                <svg
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15.6 5.29c-1.1-.1-2.07.71-2.17 1.82L13.18 10H16v2h-3l-.44 5.07a3.986 3.986 0 0 1-4.33 3.63a4 4 0 0 1-3.06-1.87l1.5-1.5c.24.74.9 1.31 1.73 1.38c1.1.1 2.07-.71 2.17-1.82L11 12H8v-2h3.17l.27-3.07c.19-2.2 2.13-3.83 4.33-3.63c1.31.11 2.41.84 3.06 1.87l-1.5 1.5c-.24-.74-.9-1.31-1.73-1.38"
+                  />
+                </svg>
+                <div
+                  class="css-1j58mj5"
+                >
+                  fn4
+                </div>
+              </div>
+            </div>
+            <svg
+              height="403"
+              width="10"
+            >
+              <line
+                class="participant-line"
+                style="stroke-width: 2; transition: stroke 0.2s ease; opacity: 0.5;"
+                x1="5"
+                x2="5"
+                y1="0"
+                y2="403"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 68px; left: 290px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 68px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 290px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 290px; left: 290px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 68px; left: 290px;"
+        >
+          <div
+            class="css-wyxx3f"
+            height="242"
+            width="20"
+          >
+            <svg
+              height="242"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="242"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 68px; left: 510px;"
+        >
+          <div
+            class="css-wyxx3f"
+            height="242"
+            width="20"
+          >
+            <svg
+              height="242"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="242"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 99px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 99px; left: 730px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 127px; left: 730px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 127px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 99px; left: 510px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 99px; left: 730px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 158px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 158px; left: 730px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 186px; left: 730px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 186px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 158px; left: 510px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 158px; left: 730px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 234px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 234px; left: 950px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 262px; left: 950px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 262px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 234px; left: 510px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 234px; left: 950px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 372px; left: 290px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 372px; left: 1170px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 400px; left: 1170px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 400px; left: 290px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 372px; left: 290px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 372px; left: 1170px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 68px; left: 290px;"
+        >
+          <div
+            class="css-gjz9q8"
+            height="352"
+            width="20"
+          >
+            <svg
+              height="352"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="352"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>"
+`;
+
+exports[`Sequence Diagram - Snapshot Tests renders sample with return diagram correctly: sample-with-return 1`] = `
+"<div>
+  <div
+    class="css-jqwdy0"
+  >
+    <div
+      class="css-1wrxmfn"
+    >
+      <div
+        class="css-cs29wk"
+      >
+        <i
+          class="fw-bi-fit-screen"
+        />
+      </div>
+    </div>
+    <div
+      class="css-8f9a5x"
+    >
+      <div
+        class="css-1wrxmfn"
+      >
+        <div
+          class="css-cs29wk"
+        >
+          <i
+            class="fw-bi-plus"
+          />
+        </div>
+      </div>
+      <div
+        class="css-1wrxmfn"
+      >
+        <div
+          class="css-cs29wk"
+        >
+          <i
+            class="fw-bi-minus"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="css-pf6ojx"
+    color="var(--vscode-foreground)"
+  >
+    <div
+      class="css-18f0176"
+    >
+      <svg
+        class="css-12q0bj3"
+        style="transform: translate(
+				400px,
+				300px)
+			scale(
+				1
+			);"
+      >
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              >
+                get
+              </textpath>
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              />
+            </text>
+          </g>
+        </g>
+      </svg>
+      <div
+        class="css-12q0bj3"
+        style="transform: translate(
+				400px,
+				300px)
+			scale(
+				1
+			);"
+      >
+        <div
+          class="node css-nlpftr"
+          style="top: 0px; left: 220px;"
+        >
+          <div
+            class="css-1mdm4mu"
+          >
+            <div
+              class="participant-background css-8musc0"
+            />
+            <div
+              class="css-13cluym"
+            >
+              <div
+                class="participant-head css-31ty19"
+                kind="FUNCTION"
+              >
+                <svg
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15.6 5.29c-1.1-.1-2.07.71-2.17 1.82L13.18 10H16v2h-3l-.44 5.07a3.986 3.986 0 0 1-4.33 3.63a4 4 0 0 1-3.06-1.87l1.5-1.5c.24.74.9 1.31 1.73 1.38c1.1.1 2.07-.71 2.17-1.82L11 12H8v-2h3.17l.27-3.07c.19-2.2 2.13-3.83 4.33-3.63c1.31.11 2.41.84 3.06 1.87l-1.5 1.5c-.24-.74-.9-1.31-1.73-1.38"
+                  />
+                </svg>
+                <div
+                  class="css-1j58mj5"
+                >
+                  get
+                </div>
+              </div>
+            </div>
+            <svg
+              height="200"
+              width="10"
+            >
+              <line
+                class="participant-line"
+                style="stroke-width: 2; transition: stroke 0.2s ease; opacity: 0.5;"
+                x1="5"
+                x2="5"
+                y1="0"
+                y2="200"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 0px; left: 440px;"
+        >
+          <div
+            class="css-1mdm4mu"
+          >
+            <div
+              class="participant-background css-8musc0"
+            />
+            <div
+              class="css-13cluym"
+            >
+              <div
+                class="participant-head css-474zhv"
+                kind="ENDPOINT"
+              >
+                <svg
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M7 17q-2.075 0-3.537-1.463T2 12t1.463-3.537T7 7h3q.425 0 .713.288T11 8t-.288.713T10 9H7q-1.25 0-2.125.875T4 12t.875 2.125T7 15h3q.425 0 .713.288T11 16t-.288.713T10 17zm2-4q-.425 0-.712-.288T8 12t.288-.712T9 11h6q.425 0 .713.288T16 12t-.288.713T15 13zm5 4q-.425 0-.712-.288T13 16t.288-.712T14 15h3q1.25 0 2.125-.875T20 12t-.875-2.125T17 9h-3q-.425 0-.712-.288T13 8t.288-.712T14 7h3q2.075 0 3.538 1.463T22 12t-1.463 3.538T17 17z"
+                  />
+                </svg>
+              </div>
+              <div
+                class="css-1itbc83"
+              >
+                httpClient
+              </div>
+            </div>
+            <svg
+              height="200"
+              width="10"
+            >
+              <line
+                class="participant-line"
+                style="stroke-width: 2; transition: stroke 0.2s ease; opacity: 0.5;"
+                x1="5"
+                x2="5"
+                y1="0"
+                y2="200"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 68px; left: 290px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 68px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 96px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 96px; left: 290px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 68px; left: 290px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 68px; left: 510px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 68px; left: 290px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>"
+`;
+
+exports[`Sequence Diagram - Snapshot Tests renders while node diagram correctly: while-node 1`] = `
+"<div>
+  <div
+    class="css-jqwdy0"
+  >
+    <div
+      class="css-1wrxmfn"
+    >
+      <div
+        class="css-cs29wk"
+      >
+        <i
+          class="fw-bi-fit-screen"
+        />
+      </div>
+    </div>
+    <div
+      class="css-8f9a5x"
+    >
+      <div
+        class="css-1wrxmfn"
+      >
+        <div
+          class="css-cs29wk"
+        >
+          <i
+            class="fw-bi-plus"
+          />
+        </div>
+      </div>
+      <div
+        class="css-1wrxmfn"
+      >
+        <div
+          class="css-cs29wk"
+        >
+          <i
+            class="fw-bi-minus"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="css-pf6ojx"
+    color="var(--vscode-foreground)"
+  >
+    <div
+      class="css-18f0176"
+    >
+      <svg
+        class="css-12q0bj3"
+        style="transform: translate(
+				400px,
+				300px)
+			scale(
+				1
+			);"
+      >
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              >
+                fn2 (count)
+              </textpath>
+            </text>
+          </g>
+        </g>
+        <g
+        >
+          <g
+            pointer-events="all"
+          >
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="transparent"
+              stroke-width="16"
+            />
+            <path
+              d="M 400 300 L 400 300"
+              fill="none"
+              stroke="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              stroke-width="1.5"
+            />
+            <defs>
+              <marker
+                markerHeight="5"
+                markerWidth="5"
+                orient="auto"
+                refX="7"
+                refY="1.5"
+                viewBox="0 0 3 3"
+              >
+                <polygon
+                  fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+                  points="0,3 0,0 3,1.5"
+                />
+              </marker>
+            </defs>
+            <text
+              dy="-8"
+              fill="var(--vscode-contrastBorder, var(--vscode-button-background))"
+              font-family="monospace"
+              text-anchor="middle"
+              transform=""
+            >
+              <textpath
+                href="#DYNAMIC_ID"
+                startOffset="50%"
+              />
+            </text>
+          </g>
+        </g>
+      </svg>
+      <div
+        class="css-12q0bj3"
+        style="transform: translate(
+				400px,
+				300px)
+			scale(
+				1
+			);"
+      >
+        <div
+          class="node css-nlpftr"
+          style="top: 0px; left: 220px;"
+        >
+          <div
+            class="css-1mdm4mu"
+          >
+            <div
+              class="participant-background css-8musc0"
+            />
+            <div
+              class="css-13cluym"
+            >
+              <div
+                class="participant-head css-31ty19"
+                kind="FUNCTION"
+              >
+                <svg
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15.6 5.29c-1.1-.1-2.07.71-2.17 1.82L13.18 10H16v2h-3l-.44 5.07a3.986 3.986 0 0 1-4.33 3.63a4 4 0 0 1-3.06-1.87l1.5-1.5c.24.74.9 1.31 1.73 1.38c1.1.1 2.07-.71 2.17-1.82L11 12H8v-2h3.17l.27-3.07c.19-2.2 2.13-3.83 4.33-3.63c1.31.11 2.41.84 3.06 1.87l-1.5 1.5c-.24-.74-.9-1.31-1.73-1.38"
+                  />
+                </svg>
+                <div
+                  class="css-1j58mj5"
+                >
+                  fn1
+                </div>
+              </div>
+            </div>
+            <svg
+              height="200"
+              width="10"
+            >
+              <line
+                class="participant-line"
+                style="stroke-width: 2; transition: stroke 0.2s ease; opacity: 0.5;"
+                x1="5"
+                x2="5"
+                y1="0"
+                y2="200"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 0px; left: 440px;"
+        >
+          <div
+            class="css-1mdm4mu"
+          >
+            <div
+              class="participant-background css-8musc0"
+            />
+            <div
+              class="css-13cluym"
+            >
+              <div
+                class="participant-head css-31ty19"
+                kind="FUNCTION"
+              >
+                <svg
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15.6 5.29c-1.1-.1-2.07.71-2.17 1.82L13.18 10H16v2h-3l-.44 5.07a3.986 3.986 0 0 1-4.33 3.63a4 4 0 0 1-3.06-1.87l1.5-1.5c.24.74.9 1.31 1.73 1.38c1.1.1 2.07-.71 2.17-1.82L11 12H8v-2h3.17l.27-3.07c.19-2.2 2.13-3.83 4.33-3.63c1.31.11 2.41.84 3.06 1.87l-1.5 1.5c-.24-.74-.9-1.31-1.73-1.38"
+                  />
+                </svg>
+                <div
+                  class="css-1j58mj5"
+                >
+                  fn2
+                </div>
+              </div>
+            </div>
+            <svg
+              height="200"
+              width="10"
+            >
+              <line
+                class="participant-line"
+                style="stroke-width: 2; transition: stroke 0.2s ease; opacity: 0.5;"
+                x1="5"
+                x2="5"
+                y1="0"
+                y2="200"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 17px; left: 70px;"
+        >
+          <div
+            class="css-1y7h70v"
+            height="3"
+            width="20"
+          >
+            <svg
+              height="3"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="3"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 48px; left: 290px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 48px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 76px; left: 510px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 76px; left: 290px;"
+        >
+          <div
+            class="css-16ivlk6"
+          >
+            <div
+              class="css-vzo25c"
+            >
+              <div
+                class="port css-0"
+                data-name="left"
+              />
+              <div
+                class="port css-0"
+                data-name="right"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 48px; left: 290px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="node css-nlpftr"
+          style="top: 48px; left: 510px;"
+        >
+          <div
+            class="css-1irli4r"
+            height="48"
+            width="20"
+          >
+            <svg
+              height="48"
+              width="20"
+            >
+              <rect
+                fill="var(--vscode-dropdown-border)"
+                height="48"
+                rx="4"
+                stroke-width="1.5"
+                width="20"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>"
+`;

--- a/workspaces/ballerina/sequence-diagram/src/test/jest.env.ts
+++ b/workspaces/ballerina/sequence-diagram/src/test/jest.env.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import '@testing-library/jest-dom';
+
+(globalThis as any).structuredClone = (val: any) => {
+    return JSON.parse(JSON.stringify(val))
+}
+
+(globalThis as any).setImmediate = (globalThis as any).setImmediate || ((fn: any, ...args: any) => globalThis.setTimeout(fn, 0, ...args)) as any;
+
+class MockResizeObserver {
+  observe = jest.fn();
+  unobserve = jest.fn();
+  disconnect = jest.fn();
+}
+
+(globalThis as any).ResizeObserver = MockResizeObserver;
+
+// Mock getBoundingClientRect for canvas elements
+Element.prototype.getBoundingClientRect = jest.fn(() => ({
+  width: 800,
+  height: 600,
+  top: 0,
+  left: 0,
+  bottom: 600,
+  right: 800,
+  x: 0,
+  y: 0,
+  toJSON: jest.fn()
+}));
+
+// Mock canvas context
+HTMLCanvasElement.prototype.getContext = jest.fn(() => ({
+  fillRect: jest.fn(),
+  clearRect: jest.fn(),
+  getImageData: jest.fn(),
+  putImageData: jest.fn(),
+  createImageData: jest.fn(),
+  setTransform: jest.fn(),
+  drawImage: jest.fn(),
+  save: jest.fn(),
+  restore: jest.fn(),
+  beginPath: jest.fn(),
+  moveTo: jest.fn(),
+  lineTo: jest.fn(),
+  closePath: jest.fn(),
+  stroke: jest.fn(),
+  fill: jest.fn(),
+  scale: jest.fn(),
+  rotate: jest.fn(),
+  translate: jest.fn(),
+  measureText: jest.fn(() => ({ width: 10 })),
+  fillStyle: '',
+  strokeStyle: '',
+  globalAlpha: 1,
+})) as any;

--- a/workspaces/ballerina/sequence-diagram/src/test/matchMedia.ts
+++ b/workspaces/ballerina/sequence-diagram/src/test/matchMedia.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation((query) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+    })),
+});
+
+window.HTMLElement.prototype.scrollIntoView = jest.fn()


### PR DESCRIPTION
## Solution
This PR adds snapshot tests for the sequence-diagram package following the same approach used in bi-diagram and component-diagram packages.

### Changes

#### Testing Infrastructure
- Added Jest, ts-jest, and @testing-library dependencies to package.json
- Created `jest.config.js` with proper module resolution for workspace packages (@wso2/ui-toolkit, @wso2/ballerina-core, @wso2/syntax-tree)
- Created `babel.config.js` for transpiling TypeScript and React code
- Added test setup files (`jest.env.ts` and `matchMedia.ts`) to mock browser APIs (ResizeObserver, canvas context, getBoundingClientRect)

#### Test Implementation
Created `src/test/Diagram.test.tsx` with 10 comprehensive snapshot tests covering:
- Endpoint call diagrams
- Function call diagrams (3 variations)
- If node diagrams (4 variations)
- While node diagrams
- Sample with return statements (using the sample data from issue #1394)

The test implementation:
- Uses React Testing Library to render the Diagram component
- Waits for the progress ring to be removed, indicating the diagram is fully rendered
- Sanitizes dynamic IDs and non-deterministic attributes (marker-end, id, data-linkid, href) before snapshot comparison
- Generates DOM snapshots stored in `src/test/__snapshots__/Diagram.test.tsx.snap`

#### Test Data
Added `sample-with-return.json` test data file from the issue description, which includes:
- HTTP client endpoint interactions
- Function with multiple return statements
- ViewState information for rendering

### Results
✅ All 10 tests pass successfully  
✅ Tests run in ~13.6 seconds  
✅ Snapshots properly generated (197KB snapshot file)  
✅ Test scripts added: `test`, `test:watch`, `test:updateSnapshots`

### Example Test Output
```
PASS src/test/Diagram.test.tsx (12.926 s)
  Sequence Diagram - Snapshot Tests
    ✓ renders endpoint call diagram correctly (1267 ms)
    ✓ renders function call 1 diagram correctly (1049 ms)
    ✓ renders function call 2 diagram correctly (1052 ms)
    ✓ renders function call 3 diagram correctly (1058 ms)
    ✓ renders if node 1 diagram correctly (1158 ms)
    ✓ renders if node 4 diagram correctly (1085 ms)
    ✓ renders if node 5 diagram correctly (1152 ms)
    ✓ renders if node 8 diagram correctly (1141 ms)
    ✓ renders while node diagram correctly (1079 ms)
    ✓ renders sample with return diagram correctly (1027 ms)

Test Suites: 1 passed, 1 total
Tests:       10 passed, 10 total
Snapshots:   10 passed, 10 total
```

This implementation ensures consistency with the existing test patterns in bi-diagram and component-diagram packages, enabling regression testing for the sequence-diagram component.

Fixes
- https://github.com/wso2/product-ballerina-integrator/issues/1394