### PR TITLE
Fix helperpane variable creation is not working in array editors

### DIFF
--- a/workspaces/ballerina/ballerina-core/src/interfaces/bi.ts
+++ b/workspaces/ballerina/ballerina-core/src/interfaces/bi.ts
@@ -140,7 +140,8 @@ export type FormFieldInputType = "TEXT" |
     "EXPRESSION_SET" |
     "FLAG" |
     "CHOICE" |
-    "LV_EXPRESSION";
+    "LV_EXPRESSION" |
+    "MAPPING_EXPRESSION_SET";
 
 export interface BaseType {
     fieldType: FormFieldInputType;

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/EditorFactory.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/EditorFactory.tsx
@@ -87,7 +87,7 @@ export const EditorFactory = (props: FormFieldEditorProps) => {
         scopeFieldAddon
     } = props;
 
-    const showWithExpressionEditor = field.types.some(type => {
+    const showWithExpressionEditor = field.types?.some(type => {
         return type && (
             type.fieldType === "EXPRESSION" ||
             type.fieldType === "LV_EXPRESSION" ||


### PR DESCRIPTION
## Purpose
> This PR includes a fix for the issue where expression editor helper pane create new variable option is not working inside the Array Editor