### PR TITLE
Refactor auto-focus logic to consider only empty fields

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/Form/index.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/Form/index.tsx
@@ -620,7 +620,9 @@ export const Form = forwardRef((props: FormProps) => {
     };
 
     // Find the first editable field
-    const firstEditableFieldIndex = formFields.findIndex((field) => field.editable !== false);
+    const firstEditableFieldIndex = formFields.findIndex(
+        (field) => field.editable !== false && (field.value == null || field.value === '')
+    );
 
     const isValid = useMemo(() => {
         let hasDiagnostics: boolean = false;


### PR DESCRIPTION
## Purpose
Fixes : https://github.com/wso2/product-ballerina-integrator/issues/1863


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form autofocus: the first empty, editable field now receives automatic focus on render, so users land in the most relevant input when opening forms. Other rendering and interaction behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->