### PR TITLE
Fix boolean editor and fix function call form with boolean params

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/Form/index.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/Form/index.tsx
@@ -490,7 +490,7 @@ export const Form = forwardRef((props: FormProps) => {
                 if (isDropdownField(field)) {
                     defaultValues[field.key] = getValueForDropdown(field) ?? "";
                 } else if (field.type === "FLAG") {
-                    defaultValues[field.key] = field.value === "true" || (typeof field.value === "boolean" && field.value);
+                    defaultValues[field.key] = String(field.value === "true") || String((typeof field.value === "boolean" && field.value));
                 } else if (typeof field.value === "string") {
                     defaultValues[field.key] = formatJSONLikeString(field.value) ?? "";
                 } else {

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/EditorFactory.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/EditorFactory.tsx
@@ -93,7 +93,8 @@ export const EditorFactory = (props: FormFieldEditorProps) => {
             type.fieldType === "TEXT" ||
             type.fieldType === "EXPRESSION_SET" ||
             (type.fieldType === "SINGLE_SELECT" && isDropDownType(type)) ||
-            type.fieldType === "RECORD_MAP_EXPRESSION"
+            type.fieldType === "RECORD_MAP_EXPRESSION" ||
+            (field.type === "FLAG" && field.types?.length > 1)
         );
     });
 
@@ -109,7 +110,7 @@ export const EditorFactory = (props: FormFieldEditorProps) => {
         return <DropdownChoiceForm field={field} />;
     } else if (field.type === "TEXTAREA" || field.type === "STRING") {
         return <TextAreaEditor field={field} />;
-    } else if (field.type === "FLAG") {
+    } else if (field.type === "FLAG" && !showWithExpressionEditor) {
         return <CheckBoxEditor field={field} />;
     } else if (field.type === "EXPRESSION" && field.key === "resourcePath") {
         // HACK: this should fixed with the LS API. this is used to avoid the expression editor for resource path field.

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/ExpressionEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/ExpressionEditor.tsx
@@ -580,6 +580,7 @@ export const ExpressionEditor = (props: ExpressionEditorProps) => {
                 InputMode.TEMPLATE,
                 InputMode.TEXT,
                 InputMode.NUMBER,
+                InputMode.BOOLEAN,
             ]
                 .includes(targetMode) && inputMode === InputMode.EXP;
             if (shouldClearValue) {

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/components/ChipExpressionEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/components/ChipExpressionEditor.tsx
@@ -43,7 +43,7 @@ import {
     createTooltipContainer,
     createTooltipPositioningHandlers
 } from "../CodeUtils";
-import { correctTokenStreamPositions } from "../utils";
+import { correctTokenStreamPositions, normalizeEditorValue } from "../utils";
 import { history } from "@codemirror/commands";
 import { autocompletion } from "@codemirror/autocomplete";
 import { FloatingButtonContainer, FloatingToggleButton, ChipEditorContainer } from "../styles";
@@ -389,9 +389,9 @@ export const ChipExpressionEditorComponent = (props: ChipExpressionEditorCompone
         if (props.value == null || !viewRef.current) return;
         const serializedValue = configuration.serializeValue(props.value);
         const deserializeValue = configuration.deserializeValue(props.value);
-        if (deserializeValue.trim() !== props.value.trim()) {
+        if (normalizeEditorValue(deserializeValue) !== normalizeEditorValue(props.value)) {
             props.onChange(deserializeValue, deserializeValue.length);
-            return
+            return;
         }
         const updateEditorState = async () => {
             const sanitizedValue = props.sanitizedExpression ? props.sanitizedExpression(serializedValue) : serializedValue;
@@ -489,7 +489,7 @@ export const ChipExpressionEditorComponent = (props: ChipExpressionEditorCompone
                 ...props.sx,
                 ...(props.isInExpandedMode || props.hideFxButton ? { height: '100%' } : props.sx && 'height' in props.sx ? {} : { height: 'auto' })
             }}>
-                {!props.isInExpandedMode && !props.hideFxButton && configuration.getAdornment()({ onClick: () => {}})}
+                {!props.isInExpandedMode && !props.hideFxButton && configuration.getAdornment()({ onClick: () => { } })}
                 <div style={{
                     position: 'relative',
                     width: '100%',

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/utils.ts
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/utils.ts
@@ -62,6 +62,9 @@ export const getInputModeFromTypes = (inputType: InputType): InputMode => {
     if (inputType.fieldType === "PROMPT") {
         return InputMode.PROMPT;
     }
+    if (inputType.fieldType === "FLAG") {
+        return InputMode.BOOLEAN;
+    }
 
     //default behaviour
     return getInputModeFromBallerinaType(inputType.ballerinaType);
@@ -452,3 +455,6 @@ export const processFunctionWithArguments = async (
     // Keep caret at the end of the inserted snippet.
     return { finalValue: value, cursorAdjustment: value.length };
 };
+
+export const normalizeEditorValue = (v: unknown) =>
+  typeof v === 'string' ? v.trim() : v;


### PR DESCRIPTION
## Purpose
The Boolean Editor was not rendering in the Function Call Form when the function had boolean parameters. This issue was caused by overlapping conditions in the `EditorFactory`, where the FLAG editor condition was evaluated before the Boolean editor condition, resulting in the Boolean editor being skipped.

Resolves: https://github.com/wso2/product-ballerina-integrator/issues/2121

## Goals
- Ensure the Boolean Editor is correctly rendered for boolean parameters in the Function Call Form.
- Eliminate ambiguity caused by overlapping editor selection conditions.
- Maintain correct editor prioritization within the `EditorFactory`.

## Approach
- Analyzed the editor selection logic in `EditorFactory` and identified overlapping conditions between the FLAG editor and Boolean editor.
- Refactored the conditional checks to clearly differentiate between FLAG and boolean parameter types.
- Verified correct rendering and behavior of the Boolean Editor in the Function Call Form after the fix.
