### PR TITLE
Fix mode switcher styles

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/ExpressionField.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/ExpressionField.tsx
@@ -185,7 +185,7 @@ export const ExpressionField: React.FC<ExpressionFieldProps> = (props: Expressio
             />
         );
     }
-    if (inputMode === InputMode.DROPDOWN && isDropDownType(primaryInputType)) {
+    if (inputMode === InputMode.SELECT && isDropDownType(primaryInputType)) {
         return (
             <EnumEditor
                 value={value}

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/types.ts
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/types.ts
@@ -24,7 +24,7 @@ export enum InputMode {
   NUMBER = "Number",
   BOOLEAN = "Boolean",
   SQL = "SQL",
-  DROPDOWN = "Dropdown",
+  SELECT = "Select",
   ARRAY = "Array",
   PROMPT = "Prompt",
   MAP = "Map"

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/utils.ts
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/utils.ts
@@ -51,7 +51,7 @@ export const getInputModeFromTypes = (inputType: InputType): InputMode => {
         return InputMode.EXP;
     }
     if (inputType.fieldType === "SINGLE_SELECT") {
-        return InputMode.DROPDOWN;
+        return InputMode.SELECT;
     }
     if (inputType.fieldType === "EXPRESSION_SET") {
         return InputMode.ARRAY;


### PR DESCRIPTION
## Purpose
> This PR will change the naming of the expression editor mode switcher button. Now for the dropdowns instead displaying the label as `Dropdown` it shows the label as `Select`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * AI Agent Mode with design, integration, and diagnostic capabilities
  * Enhanced Connectors with Persist and WSDL support
  * Expanded Expression Editor with new input modes
  * Improved Data Mapper with grouping and type conversion support
  * Review Mode with semantic diff visualization

* **Bug Fixes**
  * Windows installation, proxy configuration, and Cloud Editor issues
  * Data Mapper undo and visibility fixes
  * Expression Editor interpolation and validation improvements

* **Improvements**
  * Enhanced AI & Copilot authentication and state management
  * Multi-project and workspace support across core features
  * Editor performance and UI consistency improvements
  * Security dependency updates

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->