### PR TITLE
Fix if and match forms not working issue

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/ExpressionEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/ExpressionEditor.tsx
@@ -427,6 +427,14 @@ export const ExpressionEditor = (props: ExpressionEditorProps) => {
     const exprRef = useRef<FormExpressionEditorRef>(null);
     const anchorRef = useRef<HTMLDivElement>(null);
 
+    // This guard is here because the IF form and Match forms
+    //  does not populate the context value since they use expressionEditor 
+    // component directly instead of going through the FieldFactory. 
+    // This should ideally be handled as followes.
+    //  1.) Refactor IF and Match forms to use FieldFactory component
+    //  and LS property models
+    //  2.) Remove this guard and make sure all the usages of ExpressionEditor 
+    // are wrapped with ModeSwitcherContext provider
     const modeSwitcherContext = useModeSwitcherContext() ?? {
         inputMode: InputMode.EXP,
         isModeSwitcherEnabled: false,


### PR DESCRIPTION
## Purpose
> This PR will fix the issue where IF and Match forms crashes. issue was that these are special case forms that directly use expression editor for fields without going through the fieldFactory which bypasses the useModeSwitcherContext context provider resulting undefined context value destructuring. Fix was to add a guard for undefined context. this approach is acceptable as long as the special case forms have only a single expression mode for expression fields (Currently this is true)

Resolves: https://github.com/wso2/product-ballerina-integrator/issues/2490