### PR TITLE
Fix expression editor mode switcher fall back mode

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/FieldFactory.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/FieldFactory.tsx
@@ -95,6 +95,20 @@ export const FieldFactory = (props: FieldFactoryProps) => {
         expressionEditor: updatedExpressionEditor
     }), [formContext, updatedExpressionEditor]);
 
+    const getInitialSelectedInputType = (): InputType => {
+        if (!props.field.types || props.field.types.length === 0) {
+            throw new Error("Field types are not defined");
+        }
+        const selectedType = props.field.types.find(type => type.selected);
+        if (selectedType) {
+            return selectedType;
+        }
+        if (!props.field.value) {
+            return props.field.types[0];
+        }
+        return props.field.types[props.field.types.length - 1];
+    }
+
     useEffect(() => {
         if (!props.field.types || props.field.types.length === 0) {
             throw new Error("Field types are not defined");
@@ -120,9 +134,7 @@ export const FieldFactory = (props: FieldFactoryProps) => {
         setRenderingEditors(newRenderingTypes);
 
         if (!isModeSelectionDirty.current) {
-            const selectedInputType = props.field.types.find(type => type.selected) || (
-                props.field.types[props.field.types.length - 1]
-            );
+            const selectedInputType = getInitialSelectedInputType();
             const initialInputMode = getInputModeFromTypes(selectedInputType) || InputMode.EXP;
             setInputMode(initialInputMode);
             updateFieldTypesSelection(initialInputMode);


### PR DESCRIPTION
## Purpose
> This PR will resolve an issue within the expression editor mode switcher where when no selected mode is provided from the LS FE fall back should select a expression mode based on current value.
Reason for the behaviour was that after the editor factory refactoring the fallback mode selection logic was missing

Resolves: https://github.com/wso2/product-ballerina-integrator/issues/2491

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Vertex AI authentication support for AI features
  * Added Edit/Plan mode toggle for agent execution
  * Added auto-approve functionality for agent actions
  * Added platform extension-based authentication via Devant
  * Added XML format support for type imports
  * Introduced dynamic form field editors with mode switching capabilities

* **Bug Fixes**
  * Improved token refresh flow for BI Copilot authentication
  * Enhanced error handling and messaging for authentication failures
  * Fixed configuration collection workflow

* **Tests**
  * Added comprehensive snapshot testing for diagram components
  * Established Jest testing infrastructure

* **Chores**
  * Updated GitHub Actions workflows for diagram testing
  * Added automated code review configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->