### PR TITLE
implement sql expression editor

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -980,6 +980,12 @@ importers:
       '@codemirror/commands':
         specifier: ~6.10.0
         version: 6.10.0
+      '@codemirror/lang-sql':
+        specifier: ~6.10.0
+        version: 6.10.0
+      '@codemirror/language':
+        specifier: ~6.11.3
+        version: 6.11.3
       '@codemirror/state':
         specifier: ~6.5.2
         version: 6.5.2
@@ -995,6 +1001,9 @@ importers:
       '@github/markdown-toolbar-element':
         specifier: ^2.2.3
         version: 2.2.3
+      '@lezer/highlight':
+        specifier: ~1.2.3
+        version: 1.2.3
       '@wso2/ballerina-core':
         specifier: workspace:*
         version: link:../ballerina-core

--- a/workspaces/ballerina/ballerina-side-panel/package.json
+++ b/workspaces/ballerina/ballerina-side-panel/package.json
@@ -34,7 +34,10 @@
         "@codemirror/commands": "~6.10.0",
         "@codemirror/state": "~6.5.2",
         "@codemirror/view": "~6.38.6",
-        "@codemirror/autocomplete": "~6.19.1"
+        "@codemirror/autocomplete": "~6.19.1",
+        "@codemirror/lang-sql": "~6.10.0",
+        "@codemirror/language": "~6.11.3",
+        "@lezer/highlight": "~1.2.3"
     },
     "devDependencies": {
         "@storybook/react": "^6.5.16",

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/ExpressionField.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/ExpressionField.tsx
@@ -35,6 +35,7 @@ import RecordConfigPreviewEditor from './MultiModeExpressionEditor/RecordConfigP
 import { RawTemplateEditorConfig, StringTemplateEditorConfig, PrimaryModeChipExpressionEditorConfig } from './MultiModeExpressionEditor/Configurations';
 import NumberExpressionEditor from './MultiModeExpressionEditor/NumberExpressionEditor/NumberEditor';
 import BooleanEditor from './MultiModeExpressionEditor/BooleanEditor/BooleanEditor';
+import { SQLExpressionEditor } from './MultiModeExpressionEditor/SqlExpressionEditor/SqlExpressionEditor';
 
 export interface ExpressionField {
     field: FormField;
@@ -142,8 +143,8 @@ export const ExpressionField: React.FC<ExpressionField> = ({
                 value={value}
                 onChange={onChange}
             />
-            );
-        }
+        );
+    }
     if (inputMode === InputMode.RECORD) {
         return (
             <RecordConfigPreviewEditor
@@ -226,6 +227,25 @@ export const ExpressionField: React.FC<ExpressionField> = ({
                 isInExpandedMode={isInExpandedMode}
             />
 
+        );
+    }
+    if (inputMode === InputMode.SQL) {
+        return (
+            <SQLExpressionEditor
+                getHelperPane={getHelperPane}
+                isExpandedVersion={false}
+                completions={completions}
+                onChange={onChange}
+                value={value}
+                sanitizedExpression={sanitizedExpression}
+                rawExpression={rawExpression}
+                fileName={fileName}
+                targetLineRange={targetLineRange}
+                extractArgsFromFunction={extractArgsFromFunction}
+                onOpenExpandedMode={onOpenExpandedMode}
+                onRemove={onRemove}
+                isInExpandedMode={isInExpandedMode}
+            />
         );
     }
 

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/types.ts
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/types.ts
@@ -22,14 +22,16 @@ export enum InputMode {
   RECORD = "Record",
   TEMPLATE = "Template",
   NUMBER = "Number",
-  BOOLEAN = "Boolean"
+  BOOLEAN = "Boolean",
+  SQL = "SQL"
 }
 
 export const INPUT_MODE_MAP = {
   string: InputMode.TEXT,
   "ai:Prompt": InputMode.TEMPLATE,
   int: InputMode.NUMBER,
-  boolean: InputMode.BOOLEAN
+  boolean: InputMode.BOOLEAN,
+  "sql:ParameterizedQuery": InputMode.SQL
 };
 
 export enum TokenType {

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/SqlExpressionEditor/SqlExpressionEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/SqlExpressionEditor/SqlExpressionEditor.tsx
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from "react";
+import { getValueForTextModeEditor } from "../../utils";
+import { ChipExpressionEditorComponent, ChipExpressionEditorComponentProps } from "../ChipExpressionEditor/components/ChipExpressionEditor";
+import { SQLExpressionEditorConfig } from "../Configurations";
+
+export const SQLExpressionEditor: React.FC<ChipExpressionEditorComponentProps> = (props) => {
+
+    return (
+        <ChipExpressionEditorComponent
+            getHelperPane={props.getHelperPane}
+            isExpandedVersion={false}
+            completions={props.completions}
+            onChange={props.onChange}
+            value={getValueForTextModeEditor(props.value)}
+            sanitizedExpression={props.sanitizedExpression}
+            rawExpression={props.rawExpression}
+            fileName={props.fileName}
+            targetLineRange={props.targetLineRange}
+            extractArgsFromFunction={props.extractArgsFromFunction}
+            onOpenExpandedMode={props.onOpenExpandedMode}
+            onRemove={props.onRemove}
+            isInExpandedMode={props.isInExpandedMode}
+            configuration={new SQLExpressionEditorConfig()}
+        />
+    );
+};


### PR DESCRIPTION
## Purpose
The Expression Editor previously only supported basic expressions without SQL-specific capabilities, making it difficult for users to write and read SQL queries efficiently. 

This PR extends the existing Expression Editor to support SQL expressions directly and adds syntax highlighting for better readability.

Resolves: https://github.com/wso2/product-ballerina-integrator/issues/762

## Goals
- Extend the Expression Editor to allow users to write SQL queries seamlessly.  
- Improve readability and usability by providing syntax highlighting for SQL keywords, operators, identifiers, functions, and strings.  
- Provide a more intuitive and user-friendly editing experience for SQL expressions within the application.

## Approach
- Extended the current Expression Editor to recognize SQL syntax using the `@codemirror/lang-sql` package.  
- Integrated CodeMirror 6’s SQL language support to tokenize SQL queries and apply syntax highlighting for keywords (`SELECT`, `FROM`, `WHERE`), operators (`=`, `>=`), functions (`COUNT`, `SUM`), identifiers (tables and column names), strings, numbers, and comments.  
- Applied a customized theme to ensure the SQL syntax highlighting matches the editor’s UX standards.  
- Maintained backward compatibility with non-SQL expressions, ensuring that existing editor functionality remains unaffected.  
- Added sample queries for testing and validation of highlighting behavior.  
- Tested the editor with complex SQL queries to ensure correct tokenization, highlighting, and editor responsiveness.


https://github.com/user-attachments/assets/a296251d-09c0-4dbe-a08f-56bd91b639ff




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SQL expression editor with syntax highlighting support
  * SQL-parameterized queries now supported as an input mode
  * Enhanced expression editing capabilities with SQL templating

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->