### PR TITLE
Remove "Group by" option from ClauseEditor component

### DIFF
--- a/workspaces/ballerina/data-mapper/src/components/DataMapper/SidePanel/QueryClauses/ClauseEditor.tsx
+++ b/workspaces/ballerina/data-mapper/src/components/DataMapper/SidePanel/QueryClauses/ClauseEditor.tsx
@@ -47,8 +47,7 @@ export function ClauseEditor(props: ClauseEditorProps) {
         { content: "Sort by", value: IntermediateClauseType.ORDER_BY },
         { content: "Limit", value: IntermediateClauseType.LIMIT },
         { content: "From", value: IntermediateClauseType.FROM },
-        { content: "Join", value: IntermediateClauseType.JOIN },
-        { content: "Group by", value: IntermediateClauseType.GROUP_BY }
+        { content: "Join", value: IntermediateClauseType.JOIN }
     ]
 
     const nameField: DMFormField = {


### PR DESCRIPTION
## Purpose
> $subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the "Group by" clause option from the query clause selector in the data mapper, narrowing the available clause types users can select.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->