### PR TITLE
Fix when removing all the values in the expression editor causes the …

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/ExpressionEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/ExpressionEditor.tsx
@@ -636,9 +636,6 @@ export const ExpressionEditor = (props: ExpressionEditorProps) => {
                                 ariaLabel={field.label}
                                 placeholder={placeholder}
                                 onChange={async (updatedValue: string, updatedCursorPosition: number) => {
-                                    if (updatedValue === value) {
-                                        return;
-                                    }
 
                                     // clear field diagnostics
                                     setFormDiagnostics([]);
@@ -707,9 +704,6 @@ export const ExpressionEditor = (props: ExpressionEditorProps) => {
                                     field={field}
                                     value={watch(key)}
                                     onChange={async (updatedValue: string, updatedCursorPosition: number) => {
-                                        if (updatedValue === value) {
-                                            return;
-                                        }
 
                                         // clear field diagnostics
                                         setFormDiagnostics([]);


### PR DESCRIPTION
## Purpose
Fix an issue in the Expression Editor where removing all values caused the field to be unexpectedly reset.  
Resolves: https://github.com/wso2/product-ballerina-integrator/issues/1953
## Goals
Ensure that clearing all values in the Expression Editor does not trigger a reset of the value. The editor should correctly reflect an empty state when all inputs are removed.

## Approach
Removed the unnecessary value comparison inside the `onChange` handler, which was causing the value to reset when clearing all inputs.  
Now, the Expression Editor correctly updates its state without reverting to a previous value.
