### PR TITLE
fix invalid form status update in new variable creation of addConnect…

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/Connection/AddConnectionWizard/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/Connection/AddConnectionWizard/index.tsx
@@ -276,7 +276,6 @@ export function AddConnectionWizard(props: AddConnectionWizardProps) {
                 .then((response) => {
                     console.log(">>> Updated source code", response);
                     if (!isConnector) {
-                        setSavingFormStatus(SavingFormStatus.SUCCESS);
                         selectedNodeRef.current = undefined;
                         if (options?.postUpdateCallBack) {
                             options.postUpdateCallBack();


### PR DESCRIPTION
## Purpose
Fix an issue in the Create Connection flow where adding a new variable on the fly would break the form.  
Resolves: https://github.com/wso2/product-ballerina-integrator/issues/1869
## Goals
Ensure that users can add a new variable without breaking the Create Connection form. The new variable form should save independently, without interfering with the main Add Connection form.

## Approach
Removed the unnecessary `setSavingFormStatus` state update in the Create Connection form. This state was being set while creating a new variable, but it is not needed because we are saving the variable form that opens on top of the Add Connection form, not the original form itself.  
This prevents the Add Connection form from incorrectly entering a saving state when a new variable is added.
