### PR TITLE
Ensure form validation runs before LS diagnostics

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/Form/index.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/Form/index.tsx
@@ -564,23 +564,25 @@ export const Form = forwardRef((props: FormProps) => {
         onSubmit && onSubmit(data, dirtyFields);
     };
 
-    const handleFormValidation = async (): Promise<boolean> => {
+    const handleFormValidation = async (formData?: FormValues): Promise<boolean> => {
+        if (!onFormValidation) {
+            return true;
+        }
+
         setIsValidatingForm(true);
-        const data = getValues();
-        const validationResult = await onFormValidation(data, dirtyFields);
-        setIsValidatingForm(false);
-        return validationResult;
+        const data = formData ?? getValues();
+
+        try {
+            const validationResult = await onFormValidation(data, dirtyFields);
+            return validationResult;
+        } finally {
+            setIsValidatingForm(false);
+        }
     }
 
     const handleOnBlur = async () => {
         onBlur?.(getValues(), dirtyFields);
     };
-
-    // Expose a method to trigger the save
-    // useImperativeHandle(ref, () => ({
-    //     triggerSave: () => handleSubmit(handleOnSave)(), // Call handleSubmit with the save function
-    //     resetForm: (values) => reset(values),
-    // }));
 
     const handleOpenRecordEditor = (open: boolean, typeField?: FormField, newType?: string | NodeProperties) => {
         openRecordEditor?.(open, getValues(), typeField, newType);
@@ -901,19 +903,27 @@ export const Form = forwardRef((props: FormProps) => {
         })();
     };
 
-    const handleOnSaveClick = async () => {
+    const handleOnSaveClick = () => {
         setSavingButton('save');
 
-        // Check for existing form errors (including pattern validation errors)
-        if (Object.keys(errors).length > 0) {
-            setSavingButton(null);
-            return;
-        }
-
-        const isValidForm = onFormValidation ? await handleFormValidation() : true;
-        if (isValidForm) {
-            handleSubmit(handleOnSave)();
-        }
+        handleSubmit(
+            async (data) => {
+                try {
+                    const isValidForm = await handleFormValidation(data);
+                    if (!isValidForm) {
+                        setSavingButton(null);
+                        return;
+                    }
+                    handleOnSave(data);
+                } catch (error) {
+                    console.error(">>> Error validating form before save", error);
+                    setSavingButton(null);
+                }
+            },
+            () => {
+                setSavingButton(null);
+            }
+        )();
     };
 
     const formContent = (

--- a/workspaces/ballerina/ballerina-side-panel/src/components/ParamManager/ParamManager.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/ParamManager/ParamManager.tsx
@@ -28,7 +28,7 @@ import { useFormContext } from '../../context';
 import { Imports, NodeKind } from '@wso2/ballerina-core';
 import { useRpcContext } from '@wso2/ballerina-rpc-client';
 import { EditorFactory } from '../editors/EditorFactory';
-import { getFieldKeyForAdvanceProp } from '../editors/utils';
+import { buildRequiredRule, getFieldKeyForAdvanceProp } from '../editors/utils';
 
 export interface Parameter {
     id: number;
@@ -145,10 +145,11 @@ export function ParamManagerEditor(props: ParamManagerEditorProps) {
                 control={control}
                 name={field.key}
                 rules={{
-                    required: {
-                        value: !field.optional && !field.placeholder,
+                    required: buildRequiredRule({
+                        isRequired: !field.optional,
+                        label: field.label,
                         message: `${selectedNode === "DATA_MAPPER_DEFINITION" ? 'Input type' : field.label} is required`
-                    }
+                    })
                 }}
                 render={({ field: { onChange }, fieldState: { error } }) => (
                     <>

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/ActionTypeEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/ActionTypeEditor.tsx
@@ -39,7 +39,7 @@ import { FormField } from "../Form/types";
 import { useFormContext } from "../../context";
 import { Controller } from "react-hook-form";
 import { S } from "./ExpressionEditor";
-import { getPropertyFromFormField, sanitizeType } from "./utils";
+import { buildRequiredRule, getPropertyFromFormField, sanitizeType } from "./utils";
 import { debounce } from "lodash";
 import styled from "@emotion/styled";
 import ReactMarkdown from "react-markdown";
@@ -604,10 +604,7 @@ export function ActionTypeEditor(props: ActionTypeEditorProps) {
                 name={field.key}
                 defaultValue={field.value}
                 rules={{
-                    required: {
-                        value: !field.optional,
-                        message: `${field.label} is required`
-                    }
+                    required: buildRequiredRule({ isRequired: !field.optional, label: field.label })
                 }}
                 render={({ field: { name, value, onChange }, fieldState: { error } }) => {
                     onChangeRef.current = onChange;

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/AutoCompleteEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/AutoCompleteEditor.tsx
@@ -21,7 +21,7 @@ import React, { useEffect } from "react";
 import { AutoComplete } from "@wso2/ui-toolkit";
 
 import { FormField } from "../Form/types";
-import { capitalize, getValueForDropdown } from "./utils";
+import { buildRequiredRule, capitalize, getValueForDropdown } from "./utils";
 import { useFormContext } from "../../context";
 import { SubPanel, SubPanelView } from "@wso2/ballerina-core";
 
@@ -42,7 +42,10 @@ export function AutoCompleteEditor(props: AutoCompleteEditorProps) {
             id={field.key}
             description={field.documentation}
             value={value as string}
-            {...register(field.key, { required: !field.optional, value: getValueForDropdown(field) })}
+            {...register(field.key, {
+                required: buildRequiredRule({ isRequired: !field.optional, label: field.label }),
+                value: getValueForDropdown(field)
+            })}
             label={capitalize(field.label)}
             items={field.items}
             allowItemCreate={true}

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/CustomDropdownEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/CustomDropdownEditor.tsx
@@ -26,7 +26,7 @@ import styled from "@emotion/styled";
 import { Dropdown } from "@wso2/ui-toolkit";
 
 import { FormField } from "../Form/types";
-import { capitalize, getValueForDropdown } from "./utils";
+import { buildRequiredRule, capitalize, getValueForDropdown } from "./utils";
 import { useFormContext } from "../../context";
 import { SubPanel, SubPanelView } from "@wso2/ballerina-core";
 
@@ -63,7 +63,10 @@ export function CustomDropdownEditor(props: CustomDropdownEditorProps) {
                 <Dropdown
                     id={field.key}
                     description={field.documentation}
-                    {...register(field.key, { required: !field.optional, value: getValueForDropdown(field) })}
+                    {...register(field.key, {
+                        required: buildRequiredRule({ isRequired: !field.optional, label: field.label }),
+                        value: getValueForDropdown(field)
+                    })}
                     label={capitalize(field.label)}
                     items={field.itemOptions ? field.itemOptions : field.items?.map((item) => ({ id: item, content: item, value: item }))}
                     required={!field.optional}
@@ -85,7 +88,10 @@ export function CustomDropdownEditor(props: CustomDropdownEditorProps) {
         <Dropdown
             id={field.key}
             description={field.documentation}
-            {...register(field.key, { required: !field.optional, value: getValueForDropdown(field) })}
+            {...register(field.key, {
+                required: buildRequiredRule({ isRequired: !field.optional, label: field.label }),
+                value: getValueForDropdown(field)
+            })}
             label={capitalize(field.label)}
             items={field.itemOptions ? field.itemOptions : field.items?.map((item) => ({ id: item, content: item, value: item }))}
             required={!field.optional}

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/DropdownChoiceForm.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/DropdownChoiceForm.tsx
@@ -21,7 +21,7 @@ import React, { useEffect, useState } from "react";
 import { Dropdown, LocationSelector, RadioButtonGroup } from "@wso2/ui-toolkit";
 
 import { FormField } from "../Form/types";
-import { capitalize, getValueForDropdown } from "./utils";
+import { buildRequiredRule, capitalize, getValueForDropdown } from "./utils";
 import { useFormContext } from "../../context";
 import styled from "@emotion/styled";
 import { EditorFactory } from "./EditorFactory";
@@ -74,7 +74,10 @@ export function DropdownChoiceForm(props: DropdownChoiceFormProps) {
             <ChoiceSection>
                 <Dropdown
                     id={field.key}
-                    {...register(field.key, { required: !field.optional, value: getValueForDropdown(field) })}
+                    {...register(field.key, {
+                        required: buildRequiredRule({ isRequired: !field.optional, label: field.label }),
+                        value: getValueForDropdown(field)
+                    })}
                     label={capitalize(field.label)}
                     description={field.documentation}
                     items={field.itemOptions ? field.itemOptions : field.items?.map((item) => ({ id: item, content: item, value: item }))}
@@ -104,5 +107,3 @@ export function DropdownChoiceForm(props: DropdownChoiceFormProps) {
         </FormContainer>
     );
 }
-
-

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/DropdownEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/DropdownEditor.tsx
@@ -21,7 +21,7 @@ import React, { useEffect } from "react";
 import { Dropdown } from "@wso2/ui-toolkit";
 
 import { FormField } from "../Form/types";
-import { capitalize, getValueForDropdown } from "./utils";
+import { buildRequiredRule, capitalize, getValueForDropdown } from "./utils";
 import { useFormContext } from "../../context";
 import { SubPanel, SubPanelView } from "@wso2/ballerina-core";
 
@@ -67,7 +67,10 @@ export function DropdownEditor(props: DropdownEditorProps) {
         <Dropdown
             id={field.key}
             description={field.documentation}
-            {...register(field.key, { required: !field.optional, value: getValueForDropdown(field) })}
+            {...register(field.key, {
+                required: buildRequiredRule({ isRequired: !field.optional, label: field.label }),
+                value: getValueForDropdown(field)
+            })}
             label={capitalize(field.label)}
             items={dropdownItems}
             required={!field.optional}

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/ExpressionEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/ExpressionEditor.tsx
@@ -28,7 +28,7 @@ import {
     RequiredFormInput,
     ThemeColors
 } from '@wso2/ui-toolkit';
-import { getPropertyFromFormField, isExpandableMode, sanitizeType, toEditorMode } from './utils';
+import { buildRequiredRule, getPropertyFromFormField, isExpandableMode, sanitizeType, toEditorMode } from './utils';
 import { FormField, FormExpressionEditorProps, HelperpaneOnChangeOptions } from '../Form/types';
 import { useFormContext } from '../../context';
 import {
@@ -687,7 +687,11 @@ export const ExpressionEditor = (props: ExpressionEditorProps) => {
 
                         // Only use 'required' if there's no pattern validation (pattern will handle empty values)
                         if (!patternType?.pattern && !expressionSetType?.pattern) {
-                            rules.required = required ?? (!field.optional && !field.placeholder);
+                            const effectiveRequired = required ?? !field.optional;
+                            rules.required = buildRequiredRule({
+                                isRequired: !!effectiveRequired,
+                                label: field.label
+                            });
                         }
 
                         if (expressionSetType?.pattern) {

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/FileSelect.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/FileSelect.tsx
@@ -22,7 +22,7 @@ import { Dropdown, LocationSelector } from "@wso2/ui-toolkit";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 
 import { FormField } from "../Form/types";
-import { capitalize, getValueForDropdown } from "./utils";
+import { buildRequiredRule } from "./utils";
 import { useFormContext } from "../../context";
 import { Controller } from "react-hook-form";
 
@@ -48,7 +48,7 @@ export function FileSelect(props: DropdownEditorProps) {
         <Controller
             control={control}
             name={field.key}
-            rules={{ required: !field.optional && !field.placeholder }}
+            rules={{ required: buildRequiredRule({ isRequired: !field.optional, label: field.label }) }}
             render={({ field: { value }, fieldState: { error } }) => (
                 <LocationSelector
                     label={`Select ${field.label} File`}

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/FormMapEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/FormMapEditor.tsx
@@ -23,6 +23,7 @@ import styled from "@emotion/styled";
 
 import { FormField } from "../Form/types";
 import { useFormContext } from "../../context";
+import { buildRequiredRule } from "./utils";
 
 namespace S {
     export const Container = styled.div({
@@ -239,10 +240,10 @@ export function FormMapEditor(props: FormMapEditorProps) {
                             <S.FieldContainer>
                                 <div style={{ width: "100%" }}>
                                     <S.FieldLabel>Expression</S.FieldLabel>
-                                    <TextField
-                                        id={`${field.key}-${index}-expression`}
-                                        {...register(`${field.key}-${index}-expression`, {
-                                            required: !field.optional,
+                                        <TextField
+                                            id={`${field.key}-${index}-expression`}
+                                            {...register(`${field.key}-${index}-expression`, {
+                                            required: buildRequiredRule({ isRequired: !field.optional, label: field.label }),
                                             value: initialValue.expression?.value || "",
                                         })}
                                         required={!field.optional}

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/IdentifierEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/IdentifierEditor.tsx
@@ -23,7 +23,7 @@ import { useFormContext } from "../../context";
 import styled from "@emotion/styled";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { debounce } from "lodash";
-import { getPropertyFromFormField } from "./utils";
+import { buildRequiredRule, getPropertyFromFormField } from "./utils";
 
 const EditRow = styled.div`
     display: flex;
@@ -243,7 +243,10 @@ export function IdentifierEditor(props: IdentifierEditorProps) {
                         <TextField
                             id={field.key}
                             name={field.key}
-                            {...register(field.key, { required: !field.optional && !field.placeholder, value: field.value })}
+                            {...register(field.key, {
+                                required: buildRequiredRule({ isRequired: !field.optional, label: field.label }),
+                                value: field.value
+                            })}
                             label={field.label}
                             required={!field.optional}
                             description={field.documentation}

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/IdentifierField.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/IdentifierField.tsx
@@ -21,7 +21,7 @@ import React, { useState, useCallback, useEffect } from "react";
 import { debounce } from "lodash";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { useFormContext } from "../../context";
-import { capitalize, getPropertyFromFormField } from "./utils";
+import { buildRequiredRule, capitalize, getPropertyFromFormField } from "./utils";
 import { FormField } from "../Form/types";
 export interface IdentifierFieldProps {
     field: FormField;
@@ -62,7 +62,10 @@ export function IdentifierField(props: IdentifierFieldProps) {
         handleOnFieldFocus?.(field.key);
     }
 
-    const registerField = register(field.key, { required: !field.optional && !field.placeholder, value: field.value })
+    const registerField = register(field.key, {
+        required: buildRequiredRule({ isRequired: !field.optional, label: field.label }),
+        value: field.value
+    })
     const { onChange } = registerField;
 
 

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiSelectEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiSelectEditor.tsx
@@ -22,7 +22,7 @@ import { Button, Codicon, Dropdown, OptionProps, ThemeColors } from "@wso2/ui-to
 import styled from "@emotion/styled";
 
 import { FormField } from "../Form/types";
-import { getValueForDropdown } from "./utils";
+import { buildRequiredRule, getValueForDropdown } from "./utils";
 import { useFormContext } from "../../context";
 import { SubPanel, SubPanelView } from "@wso2/ballerina-core";
 
@@ -183,7 +183,10 @@ export function MultiSelectEditor(props: MultiSelectEditorProps) {
                         <Dropdown
                             id={`${field.key}-${index}`}
                             {...register(`${field.key}-${index}`, {
-                                required: !field.optional && index === 0,
+                                required: buildRequiredRule({
+                                    isRequired: !field.optional && index === 0,
+                                    label: field.label
+                                }),
                                 value: getValueForDropdown(field, index)
                             })}
                             value={currentValue}

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/PathEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/PathEditor.tsx
@@ -21,7 +21,7 @@ import { FormField } from "../Form/types";
 import { TextField } from "@wso2/ui-toolkit";
 import { useFormContext } from "../../context";
 import { parseBasePath, parseResourceActionPath } from "../../utils/path-validations";
-import { capitalize } from "./utils";
+import { buildRequiredRule, capitalize } from "./utils";
 import { debounce } from "lodash";
 
 interface PathEditorProps {
@@ -55,7 +55,10 @@ export function PathEditor(props: PathEditorProps) {
         <TextField
             id={field.key}
             name={field.key}
-            {...register(field.key, { required: !field.optional && !field.placeholder, value: field.value })}
+            {...register(field.key, {
+                required: buildRequiredRule({ isRequired: !field.optional, label: field.label }),
+                value: field.value
+            })}
             label={capitalize(field.label)}
             required={!field.optional}
             description={field.documentation}

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/TextAreaEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/TextAreaEditor.tsx
@@ -26,6 +26,7 @@ import { ExpandedEditor } from "./ExpandedEditor";
 import styled from "@emotion/styled";
 import { ExpandIcon } from "./MultiModeExpressionEditor/ChipExpressionEditor/components/FloatingButtonIcons";
 import { FloatingToggleButton } from "./MultiModeExpressionEditor/ChipExpressionEditor/components/FloatingToggleButton";
+import { buildRequiredRule } from "./utils";
 
 interface TextAreaEditorProps {
     field: FormField;
@@ -82,10 +83,7 @@ export function TextAreaEditor(props: TextAreaEditorProps) {
                     name={field.key}
                     defaultValue={field.value}
                     rules={{
-                        required: {
-                            value: !field.optional && !field.placeholder,
-                            message: `${field.label} is required`
-                        }
+                        required: buildRequiredRule({ isRequired: !field.optional, label: field.label })
                     }}
                     render={({ field: { name, value, onChange } }) => (
                         <TextAreaContainer>

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/TextEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/TextEditor.tsx
@@ -20,7 +20,7 @@ import React from "react";
 import { FormField } from "../Form/types";
 import { TextField } from "@wso2/ui-toolkit";
 import { useFormContext } from "../../context";
-import { capitalize } from "./utils";
+import { buildRequiredRule, capitalize } from "./utils";
 
 interface TextEditorProps {
     field: FormField;
@@ -40,7 +40,7 @@ export function TextEditor(props: TextEditorProps) {
 
     // Build validation rules
     const validationRules: any = {
-        required: !field.optional && !field.placeholder,
+        required: buildRequiredRule({ isRequired: !field.optional, label: field.label }),
         value: field.value
     };
 

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/TypeEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/TypeEditor.tsx
@@ -34,7 +34,7 @@ import { FormField } from "../Form/types";
 import { useFormContext } from "../../context";
 import { Controller } from "react-hook-form";
 import { S } from "./ExpressionEditor";
-import { sanitizeType } from "./utils";
+import { buildRequiredRule, sanitizeType } from "./utils";
 import { debounce } from "lodash";
 import styled from "@emotion/styled";
 import ReactMarkdown from "react-markdown";
@@ -291,10 +291,7 @@ export function TypeEditor(props: TypeEditorProps) {
                 name={field.key}
                 defaultValue={field.value}
                 rules={{
-                    required: {
-                        value: !field.optional,
-                        message: `${field.label} is required`
-                    }
+                    required: buildRequiredRule({ isRequired: !field.optional, label: field.label })
                 }}
                 render={({ field: { name, value, onChange }, fieldState: { error } }) => (
                     <div>

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/utils.ts
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/utils.ts
@@ -57,6 +57,23 @@ export function capitalize(str: string) {
     return startCase(str);
 }
 
+type RequiredRuleOptions = {
+    isRequired: boolean;
+    label?: string;
+    message?: string;
+};
+
+export const buildRequiredRule = ({ isRequired, label, message }: RequiredRuleOptions) => {
+    if (!isRequired) {
+        return false;
+    }
+
+    return {
+        value: true,
+        message: message ?? `${label ?? "This field"} is required`,
+    };
+};
+
 export function sanitizeType(type: string) {
     if (type.includes('{') || type.includes('}') || (type.match(/:/g) || []).length > 1) {
         return type;


### PR DESCRIPTION
### Purpose

Ensures React Hook Form validation executes prior to invoking LS diagnostics to prevent LS re-renders from clearing client-side errors.

https://github.com/user-attachments/assets/58dbaf02-d67c-48d1-8b7c-de6d15457e16


### Key Changes

* **Refactor Save Flow:** Reorganized `Form/index.tsx` to ensure validation layers execute in the correct sequence.
* **Validation Logic:** Updated `handleFormValidation` to accept explicit `FormValues` and implemented `try/finally` blocks around `setIsValidatingForm`.
* **State Management:** Gated `handleOnSave` on both validation layers and ensured the saving state resets correctly on failure.
* **UX Improvements:** Kept LS validation errors visible by halting the process early if diagnostics fail, avoiding premature spinner locking.

### Linked Issues

Fixes: https://github.com/wso2/product-ballerina-integrator/issues/2325

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form validation error handling with enhanced logging and state management.
  * Enhanced save operation to properly validate forms before persisting data.

* **Refactor**
  * Standardized validation rule structure across form editors for consistency and maintainability.
  * Improved error handling flow in form submission to ensure proper cleanup of validation state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->