### PR TITLE
fix expression overflow issue for large expressions

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/components/AutoExpandingEditableDiv.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/components/AutoExpandingEditableDiv.tsx
@@ -258,7 +258,7 @@ export const AutoExpandingEditableDiv = (props: AutoExpandingEditableDivProps) =
                 style={{
                     ...style,
                     flex: 1,
-                    maxHeight: props.isInExpandedMode ? `${EXPANDED_EDITOR_HEIGHT}px` : '200px',
+                    maxHeight: props.isInExpandedMode ? `${EXPANDED_EDITOR_HEIGHT}px` : '100px',
                     ...(props.isInExpandedMode && {
                         height: `${EXPANDED_EDITOR_HEIGHT}px`,
                         minHeight: `${EXPANDED_EDITOR_HEIGHT}px`,

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/styles.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/styles.tsx
@@ -35,6 +35,7 @@ export const ChipEditorField = styled.div`
     border: 1px solid var(--vscode-dropdown-border);
     word-break: break-all;
     position: relative;
+    overflow: auto;
 
     &:focus {
         outline: 1px solid var(--vscode-focusBorder, #0078d4);


### PR DESCRIPTION
## Purpose
Previously, large expressions in the **Expression Editor** caused layout overflow issues, making parts of the expression overflows the field
This created usability problems when editing or reviewing long expressions.  

This PR fixes the overflow issue by ensuring the editor properly handles large expressions with scrollable content.

---

## Goals
- Prevent layout overflow when displaying large expressions.  
- Ensure the full expression remains accessible and readable within the editor.  
- Improve overall usability and visual consistency of the Expression Editor.

---

## Approach
- Added `overflow: auto` to the expression container to enable scrolling when expressions exceed the visible area.  
- Adjusted the `max-height` property to better accommodate large expressions while maintaining layout balance.  



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced the default visible height of the expression editor in collapsed mode.
  * Enabled scrolling within the chip editor container for better content accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->