### PR TITLE
Fix Resource configuration response edit form reset the value of Stat…

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/ResourceForm/ResourceResponse/ResponseItem.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/ResourceForm/ResourceResponse/ResponseItem.tsx
@@ -45,11 +45,7 @@ export function ResponseItem(props: ParamItemProps) {
     };
 
     const getFormattedResponse = (response: StatusCodeResponse, method: HTTP_METHOD) => {
-        if (response.statusCode.value && (Number(response.statusCode.value) === 200 || Number(response.statusCode.value) === 201)) {
-            return getDefaultResponse(method);
-        } else {
-            return response.statusCode.value || getDefaultResponse(method);
-        }
+        return response.statusCode.value || getDefaultResponse(method);
     };
 
     return (


### PR DESCRIPTION
## Purpose
The resource configuration response edit form was incorrectly resetting the **Status Code** field to `200` when editing an existing response. This occurred due to faulty rendering logic that always fell back to a default value instead of using the actual configured response status code, leading to unintended changes in previously saved configurations.

Resolves: https://github.com/wso2/product-ballerina-integrator/issues/1322

## Goals
- Prevent the response edit form from resetting the Status Code to the default value.
- Ensure the form correctly reflects the actual `response.code` when editing an existing resource configuration.
- Maintain consistency and correctness of response configurations during edit flows.

## Approach
- Identified and fixed the conditional logic responsible for rendering the Status Code field.
- Updated the rendering logic to prioritize the existing `response.code` over the default status code.
- Verified the fix by editing existing resource responses and confirming the Status Code remains unchanged.



https://github.com/user-attachments/assets/9af62b77-466b-4a41-9353-0720bba2c893

