### PR TITLE
Hide target type field in forms based on advanced property

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/Form/index.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/Form/index.tsx
@@ -1120,7 +1120,7 @@ export const Form = forwardRef((props: FormProps) => {
 
                             />
                         )}
-                        {targetTypeField && (
+                        {targetTypeField && !targetTypeField.advanced && (
                             <>
                                 <EditorFactory
                                     field={targetTypeField}


### PR DESCRIPTION
## Purpose

Fixes https://github.com/wso2/product-ballerina-integrator/issues/2195

This PR hides the type descriptor field from the side panel forms if it has the `advanced` property set to `true` in the node template.
