### PR TITLE
Fix expression editor mode switcher does not update the form fields 

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/ExpressionEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/ExpressionEditor.tsx
@@ -486,9 +486,11 @@ export const ExpressionEditor = (props: ExpressionEditorProps) => {
         const inputMode = getInputModeFromTypes(selectedInputType);
         if (!inputMode) {
             setInputMode(InputMode.EXP);
+            updateFieldTypesSelection(InputMode.EXP);
             return;
         };
         setInputMode(inputMode);
+        updateFieldTypesSelection(inputMode);
     }, [field?.types, recordTypeField]);
 
     const handleFocus = async (controllerOnChange?: (value: string) => void) => {
@@ -576,10 +578,17 @@ export const ExpressionEditor = (props: ExpressionEditorProps) => {
         return valueConfigObject.getIsValueCompatible(expValue);
     }
 
+    const updateFieldTypesSelection = (targetMode: InputMode) => {
+        field.types?.forEach(type => {
+            type.selected = getInputModeFromTypes(type) === targetMode;
+        });
+    };
+
     const handleModeChange = (value: InputMode) => {
         const raw = watch(key);
         const currentValue = raw && typeof raw === "string" ? raw.trim() : "";
         if (inputMode !== InputMode.EXP) {
+            updateFieldTypesSelection(value);
             setInputMode(value);
             return;
         }
@@ -588,11 +597,13 @@ export const ExpressionEditor = (props: ExpressionEditorProps) => {
             setShowModeSwitchWarning(true)
             return;
         }
+        updateFieldTypesSelection(value);
         setInputMode(value);
     };
 
     const handleModeSwitchWarningContinue = () => {
         if (targetInputModeRef.current !== null) {
+            updateFieldTypesSelection(targetInputModeRef.current);
             setInputMode(targetInputModeRef.current);
             const targetMode = targetInputModeRef.current;
             const shouldClearValue = [
@@ -667,7 +678,7 @@ export const ExpressionEditor = (props: ExpressionEditorProps) => {
                                 <S.HeaderContainer>
                                     <S.LabelContainer>
                                         <S.Label>{field.label}</S.Label>
-                                        {field.defaultValue && <S.DefaultValue style={{marginLeft: '8px'}}>{ `(Default: ${field.defaultValue}) `}</S.DefaultValue>}
+                                        {field.defaultValue && <S.DefaultValue style={{ marginLeft: '8px' }}>{`(Default: ${field.defaultValue}) `}</S.DefaultValue>}
                                         {(required ?? !field.optional) && <RequiredFormInput />}
                                         {getPrimaryInputType(field.types)?.ballerinaType && (
                                             <S.Type style={{ marginLeft: '5px' }} isVisible={focused} title={getPrimaryInputType(field.types)?.ballerinaType}>
@@ -795,8 +806,8 @@ export const ExpressionEditor = (props: ExpressionEditorProps) => {
                                         setFormDiagnostics([]);
                                         // Use ref to get current mode (not stale closure value)
                                         const currentMode = inputModeRef.current;
-                                        const rawValue = (currentMode === InputMode.PROMPT || currentMode === InputMode.TEMPLATE) && 
-                                        rawExpression ? rawExpression(typeof updatedValue === 'string' ? updatedValue : JSON.stringify(updatedValue)) : updatedValue;
+                                        const rawValue = (currentMode === InputMode.PROMPT || currentMode === InputMode.TEMPLATE) &&
+                                            rawExpression ? rawExpression(typeof updatedValue === 'string' ? updatedValue : JSON.stringify(updatedValue)) : updatedValue;
 
                                         onChange(rawValue);
                                         if (getExpressionEditorDiagnostics && (currentMode === InputMode.EXP || currentMode === InputMode.PROMPT || currentMode === InputMode.TEMPLATE)) {


### PR DESCRIPTION
## Purpose
Fix an issue where changing the **expression mode** in the Expression Editor did not update the corresponding `formField` object.

Since the `formField` state remained stale after switching modes, Diagnostics API—were unable to correctly determine which input mode the value originated from. This resulted in inconsistent validations and unexpected diagnostic behaviour.

**Resolves:** https://github.com/wso2/product-ballerina-integrator/issues/2464

---

## Goals
- Keep the `formField` object synchronized with the selected expression mode.
- Prevent inconsistent validations and incorrect diagnostic results.
- Ensure predictable behaviour when users switch between expression modes.

---

## Approach
- Updated the Expression Editor mode-switch handling logic to propagate changes to the underlying `formField` object.
- Ensured the `formField` state reflects the latest mode immediately after a switch.
- Verified Diagnostics API behaviour to confirm it can now correctly resolve the input mode source.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the expression editor to consistently synchronize field type selections with the active input mode, ensuring selections remain properly aligned across all user interactions and mode transitions.
  * Refined UI text spacing in the expression editor's default value element for improved visual clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->