### PR TITLE
Fix match form not opening issue

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/MatchForm/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/MatchForm/index.tsx
@@ -139,6 +139,7 @@ export function MatchForm(props: MatchFormProps) {
                 optional: false,
                 editable: true,
                 advanced: false,
+                types: [{ fieldType: "EXPRESSION", selected: false }],
                 hidden: false,
             },
         ];
@@ -261,12 +262,14 @@ export function MatchForm(props: MatchFormProps) {
                                 description: "Binding pattern",
                             },
                             value: "",
+                            types: [{ fieldType: "EXPRESSION", selected: false }],
                             optional: false,
                             editable: true,
                             advanced: false,
                             hidden: false,
                         },
                     ],
+                    types: [{ fieldType: "SINGLE_SELECT", selected: false }],
                     optional: false,
                     editable: true,
                     advanced: false,
@@ -383,12 +386,14 @@ export function MatchForm(props: MatchFormProps) {
                             label: "Patterns",
                             description: "List of binding patterns",
                         },
+                        types: [{ fieldType: "SINGLE_SELECT", selected: false }],
                         value: [
                             {
                                 metadata: {
                                     label: "Pattern",
                                     description: "Binding pattern",
                                 },
+                                types: [{ fieldType: "EXPRESSION", selected: false }],
                                 value: "_",
                                 optional: false,
                                 editable: true,


### PR DESCRIPTION
## Purpose
The Match Form was crashing when opened due to a missing configuration introduced during the recent frontend refactoring related to the Language Server (LS) model changes.  
While the refactor correctly removed the deprecated `valueType` attribute, the corresponding replacement using the `types` array was not added. As a result, the Expression Editor received incomplete type metadata and failed during initialization.

## Goals
- Prevent the Match Form from crashing when opened.
- Ensure the Expression Editor receives the correct type information after the LS model refactor.
- Align the Match Form implementation with the updated LS model expectations.

## Approach
- Identified the root cause as the missing `types` array that should replace the removed `valueType` attribute.
- Updated the relevant configurations to properly include the `types` property in all necessary places.
- Ensured the Expression Editor is initialized with valid and complete type metadata.
- Verified that the Match Form opens correctly and the Expression Editor functions as expected after the fix.
