### PR TITLE
Update mode switcher selected mode

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/ExpressionEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/ExpressionEditor.tsx
@@ -437,6 +437,18 @@ export const ExpressionEditor = (props: ExpressionEditorProps) => {
         }
     }, [fieldValue, targetLineRange]);
 
+    const getFallBackSelectedType = (): InputType => {
+        if (
+            typeof field.value === 'string' &&
+            field.value.trim() !== ''
+        ) {
+            return field?.types[field.types.length - 1];
+        }
+        else {
+            return field?.types[0];
+        }
+    }
+
     useEffect(() => {
         // If recordTypeField is present, always use GUIDED mode
         if (recordTypeField) {
@@ -449,7 +461,7 @@ export const ExpressionEditor = (props: ExpressionEditorProps) => {
         };
         let selectedInputType = field?.types.find(type => type.selected);
         if (!selectedInputType) {
-            selectedInputType = field?.types[0];
+            selectedInputType = getFallBackSelectedType();
         }
         const inputMode = getInputModeFromTypes(selectedInputType);
         if (!inputMode) {


### PR DESCRIPTION
## Purpose
The input mode switcher did not correctly handle scenarios where a field already contained a value but no input mode was explicitly selected. This caused ambiguity in the frontend when deciding which input mode to render, leading to inconsistent fallback behavior.

Partially Resolves: https://github.com/wso2/product-ballerina-integrator/issues/2185

## Goals
- Ensure a valid input mode is always resolved in the frontend.
- Provide a sensible default when no value is present.

## Approach
- Updated the mode switcher logic to detect cases where a field contains a value but none of the input modes are selected.
- When the field does not contain a value, the frontend defaults to using the first available input mode.
- When the field does contain a value, the frontend defaults to using the last available input mode which will mostly be the expression editor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * AI Agent review mode with context persistence and automatic view refresh
  * Expression Editor now supports Map and Number input modes
  * Enhanced Data Mapper clause editor with improved type selection and validation

* **Improvements**
  * Simplified authentication state management for AI & Copilot
  * Refined JSON-only schema import workflow in Type Editor

* **Bug Fixes**
  * Resolved issues in Data Mapper, Expression Editor, and Security features

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->