### PR TITLE
Update README markdown preview in overview page to wrap long text

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/Overview/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/Overview/index.tsx
@@ -206,6 +206,21 @@ const ReadmeButtonContainer = styled.div`
 const ReadmeContent = styled.div`
     margin-top: 16px;
     text-wrap: pretty;
+    overflow-wrap: break-word;
+
+    p, li, td, th, blockquote {
+        overflow-wrap: break-word;
+    }
+
+    pre {
+        overflow-x: auto;
+        overflow-wrap: break-word;
+    }
+    
+    code {
+        white-space: pre-wrap;
+        overflow-wrap: break-word;
+    }
 `;
 
 const TitleContainer = styled.div`


### PR DESCRIPTION
## Purpose

Fixes https://github.com/wso2/product-ballerina-integrator/issues/1734

This PR adds word wrapping for the markdown content inside the README in the overview page.

https://github.com/user-attachments/assets/ef3a978c-cc44-403f-ab37-9790e4f206a6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enabled overflow-wrapping for README content and common block elements (paragraphs, list items, table cells, block quotes).
  * Configured pre blocks for horizontal scrolling on long lines while preserving wrapping behavior.
  * Enforced pre-wrap whitespace handling and word wrapping within inline code blocks for consistent display.
  * Updated Overview content presentation for improved visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->