### PR TITLE
fix record editor not opening when record field is in choice form

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/ServiceDesigner/ServiceCreationView.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/ServiceDesigner/ServiceCreationView.tsx
@@ -278,7 +278,7 @@ export function ServiceCreationView(props: ServiceCreationViewProps) {
 
     useEffect(() => {
         if (model) {
-            const hasPropertiesWithChoices = model?.moduleName === "http" &&
+            const hasPropertiesWithChoices =
                 Object.values(model.properties).some(property => property.choices);
 
             if (hasPropertiesWithChoices) {


### PR DESCRIPTION
## Purpose
The record editor was not rendered for fields defined using `RECORD_MAP_EXPRESSION` in **choice forms**.  
This issue was caused by an invalid module name validation being applied to HTTP-related fields, which incorrectly rejected valid record map expressions.

Resolves: https://github.com/wso2/product-ballerina-integrator/issues/2155

## Goals
- Ensure the record editor is rendered correctly for fields with `RECORD_MAP_EXPRESSION` in choice forms.
- Prevent HTTP-specific module name validation from blocking valid record map expressions.

## Approach
- Identified that an invalid module name check specific to `http` was executed during record editor rendering.
- Removed the invalid module name validation only for HTTP choice forms.
- Ensured no changes were made to shared or generic form-handling logic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended properties with choices in the Service Designer to work across all module types, previously limited to HTTP modules.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->