### PR TITLE
Fix SQL editor not rendering for query fields

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/EditorFactory.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/EditorFactory.tsx
@@ -100,6 +100,7 @@ export const EditorFactory = (props: FormFieldEditorProps) => {
         fieldInputType.fieldType === "TEXT_SET" ||
         (fieldInputType.fieldType === "SINGLE_SELECT" && isDropDownType(fieldInputType)) ||
         fieldInputType.fieldType === "RECORD_MAP_EXPRESSION" ||
+        fieldInputType.fieldType === "SQL_QUERY" ||
         fieldInputType.fieldType === "NUMBER" ||
         (fieldInputType.fieldType === "FLAG" && field.types?.length > 1)
     )


### PR DESCRIPTION
## Purpose
> Fix the issue where in sql query fields a simple text field was rendering instead of the actual SQL expression editor 

Resolves: https://github.com/wso2/product-ballerina-integrator/issues/2508