### PR TITLE
Fix completions for method access

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/CodeUtils.ts
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/CodeUtils.ts
@@ -159,6 +159,7 @@ export const completionTheme = EditorView.theme({
         borderRadius: "3px",
         padding: "2px 0px",
         maxHeight: "300px",
+        maxWidth: "300px",
         overflow: "auto",
         zIndex: "3000",
         boxShadow: "0 4px 16px rgba(0, 0, 0, 0.25)",

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/components/ChipExpressionEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/components/ChipExpressionEditor.tsx
@@ -333,7 +333,8 @@ export const ChipExpressionEditorComponent = (props: ChipExpressionEditorCompone
                 autocompletion({
                     override: [completionSource],
                     activateOnTyping: true,
-                    closeOnBlur: true
+                    closeOnBlur: true,
+                    compareCompletions: () => 0
                 }),
                 tooltips({ position: "absolute" }),
                 chipPlugin,

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/utils.ts
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/utils.ts
@@ -169,8 +169,12 @@ export const getWordBeforeCursorPosition = (textBeforeCursor: string): string =>
 export const filterCompletionsByPrefixAndType = (completions: CompletionItem[], prefix: string): CompletionItem[] => {
     if (!prefix) {
         return completions.filter(completion =>
-            completion.kind === 'field'
-        );
+            completion.kind === 'field' || completion.kind === 'function'
+        ).sort((a, b) => {
+            if (a.kind === 'field' && b.kind === 'function') return -1;
+            if (a.kind === 'function' && b.kind === 'field') return 1;
+            return 0;
+        });
     }
 
     return completions.filter(completion =>


### PR DESCRIPTION
## Purpose
Previously, method completions for array types (and similar objects) were not being shown in the completion suggestions. This issue was caused by the completion filtering logic being restricted to field-only completions.

Because of this limitation, valid method accesses (such as array functions and other object methods) were unintentionally excluded from the suggestions list. 

Resolves: https://github.com/wso2/product-ballerina-integrator/issues/2379


## Goals
- Ensure method/function completions are displayed alongside field completions.
- Maintain existing filtering behavior for fields while extending support to methods.


## Approach
The issue was addressed by updating the completion filtering logic.

Previously, the filter only allowed field completions. The fix introduces an additional condition to also allow function/method completions.
