### PR TITLE
fix create new type form overlap and alignment issue in expression ed…

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/components/TextElement.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/components/TextElement.tsx
@@ -25,6 +25,7 @@ import { FOCUS_MARKER } from "../constants";
 export const TextElement = (props: {
     element: ExpressionModel;
     expressionModel: ExpressionModel[];
+    sx?: React.CSSProperties;
     index: number;
     onTextFocus?: (e: React.FocusEvent<HTMLSpanElement>) => void;
     onExpressionChange?: (updatedExpressionModel: ExpressionModel[], cursorPosition?: number, lastTypedText?: string) => void;
@@ -170,7 +171,10 @@ export const TextElement = (props: {
             onMouseUp={handleMouseUp}
             onKeyDown={handleKeyDown}
             contentEditable
-            suppressContentEditableWarning>{props.element.value}
+            suppressContentEditableWarning
+            style={props.sx}
+            >
+                {props.element.value}
         </InvisibleSpan>
     );
 };

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/components/TokenizedExpression.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/components/TokenizedExpression.tsx
@@ -78,6 +78,9 @@ export const TokenizedExpression = (props: TokenizedExpressionProps) => {
         expressionModel.length === 0 ? (
             <TextElement
                 key="empty"
+                sx={{
+                    display: "inline-block"
+                }}
                 element={{ id: "empty", value: "", isToken: false, length: 0 } as ExpressionModel}
                 expressionModel={[]}
                 index={0}
@@ -109,6 +112,9 @@ export const TokenizedExpression = (props: TokenizedExpressionProps) => {
                             onTextFocus={props.onTextFocus}
                             index={index}
                             onExpressionChange={onExpressionChange}
+                            sx={{
+                                display: expressionModel.length === 1 ? 'inline-block' : 'inline',
+                            }}
                         />;
                     }
                 })}

--- a/workspaces/ballerina/ballerina-visualizer/src/components/Popup/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/components/Popup/index.tsx
@@ -34,7 +34,7 @@ const PopupContentContainer = styled.div`
     left: 0;
     width: 100%;
     height: 100%;
-    z-index: 30000;
+    z-index: 2001;
     display: flex;
     justify-content: center;
     align-items: center;


### PR DESCRIPTION
## Purpose
The **Type Helper** form was opening **behind** the **"Create New Variable"** form due to incorrect z-index values. Additionally, there were **alignment issues** in **expression mode** where text elements were not displaying properly.

Resolves: https://github.com/wso2/product-ballerina-integrator/issues/1669

## Goals
- Ensure the **Type Helper** form always appears **above** the "Create New Variable" form.
- Fix **text alignment issues** in **expression mode** by applying appropriate display properties.

## Approach
- Updated **z-index values** of overlapping elements to ensure the correct stacking order.
- Corrected **display properties** (`inline`, `inline-block`) of text elements to achieve proper alignment in expression mode.
