### PR TITLE
Fix tokens not deleting when updated value is an empty string

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/ChipExpressionBaseComponent.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/ChipExpressionBaseComponent.tsx
@@ -155,7 +155,7 @@ export const ChipExpressionBaseComponent = (props: ChipExpressionBaseComponentPr
     };
 
     useEffect(() => {
-        if (!props.value) return;
+        if (props.value === undefined || props.value === null) return;
         fetchInitialTokens(props.value);
     }, [props.value]);
 


### PR DESCRIPTION
## Purpose
This PR fixes an intermittent issue where **expression token chips** were sometimes **not deletable** in the UI.  
The issue occurred because when the expression value became an **empty string (`""`)**, the `expressionModel` was not being recreated, leading to a desynchronization between the UI tokens and the underlying model.  

**Resolves:** https://github.com/wso2/product-ballerina-integrator/issues/1747

---

## Goals
- Ensure that expression token chips are **consistently deletable**, even when the expression value becomes an empty string.  
- Prevent UI and model desynchronization when the expression value updates to an empty state.  
- Improve reliability and consistency of the expression editor’s behavior.

---

## Approach
- Updated the `useEffect` condition to handle empty string values correctly.  
- Previously, the effect was skipped when `props.value` was falsy (which included empty strings).  
- Modified the check to explicitly skip only `undefined` or `null` values, ensuring that empty strings trigger the model recreation as intended.  



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed initial token loading behavior for empty expressions in the expression editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->