### PR TITLE
Fix: Prevent side panel closure after Model provider creation

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
@@ -1263,7 +1263,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                 isFunctionNodeUpdate: dataMapperMode !== DataMapperDisplayMode.NONE,
             })
             .then(async (response) => {
-                console.log(">>> Source code update response", response);
                 if (response.artifacts.length > 0) {
                     if (updatedNode?.codedata?.symbol === GET_DEFAULT_MODEL_PROVIDER
                         || (updatedNode?.codedata?.node === "AGENT_CALL" && updatedNode?.properties?.model?.value === "")) {


### PR DESCRIPTION
## Purpose

Fixes an issue where the side panel would incorrectly close after a user creates a new connection (e.g., for Model Providers, Vector Stores).

Previously, creating a connection closed the panel, interrupting the workflow. This PR ensures that after a successful connection creation, the user is correctly navigated back to the connection list within the side panel.

Fixed: https://github.com/wso2/product-ballerina-integrator/issues/1721


https://github.com/user-attachments/assets/089c62af-7a3e-4f48-a660-0e2d5da69ff8



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined artifact update handling in flow diagram creation workflows so multiple creation handlers can run sequentially for more consistent processing.
  * Removed a debug console log related to artifact state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->