### PR TITLE
Add force replace option for language server download

### DIFF
--- a/workspaces/ballerina/ballerina-extension/package.json
+++ b/workspaces/ballerina/ballerina-extension/package.json
@@ -1186,6 +1186,7 @@
         "copyVSIX": "copyfiles *.vsix ./vsix",
         "copyVSIXToRoot": "copyfiles -f ./vsix/*.vsix ../../..",
         "download-ls": "node scripts/download-ls.js",
+        "download-ls:prerelease": "node scripts/download-ls.js --prerelease --replace",
         "build": "pnpm run compile && pnpm run lint && pnpm run postbuild",
         "rebuild": "pnpm run clean && pnpm run compile && pnpm run postbuild",
         "postbuild": "if [ \"$isPreRelease\" = \"true\" ]; then pnpm run download-ls --prerelease; else pnpm run download-ls; fi && pnpm run copyFonts && pnpm run copyJSLibs && pnpm run package && pnpm run copyVSIX",

--- a/workspaces/ballerina/ballerina-extension/scripts/download-ls.js
+++ b/workspaces/ballerina/ballerina-extension/scripts/download-ls.js
@@ -10,6 +10,7 @@ const GITHUB_REPO_URL = 'https://api.github.com/repos/ballerina-platform/balleri
 
 const args = process.argv.slice(2);
 const usePrerelease = args.includes('--prerelease') || process.env.isPreRelease === 'true';
+const forceReplace = args.includes('--replace');
 
 function checkExistingJar() {
     try {
@@ -177,11 +178,16 @@ async function getLatestRelease(usePrerelease) {
 
 async function main() {
     try {
-        if (checkExistingJar()) {
+        if (!forceReplace && checkExistingJar()) {
             process.exit(0);
         }
 
-        console.log(`Downloading Ballerina language server${usePrerelease ? ' (prerelease)' : ''}...`);
+        console.log(`Downloading Ballerina language server${usePrerelease ? ' (prerelease)' : ''}${forceReplace ? ' (force replace)' : ''}...`);
+
+        if (forceReplace && fs.existsSync(LS_DIR)) {
+            console.log('Force replace enabled: clearing existing language server directory...');
+            fs.rmSync(LS_DIR, { recursive: true, force: true });
+        }
 
         if (!fs.existsSync(LS_DIR)) {
             fs.mkdirSync(LS_DIR, { recursive: true });


### PR DESCRIPTION
## Purpose

Updates the `download-ls` script to accept a new argument, `--replace`.

This new argument **Removes** the existing Language Server (LS) JAR file located at `workspaces/ballerina/ballerina-extension/ls/ballerina-language-server-x.x.x.jar` before downloading the new version.

## Changes

* **Adds** the `--replace` flag handling to the `download-ls` script.
* **Ensures** the script checks for and deletes the old LS JAR file path when `--replace` is used.