### PR TITLE
fix incorrect field types in clause editor

### DIFF
--- a/workspaces/ballerina/ballerina-core/src/interfaces/bi.ts
+++ b/workspaces/ballerina/ballerina-core/src/interfaces/bi.ts
@@ -144,7 +144,9 @@ export type FormFieldInputType = "TEXT" |
     "LV_EXPRESSION" |
     "RAW_TEMPLATE" |
     "ai:Prompt" |
-    "RECORD_MAP_EXPRESSION";
+    "RECORD_MAP_EXPRESSION" | 
+    "ENUM" |
+    "DM_JOIN_CLAUSE_RHS_EXPRESSION";
 
 export interface BaseType {
     fieldType: FormFieldInputType;

--- a/workspaces/ballerina/data-mapper/src/components/DataMapper/SidePanel/QueryClauses/ClauseEditor.tsx
+++ b/workspaces/ballerina/data-mapper/src/components/DataMapper/SidePanel/QueryClauses/ClauseEditor.tsx
@@ -87,7 +87,7 @@ export function ClauseEditor(props: ClauseEditorProps) {
             clauseType === IntermediateClauseType.GROUP_BY ? "Enter the grouping key expression" :
                 "Enter the expression of the clause",
         value: clauseProps?.expression ?? "",
-        types: [{ fieldType: "IDENTIFIER", ballerinaType: "Global", selected: false }],
+        types: [{ fieldType: "EXPRESSION", ballerinaType: "Global", selected: false }],
         enabled: true,
     }
 
@@ -99,7 +99,7 @@ export function ClauseEditor(props: ClauseEditorProps) {
         editable: true,
         documentation: "Enter the order",
         value: clauseProps?.order ?? "",
-        types: [{ fieldType: "IDENTIFIER", ballerinaType: "Global", selected: false }],
+        types: [{ fieldType: "ENUM", ballerinaType: "Global", selected: false }],
         enabled: true,
         items: ["ascending", "descending"]
     }
@@ -112,7 +112,7 @@ export function ClauseEditor(props: ClauseEditorProps) {
         editable: true,
         documentation: "Enter the LHS expression of join-on condition",
         value: clauseProps?.lhsExpression ?? "",
-        types: [{ fieldType: "IDENTIFIER", ballerinaType: "Global", selected: false }],
+        types: [{ fieldType: "EXPRESSION", ballerinaType: "Global", selected: false }],
         enabled: true,
     }
 
@@ -124,7 +124,7 @@ export function ClauseEditor(props: ClauseEditorProps) {
         editable: true,
         documentation: "Enter the RHS expression of join-on condition",
         value: clauseProps?.rhsExpression ?? "",
-        types: [{ fieldType: "IDENTIFIER", ballerinaType: "Global", selected: false }],
+        types: [{ fieldType: "DM_JOIN_CLAUSE_RHS_EXPRESSION", ballerinaType: "Global", selected: false }],
         enabled: true,
     }
 


### PR DESCRIPTION
## Purpose
> Fix the issue where in clause editor fieldTypes were incorrectly set after the refactor of the property model/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Expanded form field type support to enable enhanced query clause editing with additional field configuration options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->