### PR TITLE
Add `lib.bal` With Validator Import on Library Project Creation

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/features/bi/activator.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/bi/activator.ts
@@ -156,12 +156,12 @@ export function activate(context: BallerinaExtension) {
 
     commands.registerCommand(BI_COMMANDS.TOGGLE_TRACE_LOGS, toggleTraceLogs);
 
-    commands.registerCommand(BI_COMMANDS.CREATE_BI_PROJECT, (params) => {
+    commands.registerCommand(BI_COMMANDS.CREATE_BI_PROJECT, async (params) => {
         let path: string;
         if (params.createAsWorkspace) {
-            path = createBIWorkspace(params);
+            path = await createBIWorkspace(params);
         } else {
-            path = createBIProjectPure(params);
+            path = await createBIProjectPure(params);
         }
         return path;
     });

--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/bi-diagram/rpc-manager.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/bi-diagram/rpc-manager.ts
@@ -644,10 +644,10 @@ export class BiDiagramRpcManager implements BIDiagramAPI {
 
     async createProject(params: ProjectRequest): Promise<void> {
         if (params.createAsWorkspace) {
-            const workspaceRoot = createBIWorkspace(params);
+            const workspaceRoot = await createBIWorkspace(params);
             openInVSCode(workspaceRoot);
         } else {
-            const projectRoot = createBIProjectPure(params);
+            const projectRoot = await createBIProjectPure(params);
             openInVSCode(projectRoot);
         }
     }

--- a/workspaces/ballerina/ballerina-extension/src/utils/bi.ts
+++ b/workspaces/ballerina/ballerina-extension/src/utils/bi.ts
@@ -42,10 +42,13 @@ import { debug } from "./logger";
 import { parse } from "@iarna/toml";
 import { getProjectTomlValues } from "./config";
 import { extension } from "../BalExtensionContext";
+import { runBackgroundTerminalCommand } from "./runCommand";
 
 export const README_FILE = "readme.md";
 export const FUNCTIONS_FILE = "functions.bal";
 export const DATA_MAPPING_FILE = "data_mappings.bal";
+
+export const VALIDATOR_PACKAGE_NAME = "wso2/bi.validator";
 
 /**
  * Interface for the processed project information
@@ -297,7 +300,7 @@ function setupProjectInfo(projectRequest: ProjectRequest): ProcessedProjectInfo 
     };
 }
 
-export function createBIWorkspace(projectRequest: ProjectRequest): string {
+export async function createBIWorkspace(projectRequest: ProjectRequest): Promise<string> {
     const ballerinaTomlContent = `
 [workspace]
 packages = ["${projectRequest.packageName}"]
@@ -312,7 +315,7 @@ packages = ["${projectRequest.packageName}"]
     writeBallerinaFileDidOpen(ballerinaTomlPath, ballerinaTomlContent);
 
     // Create Ballerina Package
-    createBIProjectPure({ ...projectRequest, projectPath: workspaceRoot, createDirectory: true });
+    await createBIProjectPure({ ...projectRequest, projectPath: workspaceRoot, createDirectory: true });
 
     // create settings.json file
     createVSCodeSettings(workspaceRoot);
@@ -321,7 +324,7 @@ packages = ["${projectRequest.packageName}"]
     return workspaceRoot;
 }
 
-export function createBIProjectPure(projectRequest: ProjectRequest): string {
+export async function createBIProjectPure(projectRequest: ProjectRequest): Promise<string> {
     const projectInfo = setupProjectInfo(projectRequest);
     const { projectRoot, finalOrgName, finalVersion, packageName: finalPackageName, integrationName } = projectInfo;
 
@@ -333,7 +336,6 @@ export function createBIProjectPure(projectRequest: ProjectRequest): string {
     // Build the distribution line if version is available
     const distributionLine = distribution ? `distribution = "${distribution}"\n` : '';
 
-    const libraryLine = projectRequest.isLibrary ? '\nlibrary = true' : '';
     const ballerinaTomlContent = `
 [package]
 org = "${finalOrgName}"
@@ -382,6 +384,17 @@ sticky = true
     const datamappingsBalPath = path.join(projectRoot, 'data_mappings.bal');
     writeBallerinaFileDidOpen(datamappingsBalPath, EMPTY);
 
+    if (projectRequest.isLibrary) {
+        const libraryBal = path.join(projectRoot, 'lib.bal');
+        const libraryBalContent = `import ${VALIDATOR_PACKAGE_NAME} as _;`;
+        try {
+            await runBackgroundTerminalCommand(`bal pull ${VALIDATOR_PACKAGE_NAME}`);
+        } catch (error) {
+            console.error('Failed to pull validator package:', error);
+        }
+        writeBallerinaFileDidOpen(libraryBal, libraryBalContent);
+    }
+
     // Create .vscode configuration files
     createVSCodeSettingsWithLaunch(projectRoot);
 
@@ -413,7 +426,7 @@ export async function convertProjectToWorkspace(params: AddProjectToWorkspaceReq
     createWorkspaceToml(newDirectory, currentPackageName);
     addToWorkspaceToml(newDirectory, params.packageName);
 
-    createProjectInWorkspace(params, newDirectory);
+    await createProjectInWorkspace(params, newDirectory);
 
     // create settings.json file
     createVSCodeSettings(newDirectory);
@@ -425,7 +438,7 @@ export async function addProjectToExistingWorkspace(params: AddProjectToWorkspac
     const workspacePath = StateMachine.context().workspacePath;
     addToWorkspaceToml(workspacePath, params.packageName);
 
-    createProjectInWorkspace(params, workspacePath);
+    await createProjectInWorkspace(params, workspacePath);
 }
 
 function createWorkspaceToml(workspacePath: string, packageName: string) {
@@ -537,7 +550,7 @@ function removePackageFromToml(tomlContent: string, packagePath: string): string
     }
 }
 
-function createProjectInWorkspace(params: AddProjectToWorkspaceRequest, workspacePath: string): string {
+async function createProjectInWorkspace(params: AddProjectToWorkspaceRequest, workspacePath: string): Promise<string> {
     const projectRequest: ProjectRequest = {
         projectName: params.projectName,
         packageName: params.packageName,
@@ -548,7 +561,7 @@ function createProjectInWorkspace(params: AddProjectToWorkspaceRequest, workspac
         isLibrary: params.isLibrary
     };
 
-    return createBIProjectPure(projectRequest);
+    return await createBIProjectPure(projectRequest);
 }
 
 export function openInVSCode(projectRoot: string) {

--- a/workspaces/ballerina/ballerina-extension/src/utils/config.ts
+++ b/workspaces/ballerina/ballerina-extension/src/utils/config.ts
@@ -22,6 +22,7 @@ import { WorkspaceConfiguration, workspace, Uri, RelativePattern } from 'vscode'
 import * as fs from 'fs';
 import * as path from 'path';
 import { parse } from '@iarna/toml';
+import { VALIDATOR_PACKAGE_NAME } from './bi';
 
 export enum VERSION {
     BETA = 'beta',
@@ -382,6 +383,10 @@ export function getOrgAndPackageName(projectInfo: ProjectInfo, projectPath: stri
 }
 
 export async function isLibraryProject(projectPath: string): Promise<boolean> {
-    const tomlValues = await getProjectTomlValues(projectPath);
-    return tomlValues?.package?.library === true;
+    const libBalPath = path.join(projectPath, 'lib.bal');
+    if (fs.existsSync(libBalPath)) {
+        const libBalContent = fs.readFileSync(libBalPath, 'utf8');
+        return libBalContent.includes(`import ${VALIDATOR_PACKAGE_NAME} as _;`);
+    }
+    return false;
 }


### PR DESCRIPTION
## Purpose
Related to: https://github.com/wso2/product-ballerina-integrator/issues/2202

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Library projects now automatically include validator package support with lib.bal file and imports.

* **Bug Fixes**
  * Improved reliability of BI project and workspace creation when opening in VS Code.
  * Enhanced library project detection based on actual project structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->