### PR TITLE
Revert: Temporarily disable fix for Package Overview loading issue

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/stateMachine.ts
+++ b/workspaces/ballerina/ballerina-extension/src/stateMachine.ts
@@ -61,15 +61,6 @@ const stateMachine = createMachine<MachineContext>(
         on: {
             RESET_TO_EXTENSION_READY: {
                 target: "extensionReady",
-                actions: assign({
-                    documentUri: undefined,
-                    position: undefined,
-                    identifier: undefined,
-                    projectPath: undefined,
-                    scope: undefined,
-                    org: undefined,
-                    package: undefined
-                })
             },
             UPDATE_PROJECT_STRUCTURE: {
                 actions: [
@@ -223,7 +214,6 @@ const stateMachine = createMachine<MachineContext>(
                             package: (context, event) => event.viewLocation?.package,
                             view: (context, event) => event.viewLocation.view,
                             documentUri: (context, event) => event.viewLocation.documentUri,
-                            projectPath: (context, event) => event.viewLocation?.projectPath,
                             position: (context, event) => event.viewLocation.position,
                             identifier: (context, event) => event.viewLocation.identifier,
                             serviceType: (context, event) => event.viewLocation.serviceType,
@@ -584,8 +574,8 @@ const stateMachine = createMachine<MachineContext>(
                 if (!selectedEntry?.location.view) {
                     return resolve(
                         context.workspacePath
-                            ? { view: MACHINE_VIEW.WorkspaceOverview }
-                            : { view: MACHINE_VIEW.PackageOverview, documentUri: context.documentUri }
+                        ? { view: MACHINE_VIEW.WorkspaceOverview }
+                        : { view: MACHINE_VIEW.PackageOverview, documentUri: context.documentUri }
                     );
                 }
 


### PR DESCRIPTION
## Purpose

Reverts the commit `e49bed40e43498c67e7eda49e0e9ecd348e4cc13` which aimed to fix the issue where the Package Overview fails to load when creating an Integration outside a Workspace.

This is a temporary measure as the previous fix introduced unforeseen issues.

* **Reverts Commit:** `e49bed40e43498c67e7eda49e0e9ecd348e4cc13`
* **Tracking Issue:** https://github.com/wso2/product-ballerina-integrator/issues/1895