### PR TITLE
Fix missing chatStorage config in AICommandExecutor during AI evals

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/features/ai/executors/base/AICommandExecutor.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/executors/base/AICommandExecutor.ts
@@ -141,6 +141,10 @@ export abstract class AICommandExecutor<TParams = any> {
      */
     protected async initializeWorkspaceThread(): Promise<void> {
         try {
+            if (!this.config.chatStorage) {
+                console.log('[AICommandExecutor] Chat storage not configured, skipping initialization');
+                return;
+            }
             const { workspaceId, threadId } = this.config.chatStorage;
 
             // Initialize workspace and thread
@@ -284,6 +288,9 @@ export abstract class AICommandExecutor<TParams = any> {
      * @returns Array of chat messages, or empty array if storage disabled
      */
     protected getChatHistory(): any[] {
+        if (!this.config.chatStorage) {
+            return [];
+        }
         const { workspaceId, threadId } = this.config.chatStorage;
         return chatStateStorage.getChatHistoryForLLM(workspaceId, threadId);
     }
@@ -294,6 +301,9 @@ export abstract class AICommandExecutor<TParams = any> {
      * @param metadata - Generation metadata (operation type, etc.)
      */
     protected addGeneration(userPrompt: string, metadata: any): any {
+        if (!this.config.chatStorage) {
+            return null;
+        }
         const { workspaceId, threadId } = this.config.chatStorage;
         return chatStateStorage.addGeneration(
             workspaceId,


### PR DESCRIPTION
## Purpose
Resolves a crash when running the Ballerina Extension AI evals (`AI Test` suite). `chatStorage` is not configured in the eval environment, causing `AICommandExecutor` to throw a `TypeError` during initialization and preventing all eval test cases from running.

**Error:**
```
TypeError: Cannot destructure property 'workspaceId' of 'this.config.chatStorage' as it is undefined.
```

## Goals
Make `chatStorage` optional in `AICommandExecutor` so AI evals can run successfully without requiring chat storage to be configured.

## Approach
Added null-guard checks in `initializeWorkspaceThread`, `getChatHistory`, and `addGeneration`. Each method now returns a safe default (`void`, `[]`, or `null`) if `this.config.chatStorage` is undefined, instead of attempting to destructure it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved stability of AI chat features by adding graceful handling for scenarios where chat storage is unavailable. The system now manages these situations without disruption instead of potential failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->