### PR TITLE
Fix styling to ensure knowledge base form field spans full width of side panel

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/ActionExpressionEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/ActionExpressionEditor.tsx
@@ -26,6 +26,7 @@ const Row = styled.div`
     display: flex;
     flex-direction: column;
     margin: 0;
+    width: 100%;
 `;
 
 const actionButtonStyles = {


### PR DESCRIPTION
## Purpose

Fixes the issue where the knowledge base form field did not span the full width of the side panel.

Before:
<img width="415" height="212" alt="image" src="https://github.com/user-attachments/assets/524f070b-e5d2-4be9-8c8d-45bca6d16fc8" />

After:
<img width="436" height="219" alt="image" src="https://github.com/user-attachments/assets/85215357-adc6-4782-b253-bec130d5b6ba" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enhanced the action expression editor layout by expanding the container to full width for improved visual presentation and space utilization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->