### PR TITLE
fix prompt editor flowmodel selected type is not properly selected in…

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/utils/bi.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/utils/bi.tsx
@@ -483,6 +483,10 @@ export function enrichFormTemplatePropertiesWithValues(
                 if (formProperty.diagnostics) {
                     enrichedFormTemplateProperties[key as NodePropertyKey].diagnostics = formProperty.diagnostics;
                 }
+
+                if (formProperty.types) {
+                    enrichedFormTemplateProperties[key as NodePropertyKey].types = formProperty.types;
+                }
             }
         }
     }


### PR DESCRIPTION
## Purpose
The prompt editor flow model selected type was not being correctly reflected in the expression editor. As a result, the expression editor did not show the expected selected type when editing prompt-related fields.

This issue was caused by the `enrichFormTemplatePropertiesWithValues` function not properly copying the `types` array into the corresponding `formField`, leading to incomplete type information being passed to the expression editor.

Resolves: https://github.com/wso2/product-ballerina-integrator/issues/2185

## Goals
- Ensure the selected type in the prompt editor flow model is correctly propagated to the expression editor.
- Maintain consistency between the flow model configuration and the editor state.
- Fix the data enrichment logic so all required type metadata is preserved.

## Approach
- Updated the `enrichFormTemplatePropertiesWithValues` function to correctly copy the `types` array into the relevant `formField`.
- Ensured the enriched form field contains complete and accurate type information before being consumed by the expression editor.
- Verified that the expression editor now correctly reflects the selected type from the flow model.

_No UI changes were introduced; the fix is limited to data enrichment and editor state handling._
