### PR TITLE
fix graphql operator forms to conditionally render type field when the ballerinaType exsists

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/ActionTypeEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/ActionTypeEditor.tsx
@@ -590,7 +590,7 @@ export function ActionTypeEditor(props: ActionTypeEditorProps) {
                     })()
                     }
                 </S.Header>
-                {field.types &&
+                {getPrimaryInputType(field.types)?.ballerinaType &&
                     <S.Type
                         isVisible={focused}
                         title={getPrimaryInputType(field.types)?.ballerinaType}


### PR DESCRIPTION
## Purpose
The GraphQL operators forms were breaking at runtime due to undefined property access. Certain operator configurations attempted to access the `ballerinaType` field even when the corresponding property was not present, resulting in errors and a broken form experience.

Resolves: https://github.com/wso2/product-ballerina-integrator/issues/2169

## Goals
- Prevent runtime errors in GraphQL operators forms.
- Ensure the forms render safely even when optional properties are missing.
- Improve the robustness of operator configuration handling.

## Approach
- Identified cases where the `ballerinaType` field was accessed without verifying the existence of the related property.
- Updated the form rendering logic to conditionally render the `type` field only when the `ballerinaType` property exists.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced type information display in the action type editor by refining how primary input types are detected and rendered. Type blocks now appear only when a primary input type is available, ensuring users see more accurate and contextually relevant type information in the editor interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->