### PR TITLE
Fix: Update js-yaml to resolve CVE-2025-64718

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -80,8 +80,8 @@ importers:
         specifier: ^0.4.4
         version: 0.4.4
       js-yaml:
-        specifier: ~4.1.0
-        version: 4.1.0
+        specifier: ~4.1.1
+        version: 4.1.1
       json-schema:
         specifier: 0.4.0
         version: 0.4.0
@@ -229,8 +229,8 @@ importers:
         specifier: workspace:*
         version: link:../../common-libs/ui-toolkit
       js-yaml:
-        specifier: ~4.1.0
-        version: 4.1.0
+        specifier: ~4.1.1
+        version: 4.1.1
       lodash:
         specifier: ~4.17.21
         version: 4.17.21
@@ -616,8 +616,8 @@ importers:
         specifier: ^0.4.5
         version: 0.4.5
       js-yaml:
-        specifier: ^4.1.0
-        version: 4.1.0
+        specifier: ^4.1.1
+        version: 4.1.1
       keytar:
         specifier: ^7.9.0
         version: 7.9.0
@@ -2633,8 +2633,8 @@ importers:
         specifier: ^18.2.1
         version: 18.7.0
       js-yaml:
-        specifier: ^4.1.0
-        version: 4.1.0
+        specifier: ^4.1.1
+        version: 4.1.1
       jschardet:
         specifier: ^3.0.0
         version: 3.1.4
@@ -2763,8 +2763,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0
       js-yaml:
-        specifier: ^4.1.0
-        version: 4.1.0
+        specifier: ^4.1.1
+        version: 4.1.1
       lodash.debounce:
         specifier: ~4.0.8
         version: 4.0.8
@@ -4264,8 +4264,8 @@ importers:
         specifier: ^18.2.1
         version: 18.7.0
       js-yaml:
-        specifier: ^4.1.0
-        version: 4.1.0
+        specifier: ^4.1.1
+        version: 4.1.1
       jschardet:
         specifier: ^3.1.4
         version: 3.1.4
@@ -4394,8 +4394,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0
       js-yaml:
-        specifier: ^4.1.0
-        version: 4.1.0
+        specifier: ^4.1.1
+        version: 4.1.1
       lodash.debounce:
         specifier: ~4.0.8
         version: 4.0.8
@@ -16366,6 +16366,10 @@ packages:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
 
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
   jsbn@0.1.1:
     resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
 
@@ -23047,13 +23051,13 @@ snapshots:
     dependencies:
       '@jsdevtools/ono': 7.1.3
       '@types/json-schema': 7.0.15
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
 
   '@apidevtools/json-schema-ref-parser@12.0.2':
     dependencies:
       '@jsdevtools/ono': 7.1.3
       '@types/json-schema': 7.0.15
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
 
   '@aw-web-design/x-default-browser@1.4.126':
     dependencies:
@@ -26015,7 +26019,7 @@ snapshots:
       globals: 13.24.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       minimatch: 3.1.2
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -26029,7 +26033,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       minimatch: 3.1.2
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -39875,7 +39879,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@5.8.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -39885,7 +39889,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.8.3
@@ -41357,7 +41361,7 @@ snapshots:
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
@@ -44569,7 +44573,10 @@ snapshots:
       pretty-format: 25.5.0
       throat: 5.0.0
     transitivePeerDependencies:
+      - bufferutil
+      - canvas
       - supports-color
+      - utf-8-validate
 
   jest-leak-detector@25.5.0:
     dependencies:
@@ -45136,6 +45143,10 @@ snapshots:
       esprima: 2.7.3
 
   js-yaml@4.1.0:
+    dependencies:
+      argparse: 2.0.1
+
+  js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
 
@@ -46850,7 +46861,7 @@ snapshots:
       find-up: 5.0.0
       glob: 8.1.0
       he: 1.2.0
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       log-symbols: 4.1.0
       minimatch: 5.1.6
       ms: 2.1.3
@@ -46873,7 +46884,7 @@ snapshots:
       glob: 10.4.5
       he: 1.2.0
       is-path-inside: 3.0.3
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       log-symbols: 4.1.0
       minimatch: 9.0.5
       ms: 2.1.3
@@ -48703,7 +48714,7 @@ snapshots:
   rc-config-loader@4.1.3:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       json5: 2.2.3
       require-from-string: 2.0.2
     transitivePeerDependencies:
@@ -51324,7 +51335,7 @@ snapshots:
       '@swaggerexpert/cookie': 2.0.2
       deepmerge: 4.3.1
       fast-json-patch: 3.1.1
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       neotraverse: 0.6.18
       node-abort-controller: 3.1.1
       node-fetch-commonjs: 3.3.2
