### PR TITLE
fix helperpane search fields are not focusable

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/components/HelperPane.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/components/HelperPane.tsx
@@ -39,10 +39,6 @@ export const HelperPane = React.forwardRef<HTMLDivElement, HelperPaneProps>((pro
             ref={ref}
             top={props.top}
             left={props.left}
-            onMouseDown={e => {
-                e.preventDefault();
-                e.stopPropagation();
-            }}
         >
             {props.getHelperPane(
                 props.value,


### PR DESCRIPTION
## Purpose
The search fields inside the Helper Pane were not focusable, preventing users from typing or interacting with them.  
This issue was caused by unnecessary `event.preventDefault()` and `event.stopPropagation()` calls, which blocked normal focus and click behavior within the pane.

Resolves: https://github.com/wso2/product-ballerina-integrator/issues/1975

## Goals
- Allow search fields inside the Helper Pane to be properly focused and usable.  
- Restore expected click and focus behavior for interactive elements within the pane.  
- Remove outdated event handling logic that is no longer needed with the latest CodeMirror updates.

## Approach
- Removed the unnecessary `event.preventDefault()` and `event.stopPropagation()` calls applied to Helper Pane interactions.  
- These handlers were originally added for older expression editor behavior but now interfere with focus logic.  
- With the handlers removed, search fields and other clickable elements behave correctly without side effects.

