### PR TITLE
fix create config not saving the values

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/Configurables/AddConfigurableVariables/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/Configurables/AddConfigurableVariables/index.tsx
@@ -52,6 +52,7 @@ export function AddForm(props: ConfigFormProps) {
 
     const handleSave = async (node: FlowNode) => {
         setIsSaving(true);
+        node.properties.defaultValue.modified = true;
         await rpcClient.getBIDiagramRpcClient().updateConfigVariablesV2({
             configFilePath: props.filename,
             configVariable: node,

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/Configurables.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/Configurables.tsx
@@ -146,6 +146,7 @@ export const Configurables = (props: ConfigurablesPageProps) => {
         closeModal(POPUP_IDS.CONFIGURABLES);
         //TODO: Need to disable the form before saving and move form close to finally block
         setIsSaving(true);
+        node.properties.defaultValue.modified = true;
         await rpcClient.getBIDiagramRpcClient().updateConfigVariablesV2({
             configFilePath: Utils.joinPath(URI.file(projectPathUri), 'config.bal').fsPath,
             configVariable: node,


### PR DESCRIPTION
## Purpose
Creating configurables was not saving after submission.  
The issue occurred because all fields in the form had their **modified flag** set to `false` by default.  
While this is consistent with other forms, the `configEditorV2/updateConfigVariable` API sends **empty text edits** when all fields are marked as unmodified, causing the save to fail.  

Resolves: https://github.com/wso2/product-ballerina-integrator/issues/1959

## Goals
- Ensure configurables are correctly saved after submission.  
- Maintain consistent form behavior while addressing the API-specific requirement.  
- Avoid sending empty updates to the `updateConfigVariable` API.

## Approach
- Explicitly set the **modified flag** of the `defaultValue` property to `true` for newly created configurables.  
- This bypasses the empty text edits issue, allowing the API to process the submitted data correctly.  
- Other fields retain their default behavior, keeping form consistency across the application.

## Note: If the Language Server is later updated to correctly handle unmodified fields, these explicit modified flag changes will become unnecessary and can be removed.

