### PR TITLE
Fix model provider form editors rendering as text editors

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/components/ConnectionSelector/config.ts
+++ b/workspaces/ballerina/ballerina-visualizer/src/components/ConnectionSelector/config.ts
@@ -29,7 +29,7 @@ import {
 export const CONNECTION_TYPE_CONFIGS: Record<ConnectionKind, ConnectionKindConfig> = {
     MODEL_PROVIDER: {
         displayName: "Model Provider",
-        types: [{ fieldType: "TEXT", ballerinaType: "ai:ModelProvider", selected: false }],
+        types: [{ fieldType: "EXPRESSION", ballerinaType: "ai:ModelProvider", selected: true }],
         nodePropertyKey: ["model", "modelProvider"],
         categoryConverter: convertModelProviderCategoriesToSidePanelCategories,
         searchConfig: (aiModuleOrg?: string): ConnectionSearchConfig => ({
@@ -39,25 +39,25 @@ export const CONNECTION_TYPE_CONFIGS: Record<ConnectionKind, ConnectionKindConfi
     },
     VECTOR_STORE: {
         displayName: "Vector Store",
-        types: [{ fieldType: "TEXT", ballerinaType: "ai:VectorStore", selected: false }],
+        types: [{ fieldType: "EXPRESSION", ballerinaType: "ai:VectorStore", selected: true }],
         nodePropertyKey: "vectorStore",
         categoryConverter: convertVectorStoreCategoriesToSidePanelCategories,
     },
     EMBEDDING_PROVIDER: {
         displayName: "Embedding Provider",
-        types: [{ fieldType: "TEXT", ballerinaType: "ai:EmbeddingProvider", selected: false }],
+        types: [{ fieldType: "EXPRESSION", ballerinaType: "ai:EmbeddingProvider", selected: true }],
         nodePropertyKey: "embeddingModel",
         categoryConverter: convertEmbeddingProviderCategoriesToSidePanelCategories,
     },
     CHUNKER: {
         displayName: "Chunker",
-        types: [{ fieldType: "TEXT", ballerinaType: "ai:Chunker", selected: false }],
+        types: [{ fieldType: "EXPRESSION", ballerinaType: "ai:Chunker", selected: true }],
         nodePropertyKey: "chunker",
         categoryConverter: convertChunkerCategoriesToSidePanelCategories,
     },
     MEMORY_STORE: {
         displayName: "Memory Store",
-        types: [{ fieldType: "TEXT", ballerinaType: "ai:MemoryStore", selected: false }],
+        types: [{ fieldType: "EXPRESSION", ballerinaType: "ai:MemoryStore", selected: true }],
         nodePropertyKey: "store",
         categoryConverter: convertMemoryStoreCategoriesToSidePanelCategories,
         searchConfig: (): ConnectionSearchConfig => ({


### PR DESCRIPTION
## Purpose

FIxes https://github.com/wso2/product-ballerina-integrator/issues/2228

This PR fixes the model provider form fields being rendered as text editors instead of expression editors.

<img width="1228" height="802" alt="image" src="https://github.com/user-attachments/assets/982531ec-7bc9-4ff1-8f6c-19fb2b1fa9e8" />
