### PR TITLE
Fix expression editor placeholder not rendering

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/ExpandedEditor/modes/ExpressionMode.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/ExpandedEditor/modes/ExpressionMode.tsx
@@ -36,6 +36,7 @@ const ExpressionContainer = styled.div`
 export const ExpressionMode: React.FC<EditorModeExpressionProps> = ({
     value,
     onChange,
+    field,
     completions = [],
     fileName,
     targetLineRange,
@@ -66,6 +67,7 @@ export const ExpressionMode: React.FC<EditorModeExpressionProps> = ({
                     rawExpression={rawExpression}
                     isInExpandedMode={true}
                     isExpandedVersion={true}
+                    placeholder={field.placeholder}
                 />
             </ExpressionContainer>
             {error ?

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/ExpandedEditor/modes/PromptMode.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/ExpandedEditor/modes/PromptMode.tsx
@@ -132,6 +132,7 @@ export const PromptMode: React.FC<EditorModeExpressionProps> = ({
                         enableListContinuation={true}
                         inputMode={inputMode}
                         configuration={getPrimaryInputType(field.types)?.ballerinaType === "string" ? new StringTemplateEditorConfig() : new RawTemplateEditorConfig()}
+                        placeholder={field.placeholder}
                     />
                 </ExpressionContainer>
             ) : (

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/ExpandedEditor/modes/TemplateMode.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/ExpandedEditor/modes/TemplateMode.tsx
@@ -34,6 +34,7 @@ const ExpressionContainer = styled.div`
 export const TemplateMode: React.FC<EditorModeExpressionProps> = ({
     value,
     onChange,
+    field,
     completions = [],
     fileName,
     targetLineRange,
@@ -66,6 +67,7 @@ export const TemplateMode: React.FC<EditorModeExpressionProps> = ({
                     isInExpandedMode={true}
                     isExpandedVersion={true}
                     inputMode={inputMode}
+                    placeholder={field.placeholder}
                 />
             </ExpressionContainer>
             {error ?

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/ExpressionField.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/ExpressionField.tsx
@@ -229,7 +229,7 @@ export const ExpressionField: React.FC<ExpressionFieldProps> = (props: Expressio
                 onCancel={onCancel}
                 onRemove={onRemove}
                 growRange={growRange}
-                placeholder={placeholder}
+                placeholder={field.placeholder}
                 onOpenExpandedMode={onOpenExpandedMode}
                 isInExpandedMode={isInExpandedMode}
             />
@@ -252,6 +252,7 @@ export const ExpressionField: React.FC<ExpressionFieldProps> = (props: Expressio
                 onRemove={onRemove}
                 isInExpandedMode={isInExpandedMode}
                 configuration={getEditorConfiguration(inputMode)}
+                placeholder={field.placeholder}
             />
 
         );
@@ -273,6 +274,7 @@ export const ExpressionField: React.FC<ExpressionFieldProps> = (props: Expressio
                 onRemove={onRemove}
                 isInExpandedMode={isInExpandedMode}
                 configuration={new RawTemplateEditorConfig()}
+                placeholder={field.placeholder}
             />
 
         );
@@ -294,6 +296,7 @@ export const ExpressionField: React.FC<ExpressionFieldProps> = (props: Expressio
                 onRemove={onRemove}
                 isInExpandedMode={isInExpandedMode}
                 configuration={getPrimaryInputType(field.types)?.ballerinaType === "ai:Prompt" ? new RawTemplateEditorConfig() : new StringTemplateEditorConfig()}
+                placeholder={field.placeholder}
             />
 
         );
@@ -314,6 +317,7 @@ export const ExpressionField: React.FC<ExpressionFieldProps> = (props: Expressio
                 onOpenExpandedMode={onOpenExpandedMode}
                 onRemove={onRemove}
                 isInExpandedMode={isInExpandedMode}
+                placeholder={field.placeholder}
             />
 
         );
@@ -334,6 +338,7 @@ export const ExpressionField: React.FC<ExpressionFieldProps> = (props: Expressio
                 onOpenExpandedMode={onOpenExpandedMode}
                 onRemove={onRemove}
                 isInExpandedMode={isInExpandedMode}
+                placeholder={field.placeholder}
             />
         );
     }
@@ -354,6 +359,7 @@ export const ExpressionField: React.FC<ExpressionFieldProps> = (props: Expressio
             onRemove={onRemove}
             isInExpandedMode={isInExpandedMode}
             configuration={getEditorConfiguration(inputMode)}
+            placeholder={field.placeholder}
         />
     );
 };

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/components/ChipExpressionEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/components/ChipExpressionEditor.tsx
@@ -335,10 +335,10 @@ export const ChipExpressionEditorComponent = (props: ChipExpressionEditorCompone
                     activateOnTyping: true,
                     closeOnBlur: true
                 }),
-                ...(props.placeholder ? [placeholder(props.placeholder)] : []),
                 tooltips({ position: "absolute" }),
                 chipPlugin,
                 tokenField,
+                placeholder(props.placeholder),
                 chipTheme,
                 completionTheme,
                 EditorView.lineWrapping,

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/DynamicArrayBuilder/DynamicArrayBuilder.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/DynamicArrayBuilder/DynamicArrayBuilder.tsx
@@ -195,6 +195,7 @@ export const DynamicArrayBuilder = (props: DynamicArrayBuilderProps) => {
                         //have a switch to show the array editor mode and the expression mode.
                         //Exception: TEXT_SET uses StringTemplateEditorConfig for TEXT mode
                         configuration={expressionSetType?.fieldType === "TEXT_SET" ? new StringTemplateEditorConfig() : new ChipExpressionEditorDefaultConfiguration()}
+                        placeholder={expressionFieldProps.field.placeholder}
                     />
                     <S.DeleteButton
                         appearance="icon"

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/MappingConstructor/MappingConstructor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/MappingConstructor/MappingConstructor.tsx
@@ -143,6 +143,7 @@ export const MappingConstructor: React.FC<MappingConstructorProps> = ({ label, v
                             onRemove={expressionFieldProps.onRemove}
                             isInExpandedMode={expressionFieldProps.isInExpandedMode}
                             configuration={new ChipExpressionEditorDefaultConfiguration()}
+                            placeholder={expressionFieldProps.field.placeholder}
                         />
                     </S.KeyValueContainer>
                     <S.DeleteButton

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/NumberExpressionEditor/NumberEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/NumberExpressionEditor/NumberEditor.tsx
@@ -39,6 +39,7 @@ export const NumberExpressionEditor: React.FC<ChipExpressionEditorComponentProps
             onRemove={props.onRemove}
             isInExpandedMode={props.isInExpandedMode}
             configuration={new NumberExpressionEditorConfig()}
+            placeholder={props.placeholder}
         />
     );
 };

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/SqlExpressionEditor/SqlExpressionEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/SqlExpressionEditor/SqlExpressionEditor.tsx
@@ -39,6 +39,7 @@ export const SQLExpressionEditor: React.FC<ChipExpressionEditorComponentProps> =
             onRemove={props.onRemove}
             isInExpandedMode={props.isInExpandedMode}
             configuration={new SQLExpressionEditorConfig()}
+            placeholder={props.placeholder}
         />
     );
 };

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/TextExpressionEditor/TextModeEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/TextExpressionEditor/TextModeEditor.tsx
@@ -56,6 +56,7 @@ export const TextModeEditor: React.FC<ChipExpressionEditorComponentProps> = (pro
                 onRemove={props.onRemove}
                 isInExpandedMode={props.isInExpandedMode}
                 configuration={props.configuration}
+                placeholder={props.placeholder}
             />
         </EditorContainer>
     );

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/TypeEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/TypeEditor.tsx
@@ -355,7 +355,7 @@ export function TypeEditor(props: TypeEditorProps) {
                             onBlur={handleBlur}
                             onSave={onSave}
                             onCancel={handleCancel}
-                            placeholder={field.placeholder}
+
                             autoFocus={autoFocus}
                             sx={{ paddingInline: '0' }}
                             helperPaneZIndex={40001}


### PR DESCRIPTION
## Purpose
> This PR will resolve the issue where the expression editor placeholders are not showing up for the field with a valid placeholder value

Resolves: https://github.com/wso2/product-ballerina-integrator/issues/2219