### PR TITLE
remove number editor get helper button

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/Configurations.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/Configurations.tsx
@@ -212,6 +212,10 @@ export class NumberExpressionEditorConfig extends ChipExpressionEditorDefaultCon
 
     }
 
+    getIsToggleHelperAvailable(): boolean {
+        return false;
+    }
+
     getIsValueCompatible(value: string): boolean {
         return this.DECIMAL_INPUT_REGEX.test(value);
     }


### PR DESCRIPTION
## Purpose
> This PR will hide the helper pane toggle button from the number input editor

Resolves: https://github.com/wso2/product-ballerina-integrator/issues/2331