### PR TITLE
Fix responseEditor form checkbox

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/ResourceForm/ResourceResponse/ResponseEditor.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/ResourceForm/ResourceResponse/ResponseEditor.tsx
@@ -183,6 +183,7 @@ export function ResponseEditor(props: ParamProps) {
                     ...convertPropertyToFormField(res.name),
                     key: `check`,
                     type: "FLAG",
+                    types: [{fieldType: "FLAG", selected: false}],
                     label: "Make this response reusable",
                     documentation: "Check this option to make this response reusable",
                     onValueChange: (value: string | boolean) => {


### PR DESCRIPTION
## Purpose
> This PR will FIx the issue where In ResponseEditor for `Make This Response Reusable` field a normal text editor is rendered instead of the checkbox

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated form field configuration in the Service Designer to enhance response handling capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->