### PR TITLE
Fix Windows URI Handling for AI Review Mode

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/diagnostics-utils.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/diagnostics-utils.ts
@@ -100,7 +100,7 @@ export async function checkCompilationErrors(
             diagnostics = await checkProjectDiagnostics(langClient, tempProjectPath, true);
         } catch (diagError) {
             // Resolve module dependencies using ai scheme
-            const aiUri = Uri.from({ scheme: 'ai', path: tempProjectPath }).toString();
+            const aiUri = Uri.file(tempProjectPath).with({ scheme: 'ai' }).toString();
             await langClient.resolveModuleDependencies({
                 documentIdentifier: {
                     uri: aiUri

--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/ai-panel/repair-utils.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/ai-panel/repair-utils.ts
@@ -45,9 +45,9 @@ export async function attemptRepairProject(langClient: ExtendedLangClient, tempD
 
 export async function checkProjectDiagnostics(langClient: ExtendedLangClient, tempDir: string, isAISchema: boolean = false): Promise<Diagnostics[]> {
     const allDiags: Diagnostics[] = [];
-    let projectUri = Uri.from({ scheme: 'file', path: tempDir }).toString();
+    let projectUri = Uri.file(tempDir).toString();
     if (isAISchema) {
-        projectUri = Uri.from({ scheme: 'ai', path: tempDir }).toString();
+        projectUri = Uri.file(tempDir).with({ scheme: 'ai' }).toString();
     }
     console.log("Getting project diagnostics for URI:", projectUri);
     let response: ProjectDiagnosticsResponse = await langClient.getProjectDiagnostics({

--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/bi-diagram/rpc-manager.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/bi-diagram/rpc-manager.ts
@@ -1511,7 +1511,7 @@ export class BiDiagramRpcManager implements BIDiagramAPI {
         return new Promise((resolve) => {
             let projectPath: string;
             if (params?.projectPath) {
-                const uri = Uri.parse(params.projectPath);
+                const uri = Uri.file(params.projectPath);
                 projectPath = uri.with({ scheme: 'ai' }).toString();
             } else {
                 projectPath = StateMachine.context().projectPath;


### PR DESCRIPTION
### Root Cause
Windows filesystem paths (e.g., C:\Users\...) were being converted to URIs using `Uri.parse()` and `Uri.from()`, which don't properly handle Windows paths. This resulted in malformed URIs with URL-encoded backslashes that the Java language server cannot parse.

### Solution
Use `Uri.file()` to properly convert filesystem paths to URIs before changing the scheme. This ensures correct URI formatting across all platforms.

Pattern:
```javascript
// ❌ Before (incorrect)
Uri.parse(filePath)Uri.from({ scheme: 'ai', path: filePath })
// ✅ After (correct)
Uri.file(filePath)Uri.file(filePath).with({ scheme: 'ai' })
```

### Impact
✅ Fixes critical Windows compatibility issue in AI Review Mode
✅ No breaking changes - only corrects URI construction
✅ All platforms (Windows, macOS, Linux) now use consistent URI handling
✅ All linter checks pass

### Additional Notes:
This pattern (`Uri.file()` for filesystem paths) is already used correctly in other parts of the codebase (e.g., `stateMachine.ts` line 544). These changes align the Review Mode code with the established pattern.

Fixed: https://github.com/wso2/product-ballerina-integrator/issues/2280

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized internal URI construction methods for improved code consistency across dependency resolution and project handling components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->