### PR TITLE
fix function form saving without entered parameters

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/features/ai/data-mapper/orchestrator.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/data-mapper/orchestrator.ts
@@ -668,7 +668,6 @@ export async function generateMappingCode(mappingRequest: ProcessMappingParamete
         await generateMappingCodeCore(mappingRequest, eventHandler, messageId);
     } catch (error) {
         console.error("Error during mapping code generation:", error);
-        eventHandler({ type: "error", content: getErrorMessage(error) });
         throw error;
     }
 }
@@ -1002,7 +1001,6 @@ export async function generateInlineMappingCode(inlineMappingRequest: MetadataWi
         await generateInlineMappingCodeCore(inlineMappingRequest, eventHandler, messageId);
     } catch (error) {
         console.error("Error during inline mapping code generation:", error);
-        eventHandler({ type: "error", content: getErrorMessage(error) });
         throw error;
     }
 }
@@ -1106,7 +1104,6 @@ export async function generateContextTypes(typeCreationRequest: ProcessContextTy
         await generateContextTypesCore(typeCreationRequest, eventHandler, messageId);
     } catch (error) {
         console.error("Error during context type creation:", error);
-        eventHandler({ type: "error", content: getErrorMessage(error) });
         throw error;
     }
 }

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/data-mapper/utils/extraction.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/data-mapper/utils/extraction.ts
@@ -55,7 +55,7 @@ export async function extractMappingDetails(
   if (hasProvidedRecords) {
     if (existingFunctionMatch.match) {
       throw new Error(
-        `"${parameters.functionName}" function already exists. Please provide a valid function name.`
+        `${parameters.functionName} function already exists. Please provide a valid function name.`
       );
     }
     inputParams = parameters.inputRecord;
@@ -63,7 +63,7 @@ export async function extractMappingDetails(
   } else {
     if (!existingFunctionMatch.match || !existingFunctionMatch.functionDefNode) {
       throw new Error(
-        `"${parameters.functionName}" function was not found. Please provide a valid function name.`
+        `${parameters.functionName} function was not found. Please provide a valid function name.`
       );
     }
 

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/ActionTypeEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/ActionTypeEditor.tsx
@@ -590,7 +590,7 @@ export function ActionTypeEditor(props: ActionTypeEditorProps) {
                     })()
                     }
                 </S.Header>
-                {field.types &&
+                {getPrimaryInputType(field.types)?.ballerinaType &&
                     <S.Type
                         isVisible={focused}
                         title={getPrimaryInputType(field.types)?.ballerinaType}


### PR DESCRIPTION
## Purpose
The Create Function form did not persist function parameters when saving. This issue was caused by parts of the save logic still relying on the legacy property model that existed prior to the recent refactoring, leading to a mismatch between the expected and provided request objects.

Resolves issue: https://github.com/wso2/product-ballerina-integrator/issues/2117

## Goals
- Ensure function parameters entered in the Create Function form are correctly saved.
- Align the save logic with the newly refactored property model.

## Approach
- Identified sections of the save logic that were still referencing the old property model.
- Updated the implementation to fully rely on the new, refactored property model when collecting and persisting function parameters.
- Verified that parameters are correctly preserved across function save and automation configuration forms.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent behavior for repeatable/template-based properties so repeated inputs now initialize and validate consistently.

* **Refactor**
  * Consolidated editor selection and repeatable-property handling to base rendering and value cloning on template-type detection, improving predictability when adding/removing repeated items.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->