### PR TITLE
Fix record config model wraps selected variables with braces

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/RecordConfigModal.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/RecordConfigModal.tsx
@@ -27,6 +27,7 @@ import { useForm } from "react-hook-form";
 import { debounce } from "lodash";
 import ReactMarkdown from "react-markdown";
 import { updateFieldsSelection } from "../Components/RecordConstructView/utils";
+import { ChipExpressionEditorDefaultConfiguration } from "@wso2/ballerina-side-panel/lib/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/ChipExpressionDefaultConfig";
 
 type ConfigureRecordPageProps = {
     fileName: string;
@@ -703,6 +704,7 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
                                             extractArgsFromFunction={wrappedExtractArgsFromFunction}
                                             getHelperPane={wrappedGetHelperPane}
                                             sx={{ height: "350px" }}
+                                            configuration={new ChipExpressionEditorDefaultConfiguration()}
                                             isExpandedVersion={false}
                                         />
                                         {formDiagnostics && formDiagnostics.length > 0 && (


### PR DESCRIPTION
## Purpose

The Record Config Model was incorrectly wrapping variable names with `${}` when a variable was selected via the helper pane.  
This issue occurred because the editor was being initialized with an incorrect editor configuration object, which caused unintended expression interpolation.

Resolves: https://github.com/wso2/product-ballerina-integrator/issues/2239

## Goals

- Ensure variables selected from the helper pane are inserted as plain variable names without `${}` wrapping.
- Fix the editor initialization to use the correct configuration object for the Record Config Model.
- Maintain consistent and expected editor behavior without impacting other configurations.

## Approach

- Identified that an incorrect editor configuration object was being passed to the Record Config Model.
- Updated the implementation to provide the correct editor configuration object.
- Verified that variables selected through the helper pane are now inserted correctly without expression wrapping.
