### PR TITLE
Ignore CVE-2025-64756 (glob CLI vulnerability) in Trivy scans

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -11,3 +11,11 @@ CVE-2025-9910
 # No fix released by the author
 # https://github.com/wso2/vscode-extensions/issues/550
 CVE-2020-36851
+
+# Command injection vulnerability in glob CLI
+# Affects: glob 10.4.5 and 11.0.3
+# Risk Assessment: HIGH severity but CLI-specific vulnerability
+# Decision: Not using glob CLI functionality, only using glob as a library dependency
+# The vulnerability only affects usage with -c/--cmd flag which executes shell commands
+# Related Issue: https://github.com/wso2/product-ballerina-integrator/issues/1943
+CVE-2025-64756


### PR DESCRIPTION
## Description
Added CVE-2025-64756 to `.trivyignore` to suppress false positive security alerts in Trivy scans.

## Background
Trivy is flagging CVE-2025-64756 as a HIGH severity vulnerability in the `glob` package (versions 10.4.5 and 11.0.3).

## Risk Assessment
This vulnerability is **NOT applicable** to our codebase:

- **Vulnerability Type**: Command injection via glob CLI with `-c/--cmd` flags
- **Our Usage**: We use glob as a JavaScript/TypeScript library dependency only (e.g., `globSync()` function calls)
- **Impact**: Zero - the vulnerability only affects CLI usage with shell execution flags, which we don't use

## Analysis Performed
✅ Searched entire codebase for usage of `-c` or `--cmd` with glob  
✅ Confirmed all glob usage is programmatic (library imports)  
✅ No instances of glob CLI invocation found  

## Example of Safe Usage in Our Code
const distBalFiles = globSync(path.join(distResponse[1], '**', '*.bal'), {});## Decision
Safe to ignore this CVE as it doesn't apply to library usage of the glob package.

## Related Issue
https://github.com/wso2/product-ballerina-integrator/issues/1943

## Changes
- Added `CVE-2025-64756` to `.trivyignore` with detailed comments explaining the decision