### PR TITLE
Revert "Refactor mi extension to use wso2-integrator instead of wso2-platform"

### DIFF
--- a/workspaces/mi/mi-extension/package.json
+++ b/workspaces/mi/mi-extension/package.json
@@ -19,6 +19,9 @@
     "onDebugDynamicConfigurations:mi",
     "onUri"
   ],
+  "extensionDependencies": [
+    "wso2.wso2-platform"
+  ],
   "main": "./dist/extension.js",
   "contributes": {
     "languages": [
@@ -179,7 +182,7 @@
         "MI.Scope": {
           "type": "string",
           "default": "",
-          "description": "WSO2 Cloud project scope",
+          "description": "Devant project scope",
           "scope": "resource"
         },
         "MI.suppressServerUpdateNotification": {

--- a/workspaces/mi/mi-extension/src/ai-features/aiMachine.ts
+++ b/workspaces/mi/mi-extension/src/ai-features/aiMachine.ts
@@ -24,11 +24,12 @@ import { AiPanelWebview } from './webview';
 import { extension } from '../MIExtensionContext';
 import {
     getAuthCredentials,
-    getIntegratorExtensionAPI,
+    getPlatformExtensionAPI,
     initiateInbuiltAuth,
     logout,
     validateApiKey,
     validateAwsCredentials,
+    isPlatformExtensionAvailable,
     isDevantUserLoggedIn,
     getPlatformStsToken,
     exchangeStsToCopilotToken,
@@ -667,7 +668,7 @@ const setupPlatformExtensionListener = async () => {
     platformLoginListenerSetup = true;
 
     try {
-        const api = await getIntegratorExtensionAPI();
+        const api = await getPlatformExtensionAPI();
         if (!api || !api.subscribeIsLoggedIn) {
             return;
         }

--- a/workspaces/mi/mi-extension/src/ai-features/auth.ts
+++ b/workspaces/mi/mi-extension/src/ai-features/auth.ts
@@ -34,13 +34,12 @@ import * as vscode from 'vscode';
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
 import { generateText } from 'ai';
-import { WICommandIds, IWso2PlatformExtensionAPI } from '@wso2/wso2-platform-core';
+import { CommandIds as PlatformExtCommandIds, IWso2PlatformExtensionAPI } from '@wso2/wso2-platform-core';
 import { logInfo, logWarn, logError } from './copilot/logger';
-import { WI_EXTENSION_ID } from '../constants';
-import { checkForWso2IntegratorExt } from '../extension';
 
 export const TOKEN_NOT_AVAILABLE_ERROR_MESSAGE = 'Access token is not available.';
 export const STS_TOKEN_NOT_AVAILABLE_ERROR_MESSAGE = 'Failed to get STS token from platform extension';
+export const PLATFORM_EXTENSION_ID = 'wso2.wso2-platform';
 export const TOKEN_REFRESH_ONLY_SUPPORTED_FOR_MI_INTEL = 'Token refresh is only supported for MI Intelligence authentication';
 export const DEFAULT_ANTHROPIC_MODEL = 'claude-haiku-4-5';
 
@@ -135,25 +134,25 @@ export const getCopilotTokenExchangeUrl = (): string | undefined => {
 // ==================================
 
 /**
- * Check if the WSO2 Integrator extension is installed.
+ * Check if the WSO2 Platform extension is installed.
  */
-export const isIntegratorExtensionAvailable = (): boolean => {
-    return !!vscode.extensions.getExtension(WI_EXTENSION_ID);
+export const isPlatformExtensionAvailable = (): boolean => {
+    return !!vscode.extensions.getExtension(PLATFORM_EXTENSION_ID);
 };
 
-export const getIntegratorExtensionAPI = async (): Promise<IWso2PlatformExtensionAPI | undefined> => {
-    const integratorExt = vscode.extensions.getExtension(WI_EXTENSION_ID);
-    if (!integratorExt) {
+export const getPlatformExtensionAPI = async (): Promise<IWso2PlatformExtensionAPI | undefined> => {
+    const platformExt = vscode.extensions.getExtension(PLATFORM_EXTENSION_ID);
+    if (!platformExt) {
         return undefined;
     }
 
     try {
-        if (!integratorExt.isActive) {
-            await integratorExt.activate();
+        if (!platformExt.isActive) {
+            await platformExt.activate();
         }
-        return integratorExt.exports?.cloudAPIs as IWso2PlatformExtensionAPI;
+        return platformExt.exports as IWso2PlatformExtensionAPI;
     } catch (error) {
-        logError('Failed to activate WSO2 Integrator extension', error);
+        logError('Failed to activate platform extension', error);
         return undefined;
     }
 };
@@ -162,7 +161,7 @@ export const getIntegratorExtensionAPI = async (): Promise<IWso2PlatformExtensio
  * Get STS token from the platform extension.
  */
 const getPlatformStsTokenOnce = async (): Promise<string | undefined> => {
-    const api = await getIntegratorExtensionAPI();
+    const api = await getPlatformExtensionAPI();
     if (!api) {
         return undefined;
     }
@@ -207,7 +206,7 @@ export const getPlatformStsToken = async (options: StsTokenFetchOptions = {}): P
  * Check if user is logged into Devant via platform extension.
  */
 export const isDevantUserLoggedIn = async (): Promise<boolean> => {
-    const api = await getIntegratorExtensionAPI();
+    const api = await getPlatformExtensionAPI();
     if (!api) {
         return false;
     }
@@ -215,7 +214,7 @@ export const isDevantUserLoggedIn = async (): Promise<boolean> => {
     try {
         return api.isLoggedIn();
     } catch (error) {
-        logError('Error checking WSO2 Integrator login status', error);
+        logError('Error checking Devant login status', error);
         return false;
     }
 };
@@ -433,7 +432,7 @@ export const checkToken = async (): Promise<{ token: string; loginMethod: LoginM
         return { token, loginMethod };
     }
 
-    if (!isIntegratorExtensionAvailable()) {
+    if (!isPlatformExtensionAvailable()) {
         return undefined;
     }
 
@@ -466,11 +465,11 @@ export const checkToken = async (): Promise<{ token: string; loginMethod: LoginM
  * Initiate Devant login via platform extension command.
  */
 export async function initiateDevantAuth(): Promise<boolean> {
-    if (!checkForWso2IntegratorExt()) {
-        throw new Error('The WSO2 Integrator extension is not installed. Please install it to use WSO2 Integrator Copilot.');
+    if (!isPlatformExtensionAvailable()) {
+        throw new Error('The WSO2 Platform extension is not installed. Please install it to use WSO2 Integrator Copilot.');
     }
 
-    await vscode.commands.executeCommand(WICommandIds.SignIn);
+    await vscode.commands.executeCommand(PlatformExtCommandIds.SignIn);
     return true;
 }
 

--- a/workspaces/mi/mi-extension/src/constants/index.ts
+++ b/workspaces/mi/mi-extension/src/constants/index.ts
@@ -118,8 +118,7 @@ export const COMMANDS = {
 
     BI_EXTENSION: 'WSO2.ballerina-integrator',
     BI_OPEN_COMMAND: 'ballerina.open.bi.welcome',
-    INSTALL_EXTENSION_COMMAND: 'workbench.extensions.installExtension',
-    RELOAD_WINDOW: 'workbench.action.reloadWindow'
+    INSTALL_EXTENSION_COMMAND: 'workbench.extensions.installExtension'
 };
 
 export const MVN_COMMANDS = {

--- a/workspaces/mi/mi-extension/src/extension.ts
+++ b/workspaces/mi/mi-extension/src/extension.ts
@@ -33,7 +33,7 @@ import { isOldProjectOrWorkspace, getStateMachine } from './stateMachine';
 import { webviews } from './visualizer/webview';
 import { v4 as uuidv4 } from 'uuid';
 import path from 'path';
-import { COMMANDS, WI_EXTENSION_ID } from './constants';
+import { COMMANDS } from './constants';
 import { enableLS } from './util/workspace';
 import { disposeMIAgentPanelRpcManager } from './rpc-managers/agent-mode/rpc-handler';
 const os = require('os');
@@ -117,20 +117,10 @@ export async function deactivate(): Promise<void> {
 	}
 }
 
-export function checkForWso2IntegratorExt() {
-	const wso2PlatformExtension = extensions.getExtension(WI_EXTENSION_ID);
+export function checkForDevantExt() {
+	const wso2PlatformExtension = extensions.getExtension('wso2.wso2-platform');
 	if (!wso2PlatformExtension) {
-		vscode.window.showErrorMessage('The WSO2 Integrator extension is not installed. Please install it to proceed.', "Install WSO2 Integrator").then(selection => {
-			if (selection === "Install WSO2 Integrator") {
-				vscode.commands.executeCommand(COMMANDS.INSTALL_EXTENSION_COMMAND, WI_EXTENSION_ID).then(() => {
-					vscode.window.showInformationMessage('WSO2 Integrator extension installed. Please reload VSCode to complete the extension activation.', "Reload Window").then(reloadSelection => {
-						if (reloadSelection === "Reload Window") {
-							vscode.commands.executeCommand(COMMANDS.RELOAD_WINDOW);
-						}
-					});
-				});
-			}
-		});
+		vscode.window.showErrorMessage('The WSO2 Platform extension is not installed. Please install it to proceed.');
 		return false;
 	}
 	return true;

--- a/workspaces/mi/mi-extension/src/rpc-managers/mi-diagram/rpc-manager.ts
+++ b/workspaces/mi/mi-extension/src/rpc-managers/mi-diagram/rpc-manager.ts
@@ -321,7 +321,7 @@ import { RPCLayer } from "../../RPCLayer";
 import { StateMachineAI } from '../../ai-features/aiMachine';
 import {
     getAccessToken as getCopilotAccessToken,
-    getIntegratorExtensionAPI,
+    getPlatformExtensionAPI,
     getCopilotLlmApiBaseUrl,
     getLoginMethod as getCopilotLoginMethod,
     getRefreshedAccessToken as refreshCopilotAccessToken,
@@ -351,9 +351,10 @@ import path = require("path");
 import { importCapp } from "../../util/importCapp";
 import { compareVersions, filterConnectorVersion, generateInitialDependencies, getDefaultProjectPath, getMIVersionFromPom, buildBallerinaModule, updatePomForClassMediator } from "../../util/onboardingUtils";
 import { Range as STRange } from '@wso2/mi-syntax-tree/lib/src';
-import { checkForWso2IntegratorExt } from "../../extension";
+import { checkForDevantExt } from "../../extension";
 import { getAPIMetadata } from "../../util/template-engine/mustach-templates/API";
-import { WICommandIds, ICreateNewIntegrationCmdParams } from "@wso2/wso2-platform-core";
+import { DevantScopes } from "@wso2/wso2-platform-core";
+import { ICreateComponentCmdParams, CommandIds as PlatformExtCommandIds } from "@wso2/wso2-platform-core";
 import { MiVisualizerRpcManager } from "../mi-visualizer/rpc-manager";
 import { DebuggerConfig } from "../../debugger/config";
 import { getKubernetesConfiguration, getKubernetesDataConfiguration } from "../../util/template-engine/mustach-templates/KubernetesConfiguration";
@@ -4889,15 +4890,21 @@ ${keyValuesXML}`;
 
     async deployProject(params: DeployProjectRequest): Promise<DeployProjectResponse> {
         return new Promise(async (resolve) => {
-            if (!checkForWso2IntegratorExt()) {
+            if (!checkForDevantExt()) {
                 return;
             }
+            const params: ICreateComponentCmdParams = {
+                buildPackLang: "microintegrator",
+                name: path.basename(this.projectUri),
+                componentDir: this.projectUri,
+                extName: "Devant",
+            };
 
             const langClient = await MILanguageClient.getInstance(this.projectUri);
 
             let integrationType: string | undefined;
-            if (this.projectUri) {
-                const rootPath = (await this.getProjectRoot({ path: this.projectUri })).path;
+            if (params.componentDir) {
+                const rootPath = (await this.getProjectRoot({ path: params.componentDir })).path;
                 const resp = await langClient.getProjectIntegrationType(rootPath);
 
                 function mapTypeToScope(type: string): string | undefined {
@@ -4937,17 +4944,9 @@ ${keyValuesXML}`;
                     return { success: false };
                 }
 
-                const paramsWithType: ICreateNewIntegrationCmdParams = { 
-                    buildPackLang: "microintegrator", 
-                    workspaceDir: this.projectUri, 
-                    integrations: [{ 
-                        fsPath: this.projectUri, 
-                        name: path.basename(this.projectUri), 
-                        supportedIntegrationTypes: [integrationType]
-                    }]
-                }
-                
-                commands.executeCommand(WICommandIds.CreateNewComponent, paramsWithType);
+                const paramsWithType: ICreateComponentCmdParams = { ...params, integrationType: integrationType as DevantScopes, };
+
+                commands.executeCommand(PlatformExtCommandIds.CreateNewComponent, paramsWithType);
                 resolve({ success: true });
 
             } else {
@@ -4970,7 +4969,7 @@ ${keyValuesXML}`;
                 }
             }
 
-            const platformExtAPI = await getIntegratorExtensionAPI();
+            const platformExtAPI = await getPlatformExtensionAPI();
             if (!platformExtAPI) {
                 return { hasComponent: hasContextYaml, isLoggedIn: false, hasLocalChanges: false };
             }

--- a/workspaces/mi/mi-extension/src/uri-handler.ts
+++ b/workspaces/mi/mi-extension/src/uri-handler.ts
@@ -18,8 +18,8 @@
 import { URLSearchParams } from "url";
 import { window, Uri, ProviderResult, commands } from "vscode";
 import { COMMANDS } from "./constants";
-import { checkForWso2IntegratorExt } from "./extension";
-import { IOpenCompSrcCmdParams, WICommandIds } from "@wso2/wso2-platform-core";
+import { checkForDevantExt } from "./extension";
+import { IOpenCompSrcCmdParams, CommandIds as PlatformExtCommandIds } from "@wso2/wso2-platform-core";
 
 export function activateUriHandlers() {
     window.registerUriHandler({
@@ -28,10 +28,10 @@ export function activateUriHandlers() {
             switch (uri.path) {
                 case '/signin':
                     // Legacy OAuth callback route - no longer used for MI Copilot auth.
-                    console.log("Legacy /signin route called - MI Copilot authentication now uses WSO2 integrator extension.");
+                    console.log("Legacy /signin route called - MI Copilot authentication now uses Devant platform extension.");
                     break;
                 case '/open':
-                    if(!checkForWso2IntegratorExt()) {
+                    if(!checkForDevantExt()) {
                         return;
                     }
                     const org = urlParams.get("org");
@@ -42,7 +42,7 @@ export function activateUriHandlers() {
                     const integrationDisplayType = urlParams.get("integrationDisplayType");
                     window.showInformationMessage('Opening component');
                     if (org && project && component && technology && integrationType) {
-                        commands.executeCommand(WICommandIds.OpenCompSrcDir, {
+                        commands.executeCommand(PlatformExtCommandIds.OpenCompSrcDir, {
                             org, project, component, technology, integrationType, integrationDisplayType, extName: "Devant"
                         } as IOpenCompSrcCmdParams);
                     } else {

--- a/workspaces/mi/mi-visualizer/src/views/AIPanel/component/WaitingForLoginSection.tsx
+++ b/workspaces/mi/mi-visualizer/src/views/AIPanel/component/WaitingForLoginSection.tsx
@@ -468,7 +468,7 @@ export const WaitingForLoginSection = ({ loginMethod, isValidating = false, erro
             <WaitingMessage>
                 <Title>Waiting for Login</Title>
                 <SubTitle>
-                    Please complete the WSO2 Integration Platform sign-in to continue using WSO2 Integrator Copilot.
+                    Waiting for Devant sign-in. Complete your login in the WSO2 Platform extension to continue with WSO2 Integrator Copilot.
                 </SubTitle>
                 <ButtonContainer>
                     <VSCodeButton appearance="secondary" onClick={cancelLogin}>

--- a/workspaces/mi/mi-visualizer/src/views/Overview/DeploymentStatus.tsx
+++ b/workspaces/mi/mi-visualizer/src/views/Overview/DeploymentStatus.tsx
@@ -164,13 +164,13 @@ export function DeploymentOptions({ handleDockerBuild, handleConfigureKubernetes
             <Title variant="h3">Deployment Options</Title>
 
             <DeploymentOption
-                title={devantMetadata?.hasComponent ? "Deployed in WSO2 Cloud" : "Deploy to WSO2 Cloud"}
+                title={devantMetadata?.hasComponent ? "Deployed in Devant" : "Deploy to Devant"}
                 description={
                     devantMetadata?.hasComponent
-                        ? "This integration is already deployed in WSO2 Cloud."
-                        : "Deploy your integration to the cloud using WSO2 Cloud."
+                        ? "This integration is already deployed in Devant."
+                        : "Deploy your integration to the cloud using Devant by WSO2."
                 }
-                buttonText={devantMetadata?.hasComponent ? "View in Console" : "Deploy"}
+                buttonText={devantMetadata?.hasComponent ? "View in Devant" : "Deploy"}
                 isExpanded={expandedOptions.has("devant")}
                 onToggle={() => toggleOption("devant")}
                 onDeploy={devantMetadata?.hasComponent ? () => goToDevant() : () => handleDeploy({})}
@@ -178,7 +178,7 @@ export function DeploymentOptions({ handleDockerBuild, handleConfigureKubernetes
                 secondaryAction={
                     devantMetadata?.hasComponent && devantMetadata?.hasLocalChanges
                         ? {
-                                description: "To redeploy in WSO2 Cloud, please commit and push your changes.",
+                                description: "To redeploy in Devant, please commit and push your changes.",
                                 buttonText: "Open Source Control",
                                 onClick: () =>
                                     rpcClient


### PR DESCRIPTION
Reverts wso2/vscode-extensions#1861

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Extension now requires WSO2 Platform extension as a dependency
* Updated all UI text and descriptions to reference Devant and WSO2 Platform extension
* Updated authentication and deployment workflows to integrate with WSO2 Platform extension
* Updated scope descriptions to reference Devant project scope

<!-- end of auto-generated comment: release notes by coderabbit.ai -->