### PR TITLE
Implement Array Index Access in Helper Pane for Array Fields

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/hooks/useHelperPaneNavigation.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/hooks/useHelperPaneNavigation.tsx
@@ -21,6 +21,9 @@ import { useState } from "react";
 export type BreadCrumbStep = {
     label: string;
     replaceText: string;
+    isArrayAccess?: boolean;
+    arrayIndex?: number;
+    fieldName?: string;
 }
 
 export const useHelperPaneNavigation = (initialLabel: string) => {
@@ -36,6 +39,39 @@ export const useHelperPaneNavigation = (initialLabel: string) => {
             replaceText: currentValue + separator + value
         }];
         setBreadCrumbSteps(newBreadCrumSteps);
+    };
+
+    const navigateToNextArray = (value: string, currentValue: string, index: number) => {
+        const separator = currentValue ? '.' : '';
+        const indexedValue = `${value}[${index}]`;
+        const newBreadCrumSteps = [...breadCrumbSteps, {
+            label: indexedValue,
+            replaceText: currentValue + separator + indexedValue,
+            isArrayAccess: true,
+            arrayIndex: index,
+            fieldName: value
+        }];
+        setBreadCrumbSteps(newBreadCrumSteps);
+    };
+
+    const updateLastStepArrayIndex = (index: number) => {
+        if (breadCrumbSteps.length <= 1) return;
+        const steps = [...breadCrumbSteps];
+        const lastStep = steps[steps.length - 1];
+        if (!lastStep.isArrayAccess || !lastStep.fieldName) return;
+
+        const parentStep = steps[steps.length - 2];
+        const parentPath = parentStep.replaceText;
+        const separator = parentPath ? '.' : '';
+        const newReplaceText = parentPath + separator + lastStep.fieldName + '[' + index + ']';
+
+        steps[steps.length - 1] = {
+            ...lastStep,
+            arrayIndex: index,
+            label: lastStep.fieldName + '[' + index + ']',
+            replaceText: newReplaceText
+        };
+        setBreadCrumbSteps(steps);
     };
 
     const navigateToBreadcrumb = (step: BreadCrumbStep) => {
@@ -56,6 +92,8 @@ export const useHelperPaneNavigation = (initialLabel: string) => {
     return {
         breadCrumbSteps,
         navigateToNext,
+        navigateToNextArray,
+        updateLastStepArrayIndex,
         navigateToBreadcrumb,
         isAtRoot,
         getCurrentPath,

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/styles/ArrayIndexStepper.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/styles/ArrayIndexStepper.tsx
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import styled from "@emotion/styled";
+import { ThemeColors } from "@wso2/ui-toolkit";
+
+export const ArrayIndexRow = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin: 0px 8px 4px;
+    padding: 4px 10px;
+    background-color: ${ThemeColors.SURFACE_DIM_2};
+    border-radius: 6px;
+`;
+
+export const ArrayIndexLabel = styled.span`
+    font-size: 11px;
+    color: ${ThemeColors.ON_SURFACE};
+    opacity: 0.7;
+`;
+
+export const ArrayIndexControls = styled.div`
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+`;
+
+export const ArrayIndexStepButton = styled.button`
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: ${ThemeColors.HIGHLIGHT};
+    font-size: 16px;
+    line-height: 1;
+    padding: 0 2px;
+    user-select: none;
+
+    &:disabled {
+        cursor: not-allowed;
+        opacity: 0.3;
+        color: ${ThemeColors.ON_SURFACE};
+    }
+`;
+
+export const ArrayIndexBadge = styled.span`
+    font-size: 11px;
+    min-width: 22px;
+    text-align: center;
+    padding: 2px 6px;
+    border-radius: 4px;
+    background-color: var(--vscode-chat-slashCommandBackground);
+    color: var(--vscode-chat-slashCommandForeground);
+    font-variant-numeric: tabular-nums;
+`;

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/utils/types.ts
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/utils/types.ts
@@ -90,3 +90,10 @@ export const shouldShowNavigationArrow = (item: CompletionItem): boolean => {
     const typeDetail = item?.labelDetails?.detail || item?.description;
     return !isPrimitiveType(typeDetail) || item?.labelDetails?.description === "Record";
 };
+
+// Determines if a type is an array of non-primitive (object) types
+export const isArrayOfObjectsType = (typeDetail: string): boolean => {
+    if (!typeDetail) return false;
+    const cleanType = typeDetail.trim();
+    return cleanType.endsWith('[]') && !isPrimitiveType(cleanType);
+};


### PR DESCRIPTION
## Purpose

Resolves https://github.com/wso2/product-ballerina-integrator/issues/2480

This PR introduces array index support in the Helper Pane for array fields (e.g., `ai:Trace[]`).

When a user selects an array field:

- `[0]` is selected by default
- The properties of the selected array item are automatically loaded
- Users can change the index using a numeric stepper at the top of the pane

https://github.com/user-attachments/assets/007cc36c-8726-4db2-880d-5a103ce30e4b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced array element navigation with index controls in the helper pane.
  * Added array-aware breadcrumb tracking to maintain context when navigating nested arrays.
  * Introduced array index stepper UI controls for stepping through array elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->