### PR TITLE
Fix helper pane overflow issue in popup

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/CodeUtils.ts
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/CodeUtils.ts
@@ -264,9 +264,9 @@ export const buildOnFocusListner = (onTrigger: (cursor: CursorInfo) => void) => 
                 let relativeLeft = coords.left - editorRect.left;
 
                 const HELPER_PANE_WIDTH = 300;
-                const viewportWidth = window.innerWidth;
-                const absoluteLeft = coords.left;
-                const overflow = absoluteLeft + HELPER_PANE_WIDTH - viewportWidth;
+                const editorWidth = editorRect.width;
+                const relativeRight = relativeLeft + HELPER_PANE_WIDTH;
+                const overflow = relativeRight - editorWidth;
 
                 if (overflow > 0) {
                     relativeLeft -= overflow;
@@ -302,9 +302,9 @@ export const buildOnSelectionChange = (onTrigger: (cursor: CursorInfo) => void) 
             let relativeLeft = coords.left - editorRect.left;
 
             const HELPER_PANE_WIDTH = 300;
-            const viewportWidth = window.innerWidth;
-            const absoluteLeft = coords.left;
-            const overflow = absoluteLeft + HELPER_PANE_WIDTH - viewportWidth;
+            const editorWidth = editorRect.width;
+            const relativeRight = relativeLeft + HELPER_PANE_WIDTH;
+            const overflow = relativeRight - editorWidth;
 
             if (overflow > 0) {
                 relativeLeft -= overflow;
@@ -367,9 +367,9 @@ export const buildOnChangeListner = (onTrigeer: (newValue: string, cursor: Curso
             let relativeLeft = coords.left - editorRect.left;
 
             const HELPER_PANE_WIDTH = 300;
-            const viewportWidth = window.innerWidth;
-            const absoluteLeft = coords.left;
-            const overflow = absoluteLeft + HELPER_PANE_WIDTH - viewportWidth;
+            const editorWidth = editorRect.width;
+            const relativeRight = relativeLeft + HELPER_PANE_WIDTH;
+            const overflow = relativeRight - editorWidth;
 
             if (overflow > 0) {
                 relativeLeft -= overflow;


### PR DESCRIPTION
## Purpose
This PR resolves a UI overflow issue in the Expression Editor where the helper pane extends outside the editor’s popup container.  
Previously, the helper pane position was calculated relative to the **window**, causing it to overflow when the editor was rendered inside a constrained popup.  
This fix ensures the helper pane remains fully visible within the editor boundary.

_Resolves: https://github.com/wso2/product-ballerina-integrator/issues/1890

---

## Goals
- Prevent the helper pane from overflowing outside the Expression Editor popup.  
- Ensure the helper pane repositions correctly using the **editor container boundaries**, not the global window.  
- Improve usability and consistency when the editor is used inside popups or confined layouts.

---

## Approach
- Updated the helper pane positioning logic to reference the **Expression Editor container’s bounding rectangle** instead of `window.innerWidth`.  
- Calculated overflow relative to the editor container and shifted the helper pane left if it exceeded the available space.  
- Verified the behavior across different popup sizes to ensure the pane always stays within the visible editor region.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-project Ballerina workspace support with workspace-level overview and management
  * Record configuration modal editor for enhanced form field configuration
  * CodeMirror-based expression editor with interactive tokenized chip support
  * Real-time dependency resolution progress tracking and visual feedback

* **Chores**
  * Updated js-yaml dependency version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->