### PR TITLE
Update chat agent creation to include agent in service init only for Ballerina U13

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/AIChatAgent/AIChatAgentWizard.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/AIChatAgent/AIChatAgentWizard.tsx
@@ -172,8 +172,13 @@ export function AIChatAgentWizard(props: AIChatAgentWizardProps) {
             await rpcClient.getBIDiagramRpcClient().getSourceCode({ filePath: projectPath.current, flowNode: modelNodeTemplate });
 
             // hack: Generate agent at module level for Ballerina versions under 2201.13.0
-            const response = await rpcClient.getLangClientRpcClient().getBallerinaVersion();
-            const ballerinaVersion = response.version;
+            let ballerinaVersion: string | undefined;
+            try {
+                const versionResponse = await rpcClient.getLangClientRpcClient().getBallerinaVersion();
+                ballerinaVersion = versionResponse?.version;
+            } catch (error) {
+                console.warn("Unable to resolve Ballerina version; falling back to legacy agent generation.", error);
+            }
 
             // Execute for versions under 2201.13.0, or if version cannot be determined (safety fallback)
             const executeForLegacyVersion = !ballerinaVersion || (() => {


### PR DESCRIPTION
## Purpose

Related to https://github.com/wso2/product-integrator/issues/360

Due to the above issue, program execution fails when agents are defined at service init and use tools. This issue is only observed in Ballerina U12. This PR adds a temporary fix, so that if users use U12, we generate agent at module level and if they use U13 or above we generate the agent in service init.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI Chat Agent Wizard now supports legacy Ballerina setups (pre-2201.13.0 or when version is unknown). The wizard detects compatibility, locates existing agent definitions if present, preserves and applies system prompts, model selection, tools and variables, and generates module-level agents as needed while keeping standard behavior for newer versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->