### PR TITLE
Get runtime version from integration projects

### DIFF
--- a/workspaces/mi/mi-extension/src/stateMachine.ts
+++ b/workspaces/mi/mi-extension/src/stateMachine.ts
@@ -824,7 +824,7 @@ function updateProjectExplorer(location: VisualizerLocation | undefined) {
 async function checkIfMiProject(projectUri: string, view: MACHINE_VIEW = MACHINE_VIEW.Overview) {
     console.log(`Detecting project in ${projectUri} - ${new Date().toLocaleTimeString()}`);
 
-    let isProject = false, isOldProject = false, isOldWorkspace = false, displayOverview = true, isEnvironmentSetUp = false;
+    let isProject = false, isOldProject = false, isOldWorkspace = false, displayOverview = true, isEnvironmentSetUp = false, isLegacyRuntime = true;
     const customProps: any = {};
     try {
         // Check for pom.xml files excluding node_modules directory
@@ -871,6 +871,9 @@ async function checkIfMiProject(projectUri: string, view: MACHINE_VIEW = MACHINE
             }
         }
 
+        const runtimeVersion = await getMIVersionFromPom(projectUri);
+        isLegacyRuntime = runtimeVersion ? compareVersions(runtimeVersion, RUNTIME_VERSION_440) < 0 : true;
+
         vscode.commands.executeCommand('setContext', 'MI.status', 'projectDetected');
         vscode.commands.executeCommand('setContext', 'MI.projectType', 'miProject'); // for command enablements
         await extension.context.workspaceState.update('projectType', 'miProject');
@@ -898,9 +901,6 @@ async function checkIfMiProject(projectUri: string, view: MACHINE_VIEW = MACHINE
         // console.log project path
         console.log(`Current workspace path: ${projectUri}`);
     }
-
-    const runtimeVersion = await getMIVersionFromPom(projectUri);
-    const isLegacyRuntime = runtimeVersion ? compareVersions(runtimeVersion, RUNTIME_VERSION_440) < 0 : true;
 
     console.log(`Project detection completed for path: ${projectUri} at ${new Date().toLocaleTimeString()}`);
     return {


### PR DESCRIPTION
This PR will fix the first concern in the issue https://github.com/wso2/mi-vscode/issues/1366

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced runtime version detection for legacy environments, now occurring earlier in the initialization flow.
  * Optimized state machine context propagation to properly track runtime compatibility status throughout the application lifecycle.
  * Eliminated redundant runtime version evaluation, improving initialization efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->