### PR TITLE
Remove 'Show Examples' command and related functionality

### DIFF
--- a/workspaces/ballerina/ballerina-extension/package.json
+++ b/workspaces/ballerina/ballerina-extension/package.json
@@ -26,7 +26,6 @@
     "activationEvents": [
         "onStartupFinished",
         "onLanguage:ballerina",
-        "onCommand:ballerina.showExamples",
         "workspaceContains:**/Ballerina.toml",
         "onNotebook:ballerina-notebook",
         "onUri"
@@ -348,11 +347,6 @@
             }
         ],
         "commands": [
-            {
-                "command": "ballerina.showExamples",
-                "title": "Show Examples",
-                "category": "Ballerina"
-            },
             {
                 "command": "ballerina.project.build",
                 "title": "Build",

--- a/workspaces/ballerina/ballerina-extension/src/extension.ts
+++ b/workspaces/ballerina/ballerina-extension/src/extension.ts
@@ -154,8 +154,9 @@ export async function activateBallerina(): Promise<BallerinaExtension> {
         activateEditorSupport(ballerinaExtInstance);
 
         // <------------ MAIN FEATURES ----------->
-        // Enable Ballerina by examples
-        activateBBE(ballerinaExtInstance);
+        // TODO: Enable Ballerina by examples once the samples are available
+        // https://github.com/wso2/product-ballerina-integrator/issues/1967
+        // activateBBE(ballerinaExtInstance);
 
         //Enable BI Feature
         activateBIFeatures(ballerinaExtInstance);

--- a/workspaces/ballerina/ballerina-extension/src/features/project/cmds/cmd-runner.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/project/cmds/cmd-runner.ts
@@ -50,7 +50,6 @@ export const PALETTE_COMMANDS = {
     SHOW_DIAGRAM: 'ballerina.show.diagram',
     SHOW_SOURCE: 'ballerina.show.source',
     SHOW_ARCHITECTURE_VIEW: 'ballerina.view.architectureView',
-    SHOW_EXAMPLES: 'ballerina.showExamples',
     REFRESH_SHOW_ARCHITECTURE_VIEW: "ballerina.view.architectureView.refresh",
     RUN_CONFIG: 'ballerina.project.run.config',
     CONFIG_CREATE_COMMAND: 'ballerina.project.config.create',

--- a/workspaces/ballerina/ballerina-extension/src/views/bbe/activator.ts
+++ b/workspaces/ballerina/ballerina-extension/src/views/bbe/activator.ts
@@ -104,12 +104,6 @@ function showExamples(context: ExtensionContext, langClient: ExtendedLangClient)
 }
 
 export function activate(ballerinaExtInstance: BallerinaExtension) {
-    const context = <ExtensionContext>ballerinaExtInstance.context;
-    const langClient = <ExtendedLangClient>ballerinaExtInstance.langClient;
-    const examplesListRenderer = commands.registerCommand(PALETTE_COMMANDS.SHOW_EXAMPLES, () => {
-        sendTelemetryEvent(ballerinaExtInstance, TM_EVENT_OPEN_EXAMPLES, CMP_EXAMPLES_VIEW);
-        showExamples(context, langClient);
-    });
-
-    context.subscriptions.push(examplesListRenderer);
+    // TODO: Implement this once the samples are available
+    // https://github.com/wso2/product-ballerina-integrator/issues/1967
 }

--- a/workspaces/ballerina/ballerina-extension/test/ai/evals/code/utils/batch-processing.ts
+++ b/workspaces/ballerina/ballerina-extension/test/ai/evals/code/utils/batch-processing.ts
@@ -102,18 +102,4 @@ async function setupTestEnvironmentForBatch(projectPath: string): Promise<void> 
     
     // Give VSCode time to detect the workspace and trigger activation
     await new Promise(resolve => setTimeout(resolve, TIMING.WORKSPACE_SETTLE_DELAY));
-    
-    // Force extension activation by opening a Ballerina file
-    try {
-        const testBalFile = Uri.file(path.join(projectPath, FILES.MAIN_BAL));
-        await commands.executeCommand(VSCODE_COMMANDS.OPEN, testBalFile);
-        await new Promise(resolve => setTimeout(resolve, TIMING.FILE_OPEN_DELAY));
-    } catch (error) {
-        // Fallback: try to execute a ballerina command to force activation
-        try {
-            await commands.executeCommand(VSCODE_COMMANDS.SHOW_EXAMPLES);
-        } catch (cmdError) {
-            // Extension might still be loading
-        }
-    }
 }

--- a/workspaces/ballerina/ballerina-extension/test/ai/evals/code/utils/constants.ts
+++ b/workspaces/ballerina/ballerina-extension/test/ai/evals/code/utils/constants.ts
@@ -76,6 +76,5 @@ observabilityIncluded = true
 export const VSCODE_COMMANDS = {
     CLOSE_ALL_EDITORS: "workbench.action.closeAllEditors",
     OPEN: "vscode.open",
-    SHOW_EXAMPLES: "ballerina.showExamples",
     AI_GENERATE_CODE_CORE: "ballerina.test.ai.generateCodeCore"
 } as const;

--- a/workspaces/ballerina/ballerina-extension/test/ai/integration_tests/libs/setup.ts
+++ b/workspaces/ballerina/ballerina-extension/test/ai/integration_tests/libs/setup.ts
@@ -35,8 +35,7 @@ const PATHS = {
 
 const VSCODE_COMMANDS = {
     CLOSE_ALL_EDITORS: "workbench.action.closeAllEditors",
-    OPEN: "vscode.open",
-    SHOW_EXAMPLES: "ballerina.showExamples",
+    OPEN: "vscode.open"
 };
 
 /**
@@ -58,21 +57,6 @@ export async function setupTestEnvironment(): Promise<void> {
     // Note: Workspace is already opened by VS Code via launch.json args
     // Wait for workspace to settle and extension to activate
     await new Promise(resolve => setTimeout(resolve, TIMING.WORKSPACE_SETTLE_DELAY));
-
-    // Force extension activation by opening a Ballerina file
-    try {
-        const PROJECT_ROOT = path.resolve(__dirname, PATHS.PROJECT_ROOT_RELATIVE);
-        const testBalFile = Uri.file(path.join(PROJECT_ROOT, "main.bal"));
-        await commands.executeCommand(VSCODE_COMMANDS.OPEN, testBalFile);
-        await new Promise(resolve => setTimeout(resolve, TIMING.FILE_OPEN_DELAY));
-    } catch (error) {
-        // Fallback: try to execute a ballerina command to force activation
-        try {
-            await commands.executeCommand(VSCODE_COMMANDS.SHOW_EXAMPLES);
-        } catch (cmdError) {
-            // Extension might still be loading
-        }
-    }
 
     // Wait for extension to activate (it activates onStartupFinished)
     // Give it sufficient time to load language server and initialize


### PR DESCRIPTION
The 'Show Examples' command is currently non-functional, and enabling it requires additional work to create the necessary samples and complete the end-to-end flow (tracked in https://github.com/wso2/product-ballerina-integrator/issues/1967
).
This PR temporarily removes the command and its related functionality until the required samples are ready.

Related to: https://github.com/wso2/product-ballerina-integrator/issues/1972