### PR TITLE
fix issue expression editor to properly render the array editor in array mode

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/ExpressionField.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/ExpressionField.tsx
@@ -151,18 +151,15 @@ export const ExpressionField: React.FC<ExpressionFieldProps> = (props: Expressio
         isInExpandedMode
     } = props;
 
-    if (Array.isArray(value)) {
-        if (inputMode === InputMode.ARRAY || inputMode === InputMode.TEXT_ARRAY) {
-            return (
-                <DynamicArrayBuilder
-                    value={value}
-                    label={field.label}
-                    onChange={(val) => onChange(val, val.length)}
-                    expressionFieldProps={props}
-                />
-            );
-        }
-        throw new Error(`Unsupported editor for input mode: ${inputMode}`);
+    if (Array.isArray(value) || inputMode === InputMode.ARRAY || inputMode === InputMode.TEXT_ARRAY) {
+        return (
+            <DynamicArrayBuilder
+                value={value}
+                label={field.label}
+                onChange={(val) => onChange(val, val.length)}
+                expressionFieldProps={props}
+            />
+        );
     }
     if (inputMode === InputMode.MAP) {
         return (
@@ -173,19 +170,6 @@ export const ExpressionField: React.FC<ExpressionFieldProps> = (props: Expressio
                 expressionFieldProps={props}
             />
         );
-    }
-    if (inputMode === InputMode.TEXT_ARRAY) {
-        return (
-            <DynamicArrayBuilder
-                value={value}
-                label={field.label}
-                onChange={(val) => onChange(val, val.length)}
-                expressionFieldProps={props}
-            />
-        );
-    }
-    if (Array.isArray(value)) {
-        throw new Error(`Invalid value type: expected a string but received an array for input mode ${inputMode}`);
     }
 
     const primaryInputType = getPrimaryInputType(field.types || []);


### PR DESCRIPTION
## Purpose
When the input type was defined as an array, the UI incorrectly rendered the expression editor instead of the array editor. This resulted in an inconsistent and incorrect editing experience for array-based inputs.

The issue was caused by incorrect conditional logic in the `expressionField`, where the value type was checked first and the input type was evaluated only inside that condition, leading to array input types being misidentified.

Resolves: https://github.com/wso2/product-ballerina-integrator/issues/2233

## Goals
- Ensure array input types are correctly rendered using the array editor.
- Prevent array inputs from being incorrectly handled as expressions.
- Improve the accuracy of input type detection logic.

## Approach
- Refactored the conditional logic in `expressionField` to correctly identify array input types.
- Updated the checks to evaluate the value type and input mode together using an OR condition, instead of nesting the input type check inside the value type check.
- Verified that array input types now consistently render the array editor as expected.