@@ -52952,7 +52963,7 @@ snapshots:
       glob: 10.4.5
       got: 13.0.0
       hpagent: 1.2.0
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       mocha: 10.8.2
       monaco-page-objects: 3.14.1(selenium-webdriver@4.38.0)(typescript@5.8.3)
       sanitize-filename: 1.6.3
@@ -52983,7 +52994,7 @@ snapshots:
       glob: 11.0.3
       got: 14.4.7
       hpagent: 1.2.0
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       mocha: 11.7.5
       sanitize-filename: 1.6.3
       selenium-webdriver: 4.38.0

--- a/workspaces/api-designer/api-designer-extension/package.json
+++ b/workspaces/api-designer/api-designer-extension/package.json
@@ -136,6 +136,6 @@
     "cors-anywhere": "^0.4.4",
     "@apidevtools/json-schema-ref-parser": "11.6.1",
     "adm-zip": "~0.5.14",
-    "js-yaml": "~4.1.0"
+    "js-yaml": "~4.1.1"
   }
 }

--- a/workspaces/api-designer/api-designer-visualizer/package.json
+++ b/workspaces/api-designer/api-designer-visualizer/package.json
@@ -26,7 +26,7 @@
     "@wso2/font-wso2-vscode": "workspace:*",
     "react-dom": "18.2.0",
     "react-markdown": "~9.0.1",
-    "js-yaml": "~4.1.0",
+    "js-yaml": "~4.1.1",
     "process": "~0.11.10",
     "path": "~0.12.7",
     "@hookform/resolvers": "~3.3.4",

--- a/workspaces/ballerina/ballerina-extension/package.json
+++ b/workspaces/ballerina/ballerina-extension/package.json
@@ -1256,7 +1256,7 @@
         "decache": "^4.6.2",
         "express": "^4.18.2",
         "istanbul": "^0.4.5",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.1.1",
         "jwt-decode": "^3.1.2",
         "keytar": "^7.9.0",
         "kill-port": "2.0.1",

--- a/workspaces/choreo/choreo-extension/package.json
+++ b/workspaces/choreo/choreo-extension/package.json
@@ -224,7 +224,7 @@
     "byline": "^5.0.0",
     "dotenv": "^16.0.3",
     "file-type": "^18.2.1",
-    "js-yaml": "^4.1.0",
+    "js-yaml": "^4.1.1",
     "yaml": "^2.6.0",
     "jschardet": "^3.0.0",
     "vscode-messenger": "^0.5.1",

--- a/workspaces/choreo/choreo-webviews/package.json
+++ b/workspaces/choreo/choreo-webviews/package.json
@@ -40,7 +40,7 @@
     "remark-gfm": "^4.0.1",
     "prism-react-renderer": "^2.4.1",
     "lodash.debounce": "~4.0.8",
-    "js-yaml": "^4.1.0"
+    "js-yaml": "^4.1.1"
   },
   "devDependencies": {
     "copyfiles": "~2.4.1",

--- a/workspaces/wso2-platform/wso2-platform-extension/package.json
+++ b/workspaces/wso2-platform/wso2-platform-extension/package.json
@@ -247,7 +247,7 @@
     "byline": "^5.0.0",
     "dotenv": "^16.0.3",
     "file-type": "^18.2.1",
-    "js-yaml": "^4.1.0",
+    "js-yaml": "^4.1.1",
     "yaml": "^2.8.0",
     "jschardet": "^3.1.4",
     "vscode-messenger": "^0.5.1",

--- a/workspaces/wso2-platform/wso2-platform-webviews/package.json
+++ b/workspaces/wso2-platform/wso2-platform-webviews/package.json
@@ -39,7 +39,7 @@
     "remark-gfm": "^4.0.1",
     "prism-react-renderer": "^2.4.1",
     "lodash.debounce": "~4.0.8",
-    "js-yaml": "^4.1.0"
+    "js-yaml": "^4.1.1"
   },
   "devDependencies": {
     "copyfiles": "~2.4.1",


### PR DESCRIPTION
## Purpose

Fixes the Medium severity security vulnerability (**CVE-2025-64718**) detected in the `js-yaml` dependency.

This update bumps the package version in `pnpm-lock.yaml` to the recommended fixed version, **`4.1.1`**.

## Changes

* Updates `js-yaml` version constraint.
* Syncs `pnpm-lock.yaml` file.

Fixed: https://github.com/wso2/product-ballerina-integrator/issues/1886