### PR TITLE
Add CodeRabbit config to review PRs on feature/*, release/*, and hotfix/* branches

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,12 @@
+# CodeRabbit configuration - https://docs.coderabbit.ai/getting-started/yaml-configuration
+# Repo config overrides org-level settings. Explicitly list all branches to review
+# so main stays covered while adding feature/*, release/* and hotfix/* 
+language: "en-US"
+reviews:
+  auto_review:
+    enabled: true
+    base_branches:
+      - "main"
+      - "feature/.*"
+      - "release/.*"
+      - "hotfix/.*"


### PR DESCRIPTION


### Summary
Configure CodeRabbit to review PRs targeting `feature/*`, `release/*`, and `hotfix/*` branches in addition to `main`, instead of only main.

### Changes
- Added `.coderabbit.yaml` at the repository root.
- Set `base_branches` so CodeRabbit reviews PRs when the base branch matches:
  - `main` – keep existing main-branch reviews
  - `feature/.*` – feature branches (e.g. `feature/xyz`)
  - `release/.*` – release branches (e.g. `release/bi-1.8.x`)
  - `hotfix/.*` – hotfix branches (e.g. `hotfix/critical-fix`)

### Motivation
CodeRabbit is configured at the organization level to only review PRs targeting `main`. This repository config lets CodeRabbit also review PRs for `feature/*`, `release/*`, and `hotfix/*`, while still including `main`.
