### PR TITLE
fix delete key behavior in expression editor

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/ChipExpressionBaseComponent.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/ChipExpressionBaseComponent.tsx
@@ -39,7 +39,7 @@ import {
 } from "./utils";
 import { CompletionItem, FnSignatureDocumentation, HelperPaneHeight } from "@wso2/ui-toolkit";
 import { useFormContext } from "../../../../context";
-import { DATA_ELEMENT_ID_ATTRIBUTE, FOCUS_MARKER, ARROW_LEFT_MARKER, ARROW_RIGHT_MARKER, BACKSPACE_MARKER, COMPLETIONS_MARKER, HELPER_MARKER } from "./constants";
+import { DATA_ELEMENT_ID_ATTRIBUTE, FOCUS_MARKER, ARROW_LEFT_MARKER, ARROW_RIGHT_MARKER, BACKSPACE_MARKER, COMPLETIONS_MARKER, HELPER_MARKER, DELETE_MARKER } from "./constants";
 import { LineRange } from "@wso2/ballerina-core/lib/interfaces/common";
 
 export type ChipExpressionBaseComponentProps = {
@@ -162,10 +162,12 @@ export const ChipExpressionBaseComponent = (props: ChipExpressionBaseComponentPr
         cursorPosition: number,
         lastTypedText?: string
     ) => {
+        const updatedValue = getTextValueFromExpressionModel(updatedModel);
+
         // Calculate cursor movement
         const cursorPositionBeforeUpdate = getAbsoluteCaretPositionFromModel(expressionModel);
         const cursorPositionAfterUpdate = getAbsoluteCaretPositionFromModel(updatedModel);
-        const cursorDelta = cursorPositionAfterUpdate - cursorPositionBeforeUpdate;
+        const cursorDelta = updatedValue.length - props.value.length;
 
         // Update tokens based on cursor movement
         const previousFullText = getTextValueFromExpressionModel(expressionModel);
@@ -178,8 +180,6 @@ export const ChipExpressionBaseComponent = (props: ChipExpressionBaseComponentPr
             pendingForceSetTokensRef.current = updatedTokens;
         }
 
-        // Get updated values
-        const updatedValue = getTextValueFromExpressionModel(updatedModel);
         const wordBeforeCursor = getWordBeforeCursor(updatedModel);
         const valueBeforeCursor = updatedValue.substring(0, cursorPositionAfterUpdate);
 
@@ -264,7 +264,8 @@ export const ChipExpressionBaseComponent = (props: ChipExpressionBaseComponentPr
 
         const isSpecialKey = lastTypedText === BACKSPACE_MARKER
             || lastTypedText === COMPLETIONS_MARKER
-            || lastTypedText === HELPER_MARKER;
+            || lastTypedText === HELPER_MARKER
+            || lastTypedText === DELETE_MARKER;
 
         const endsWithTriggerChar = lastTypedText.endsWith('+')
             || lastTypedText.endsWith(' ')

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/utils.ts
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/utils.ts
@@ -683,9 +683,6 @@ const handleBackspace = (
     if (caretOffset === 0) {
         handleBackspaceAtStart(e, expressionModel, index, onExpressionChange);
     }
-    // else {
-    //     handleBackspaceInMiddle(e, expressionModel, index, caretOffset);
-    // }
 };
 
 const handleBackspaceAtStart = (
@@ -754,24 +751,6 @@ const mergeWithPreviousElement = (
     onExpressionChange?.(newExpressionModel, newCursorPosition, BACKSPACE_MARKER);
 };
 
-// const handleBackspaceInMiddle = (
-//     e: React.KeyboardEvent<HTMLSpanElement>,
-//     expressionModel: ExpressionModel[],
-//     index: number,
-//     caretOffset: number
-// ) => {
-//     const hasPreviousParameterToken = 
-//         caretOffset === 1 &&
-//         index - 1 >= 0 &&
-//         expressionModel[index - 1].isToken &&
-//         expressionModel[index - 1].type === 'parameter';
-
-//     if (hasPreviousParameterToken) {
-//         e.preventDefault();
-//         e.stopPropagation();
-//     }
-// };
-
 const handleDelete = (
     e: React.KeyboardEvent<HTMLSpanElement>,
     expressionModel: ExpressionModel[],
@@ -782,50 +761,69 @@ const handleDelete = (
 ) => {
     if (caretOffset !== textLength) return;
 
+    e.preventDefault();
+    e.stopPropagation();
+
     const currentElement = expressionModel[index];
     if (!currentElement || index === expressionModel.length - 1) return;
 
+    let newExpressionModel = [...expressionModel];
+    const tokensToRemove: number[] = [];
+
+    // Scan forward to find first non-token or collect all tokens
     for (let i = index + 1; i < expressionModel.length; i++) {
-        if (!expressionModel[i].isToken) {
-            mergeWithNextElement(expressionModel, index, i, currentElement, onExpressionChange);
+        if (expressionModel[i].isToken) {
+            tokensToRemove.push(i);
+        } else {
+            deleteFirstCharFromNextElement(
+                expressionModel,
+                index,
+                i,
+                tokensToRemove,
+                onExpressionChange
+            );
             return;
         }
     }
+
+    // If we only found tokens, remove them
+    if (tokensToRemove.length > 0) {
+        newExpressionModel = newExpressionModel.filter(
+            (_, idx) => !tokensToRemove.includes(idx)
+        );
+        const newCursorPosition = getAbsoluteCaretPositionFromModel(newExpressionModel);
+        onExpressionChange?.(newExpressionModel, newCursorPosition, DELETE_MARKER);
+    }
 };
 
-const mergeWithNextElement = (
+const deleteFirstCharFromNextElement = (
     expressionModel: ExpressionModel[],
     currentIndex: number,
     nextIndex: number,
-    currentElement: ExpressionModel,
+    tokensToRemove: number[],
     onExpressionChange?: (updatedExpressionModel: ExpressionModel[], cursorPosition?: number, lastTypedText?: string) => void
 ) => {
+    const currentElement = expressionModel[currentIndex];
     const nextElement = expressionModel[nextIndex];
-    const updatedValue = currentElement.value + nextElement.value.slice(1);
+    const updatedNextValue = nextElement.value.slice(1);
+    const shouldRemoveNext = updatedNextValue.length === 0;
 
-    const updatedModel = expressionModel.map((el, idx) => {
-        if (idx === currentIndex) {
-            return {
-                ...currentElement,
-                value: updatedValue,
-                length: updatedValue.length,
-                isFocused: true,
-                focusOffset: currentElement.value.length
-            };
-        } else if (idx === nextIndex) {
-            return {
-                ...nextElement,
-                value: nextElement.value.slice(1),
-                length: nextElement.value.length - 1,
-                isFocused: false,
-                focusOffset: undefined
-            };
-        }
-        return el;
-    });
+    const newExpressionModel = expressionModel
+        .map((el, idx) => {
+            if (idx === currentIndex) {
+                return { ...el, isFocused: true, focusOffset: el.length };
+            } else if (idx === nextIndex && !shouldRemoveNext) {
+                return { ...el, value: updatedNextValue, length: updatedNextValue.length };
+            }
+            return el;
+        })
+        .filter((_, idx) => {
+            if (idx === nextIndex) return !shouldRemoveNext;
+            return !tokensToRemove.includes(idx);
+        });
 
-    const newCursorPosition = getAbsoluteCaretPositionFromModel(updatedModel);
-    onExpressionChange?.(updatedModel, newCursorPosition, DELETE_MARKER);
+    const newCursorPosition = getAbsoluteCaretPositionFromModel(newExpressionModel);
+    onExpressionChange?.(newExpressionModel, newCursorPosition, DELETE_MARKER);
 };
 
 const handleArrowRight = (


### PR DESCRIPTION
## Purpose
> The current implementation of the **delete event** in the Expression Editor does not fully align with the standard behavior of the Delete key. This results in inconsistent deletion of characters, tokens, or elements, leading to a non-intuitive user experience during expression editing.  

Resolves: [wso2/product-ballerina-integrator#1687](https://github.com/wso2/product-ballerina-integrator/issues/1687)

---

## Goals
> The goal of this fix is to make the **delete event handling** consistent with the standard Delete key behavior found in typical text editors. This ensures that deleting elements in the Expression Editor behaves predictably and aligns with user expectations.

---

## Approach
> The `keydown` handler for the Delete key was updated to:
> - Correctly identify and remove the character or token **after** the cursor position.  
> - Maintain the cursor position after deletion to provide a smooth editing experience.  
> - Ensure consistent behavior when deleting within or across expression chips.  
> - Allow users to **select text and delete them** using the standard Delete key.  
>
> This fix makes the editor’s deletion logic mirror standard text input behavior, improving usability and consistency.
