### PR TITLE
Fix expression cursor on popup

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/CodeUtils.ts
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/CodeUtils.ts
@@ -34,8 +34,6 @@ export type CursorInfo = {
 
 export type TokenType = 'variable' | 'property' | 'parameter';
 
-export const ProgrammerticSelectionChange = Annotation.define<boolean>();
-
 export const SyncDocValueWithPropValue = Annotation.define<boolean>();
 
 
@@ -296,10 +294,6 @@ export const buildOnSelectionChange = (onTrigger: (cursor: CursorInfo) => void) 
         if (!update.selectionSet) return;
         if (update.docChanged) return;
         if (!update.view.hasFocus) return;
-
-        if (update.transactions.some(tr => tr.annotation(ProgrammerticSelectionChange))) {
-            return;
-        }
 
         const cursorPosition = update.state.selection.main;
         const coords = update.view.coordsAtPos(cursorPosition.to);

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/components/ChipExpressionEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/components/ChipExpressionEditor.tsx
@@ -35,7 +35,6 @@ import {
     CursorInfo,
     buildOnFocusOutListner,
     buildOnSelectionChange,
-    ProgrammerticSelectionChange,
     SyncDocValueWithPropValue
 } from "../CodeUtils";
 import { history } from "@codemirror/commands";


### PR DESCRIPTION
## Purpose
The expression editor had an issue where newly created variables were always inserted at the **start** of the editor instead of the current cursor position.  
This happened because the editor was explicitly resetting the cursor position when the user clicked outside the editor.  
This PR fixes the behavior so new variables insert at the correct cursor location.

Resolves: https://github.com/wso2/product-ballerina-integrator/issues/1968

## Goals
- Prevent the unintended cursor reset when the user interacts outside the editor.  
- Ensure newly created variables are inserted at the correct cursor position maintained internally by CodeMirror.  
- Remove unnecessary logic that interferes with CodeMirror’s own cursor state handling.

## Approach
- Removed the **explicit cursor reset** that manually set the cursor to position `0` on blur/outside clicks.
- Since we already call `viewRef.current?.dom.blur();`, the cursor visually disappears for the user, but CodeMirror internally maintains the correct cursor position.  
- With the explicit reset removed, variable insertion now respects the last valid cursor position managed by CodeMirror.
