### PR TITLE
Prevent updates to hidden form field

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/Form/index.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/Form/index.tsx
@@ -487,7 +487,9 @@ export const Form = forwardRef((props: FormProps) => {
             const formValues = getValues();
             console.log("Existing form values: ", formValues);
             formFields.forEach((field) => {
-                if (isDropdownField(field)) {
+                if (field.hidden) {
+                    defaultValues[field.key] = field.value;
+                } else if (isDropdownField(field)) {
                     defaultValues[field.key] = getValueForDropdown(field) ?? "";
                 } else if (field.type === "FLAG") {
                     defaultValues[field.key] = String(field.value === "true") || String((typeof field.value === "boolean" && field.value));


### PR DESCRIPTION
## Purpose

Fixes the form validation issue by ensuring the `checkError` hidden field remains untouched. 

Previously, the `checkError` value was being updated to a string, which caused the API to return irrelevant diagnostic errors as it does not expect updates to this specific hidden field. This PR ensures the original value is preserved during the save process.

## Changes
- Ensure the hidden field value remains consistent with the initial API state.

## Tasks
- https://github.com/wso2/product-ballerina-integrator/issues/2216