### PR TITLE
fix completions not displayed for field access

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/CodeUtils.ts
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/CodeUtils.ts
@@ -397,22 +397,24 @@ export const buildOnChangeListner = (onTrigeer: (newValue: string, cursor: Curso
     return onChangeListner;
 }
 
-export const buildCompletionSource = (getCompletions: () => CompletionItem[]) => {
-    return (context: CompletionContext): CompletionResult | null => {
-        const word = context.matchBefore(/\w*/);
-        if (!word || (word.from === word.to && !context.explicit)) {
-            return null;
-        }
-
+export const buildCompletionSource = (getCompletions: () => Promise<CompletionItem[]>) => {
+    return async (context: CompletionContext): Promise<CompletionResult | null> => {
         const textBeforeCursor = context.state.doc.toString().slice(0, context.pos);
         const lastNonSpaceChar = textBeforeCursor.trimEnd().slice(-1);
 
-        // Don't show completions for trigger characters
-        if (lastNonSpaceChar === '+' || lastNonSpaceChar === ':') {
+        const word = context.matchBefore(/\w*/);
+        if (lastNonSpaceChar !== '.' && (
+            !word || (word.from === word.to && !context.explicit)
+        )) {
             return null;
         }
 
-        const completions = getCompletions();
+        // Don't show completions for trigger characters
+        if (lastNonSpaceChar === '+') {
+            return null;
+        }
+
+        const completions = await getCompletions();
         const prefix = word.text;
         const filteredCompletions = filterCompletionsByPrefixAndType(completions, prefix);
 

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/components/ChipExpressionEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/components/ChipExpressionEditor.tsx
@@ -18,7 +18,7 @@
 
 import { EditorState } from "@codemirror/state";
 import { EditorView, keymap, tooltips } from "@codemirror/view";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useFormContext } from "../../../../../context";
 import {
     buildNeedTokenRefetchListner,
@@ -88,8 +88,9 @@ export const ChipExpressionEditorComponent = (props: ChipExpressionEditorCompone
     const fieldContainerRef = useRef<HTMLDivElement>(null);
     const viewRef = useRef<EditorView | null>(null);
     const [isTokenUpdateScheduled, setIsTokenUpdateScheduled] = useState(true);
-    const completionsRef = useRef(props.completions);
+    const completionsRef = useRef<CompletionItem[]>(props.completions);
     const helperPaneToggleButtonRef = useRef<HTMLButtonElement>(null);
+    const completionsFetchScheduledRef = useRef<boolean>(false);
 
     const { expressionEditor } = useFormContext();
     const expressionEditorRpcManager = expressionEditor?.rpcManager;
@@ -99,6 +100,7 @@ export const ChipExpressionEditorComponent = (props: ChipExpressionEditorCompone
     });
 
     const handleChangeListner = buildOnChangeListner((newValue, cursor) => {
+        completionsFetchScheduledRef.current = true;
         props.onChange(newValue, cursor.position.to);
         const textBeforeCursor = newValue.slice(0, cursor.position.to);
         const lastNonSpaceChar = textBeforeCursor.trimEnd().slice(-1);
@@ -124,7 +126,22 @@ export const ChipExpressionEditorComponent = (props: ChipExpressionEditorCompone
         setIsTokenUpdateScheduled(true);
     });
 
-    const completionSource = buildCompletionSource(() => completionsRef.current);
+    const waitForStateChange = (): Promise<CompletionItem[]> => {
+        return new Promise((resolve) => {
+            const checkState = () => {
+                if (!completionsFetchScheduledRef.current) {
+                    resolve(completionsRef.current);
+                } else {
+                    requestAnimationFrame(checkState);
+                }
+            };
+            checkState();
+        });
+    };
+
+    const completionSource = useMemo(() => {
+        return buildCompletionSource(waitForStateChange);
+    }, [props.completions]);
 
     const helperPaneKeymap = buildHelperPaneKeymap(() => helperPaneState.isOpen, () => {
         setHelperPaneState(prev => ({ ...prev, isOpen: false }));
@@ -284,6 +301,7 @@ export const ChipExpressionEditorComponent = (props: ChipExpressionEditorCompone
     // just don't touch this.
     useEffect(() => {
         completionsRef.current = props.completions;
+        completionsFetchScheduledRef.current = false;
     }, [props.completions]);
 
     useEffect(() => {


### PR DESCRIPTION
## Purpose
The completion suggestions were not appearing when typing certain identifiers such as `user.` to access fields of a record type.  
This occurred because CodeMirror was using **stale completion data**, as the newly fetched completions were not being synced with the internal `completionSource`.

Resolves: https://github.com/wso2/product-ballerina-integrator/issues/1841

## Goals
- Ensure CodeMirror always uses the **latest fetched completion items**.
- Avoid showing stale or outdated completion lists.
- Improve reliability and accuracy of code completion, especially when accessing fields on record types (e.g., `user.`).

## Approach
- Implemented a synchronization mechanism between the fetched completions and CodeMirror’s `completionSource`.
- Added a `waitForStateChange()` utility that waits until the updated completion values are applied before CodeMirror handles completion queries.
- Synced the latest completions via `useRef` and `requestAnimationFrame`, ensuring the editor receives up-to-date data.
- This resolves the issue where completions would not appear because CodeMirror was referencing outdated values.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code completion responsiveness by implementing enhanced asynchronous handling for completion data retrieval and processing in the expression editor.
  * Strengthened synchronization of completion state to ensure better data consistency and reliability across the editing interface.
  * These optimizations provide a smoother and more responsive experience when working with code completion suggestions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->