### PR TITLE
Separate Ballerina LS release setup

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -9,6 +9,9 @@ inputs:
   enableLSCache:
     default: false
     type: boolean
+  isReleaseBuild:
+    default: false
+    type: boolean
   ballerina:
     description: Update Ballerina extension version
     type: boolean
@@ -41,6 +44,14 @@ inputs:
     default: false
   version:
     default: "N/A"
+    type: string
+    required: false
+  ballerinaLSRelease:
+    default: "latest"
+    type: string
+    required: false
+  ballerinaLSTag:
+    default: ""
     type: string
     required: false
   balVersion:
@@ -166,6 +177,42 @@ runs:
         path: workspaces/ballerina/ballerina-extension/ls
         key: ballerina-ls
         retention-days: 1
+
+    - name: Validate Ballerina LS selection
+      shell: bash
+      run: |
+        if [[ "${{ inputs.ballerinaLSRelease }}" == "specific-tag" && -z "${{ inputs.ballerinaLSTag }}" ]]; then
+          echo "ballerinaLSTag is required when ballerinaLSRelease is set to specific-tag."
+          exit 1
+        fi
+
+    - name: Download Ballerina LS
+      shell: bash
+      run: |
+        args=()
+
+        if [[ "${{ inputs.isReleaseBuild }}" == "true" ]]; then
+          args+=(--replace)
+        fi
+
+        case "${{ inputs.ballerinaLSRelease }}" in
+          latest)
+            ;;
+          pre-release)
+            args+=(--prerelease)
+            ;;
+          specific-tag)
+            args+=(--tag "${{ inputs.ballerinaLSTag }}")
+            ;;
+          *)
+            echo "Unsupported ballerinaLSRelease value: ${{ inputs.ballerinaLSRelease }}"
+            exit 1
+            ;;
+        esac
+
+        pnpm --dir workspaces/ballerina/ballerina-extension run download-ls -- "${args[@]}"
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
 
     - name: Build repo
       shell: bash

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -179,6 +179,7 @@ runs:
         retention-days: 1
 
     - name: Validate Ballerina LS selection
+      if: ${{ inputs.ballerina == 'true' || inputs.bi == 'true' }}
       shell: bash
       run: |
         if [[ ("$IS_BALLERINA_RELEASE" == "true" || "$IS_BI_RELEASE" == "true") && "$BALLERINA_LS_RELEASE" == "N/A" ]]; then
@@ -197,6 +198,7 @@ runs:
         BALLERINA_LS_TAG: ${{ inputs.ballerinaLSTag }}
 
     - name: Download Ballerina LS
+      if: ${{ inputs.ballerina == 'true' || inputs.bi == 'true' }}
       shell: bash
       run: |
         args=()
@@ -209,11 +211,14 @@ runs:
           N/A)
             ;;
           latest)
+            echo "Using Ballerina LS source: latest"
             ;;
           pre-release)
+            echo "Using Ballerina LS source: pre-release"
             args+=(--prerelease)
             ;;
           specific-tag)
+            echo "Using Ballerina LS source: specific-tag ($BALLERINA_LS_TAG)"
             args+=(--tag "$BALLERINA_LS_TAG")
             ;;
           *)

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -181,26 +181,31 @@ runs:
     - name: Validate Ballerina LS selection
       shell: bash
       run: |
-        if [[ ("${{ inputs.ballerina }}" == "true" || "${{ inputs.bi }}" == "true") && "${{ inputs.ballerinaLSRelease }}" == "N/A" ]]; then
+        if [[ ("$IS_BALLERINA_RELEASE" == "true" || "$IS_BI_RELEASE" == "true") && "$BALLERINA_LS_RELEASE" == "N/A" ]]; then
           echo "ballerinaLSRelease must be set for Ballerina or BI extension releases."
           exit 1
         fi
 
-        if [[ ("${{ inputs.ballerina }}" == "true" || "${{ inputs.bi }}" == "true") && "${{ inputs.ballerinaLSRelease }}" == "specific-tag" && -z "${{ inputs.ballerinaLSTag }}" ]]; then
+        if [[ ("$IS_BALLERINA_RELEASE" == "true" || "$IS_BI_RELEASE" == "true") && "$BALLERINA_LS_RELEASE" == "specific-tag" && -z "$BALLERINA_LS_TAG" ]]; then
           echo "ballerinaLSTag is required when ballerinaLSRelease is set to specific-tag."
           exit 1
         fi
+      env:
+        IS_BALLERINA_RELEASE: ${{ inputs.ballerina }}
+        IS_BI_RELEASE: ${{ inputs.bi }}
+        BALLERINA_LS_RELEASE: ${{ inputs.ballerinaLSRelease }}
+        BALLERINA_LS_TAG: ${{ inputs.ballerinaLSTag }}
 
     - name: Download Ballerina LS
       shell: bash
       run: |
         args=()
 
-        if [[ "${{ inputs.isReleaseBuild }}" == "true" ]]; then
+        if [[ "$IS_RELEASE_BUILD" == "true" ]]; then
           args+=(--replace)
         fi
 
-        case "${{ inputs.ballerinaLSRelease }}" in
+        case "$BALLERINA_LS_RELEASE" in
           N/A)
             ;;
           latest)
@@ -209,16 +214,19 @@ runs:
             args+=(--prerelease)
             ;;
           specific-tag)
-            args+=(--tag "${{ inputs.ballerinaLSTag }}")
+            args+=(--tag "$BALLERINA_LS_TAG")
             ;;
           *)
-            echo "Unsupported ballerinaLSRelease value: ${{ inputs.ballerinaLSRelease }}"
+            echo "Unsupported ballerinaLSRelease value: $BALLERINA_LS_RELEASE"
             exit 1
             ;;
         esac
 
         pnpm --dir workspaces/ballerina/ballerina-extension run download-ls -- "${args[@]}"
       env:
+        IS_RELEASE_BUILD: ${{ inputs.isReleaseBuild }}
+        BALLERINA_LS_RELEASE: ${{ inputs.ballerinaLSRelease }}
+        BALLERINA_LS_TAG: ${{ inputs.ballerinaLSTag }}
         GITHUB_TOKEN: ${{ inputs.token }}
 
     - name: Build repo

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -181,7 +181,12 @@ runs:
     - name: Validate Ballerina LS selection
       shell: bash
       run: |
-        if [[ "${{ inputs.ballerinaLSRelease }}" == "specific-tag" && -z "${{ inputs.ballerinaLSTag }}" ]]; then
+        if [[ ("${{ inputs.ballerina }}" == "true" || "${{ inputs.bi }}" == "true") && "${{ inputs.ballerinaLSRelease }}" == "N/A" ]]; then
+          echo "ballerinaLSRelease must be set for Ballerina or BI extension releases."
+          exit 1
+        fi
+
+        if [[ ("${{ inputs.ballerina }}" == "true" || "${{ inputs.bi }}" == "true") && "${{ inputs.ballerinaLSRelease }}" == "specific-tag" && -z "${{ inputs.ballerinaLSTag }}" ]]; then
           echo "ballerinaLSTag is required when ballerinaLSRelease is set to specific-tag."
           exit 1
         fi
@@ -196,6 +201,8 @@ runs:
         fi
 
         case "${{ inputs.ballerinaLSRelease }}" in
+          N/A)
+            ;;
           latest)
             ;;
           pre-release)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,14 @@ on:
         default: 'N/A'
         type: string
         required: false
+      ballerinaLSRelease:
+        default: 'latest'
+        type: string
+        required: false
+      ballerinaLSTag:
+        default: ''
+        type: string
+        required: false
       isReleaseBuild:  
         type: boolean
         default: false
@@ -213,6 +221,9 @@ jobs:
           mi: ${{ inputs.mi }}
           hurl-client: ${{ inputs.hurl-client }}
           version: ${{ inputs.version }}
+          ballerinaLSRelease: ${{ inputs.ballerinaLSRelease }}
+          ballerinaLSTag: ${{ inputs.ballerinaLSTag }}
+          isReleaseBuild: ${{ inputs.isReleaseBuild }}
           token: ${{ secrets.CHOREO_BOT_TOKEN }}
           BALLERINA_AUTH_ORG: ${{ secrets.BALLERINA_AUTH_ORG }}
           BALLERINA_AUTH_CLIENT_ID: ${{ secrets.BALLERINA_AUTH_CLIENT_ID }}

--- a/.github/workflows/release-vsix.yml
+++ b/.github/workflows/release-vsix.yml
@@ -51,6 +51,19 @@ on:
           - 'minor'
           - 'major'    
           - 'N/A'     
+      ballerinaLSRelease:
+        type: choice
+        description: 'Ballerina LS source for ballerina extension releases'
+        required: true
+        default: 'latest'
+        options:
+          - 'latest'
+          - 'pre-release'
+          - 'specific-tag'
+      ballerinaLSTag:
+        type: string
+        description: 'Ballerina LS tag when source is specific-tag (e.g. v1.8.0.m1)'
+        required: false
 
 jobs:
   Build:
@@ -69,6 +82,8 @@ jobs:
       mi:  ${{ inputs.mi }}
       hurl-client: ${{ inputs.hurl-client }}
       version: ${{ inputs.version }}
+      ballerinaLSRelease: ${{ inputs.ballerinaLSRelease }}
+      ballerinaLSTag: ${{ inputs.ballerinaLSTag }}
       isReleaseBuild: true
 
   Release:

--- a/.github/workflows/release-vsix.yml
+++ b/.github/workflows/release-vsix.yml
@@ -55,8 +55,9 @@ on:
         type: choice
         description: 'Ballerina LS source for ballerina extension releases'
         required: true
-        default: 'latest'
+        default: 'N/A'
         options:
+          - 'N/A'
           - 'latest'
           - 'pre-release'
           - 'specific-tag'

--- a/workspaces/ballerina/ballerina-extension/DEVELOPMENT_SETUP.md
+++ b/workspaces/ballerina/ballerina-extension/DEVELOPMENT_SETUP.md
@@ -1,0 +1,46 @@
+# Ballerina Extension Development Setup
+
+## Initial Setup
+
+Run `rush install` once after cloning the repository to install dependencies and set up the workspace.
+
+## Build
+
+Use `rush build` for a full build of the repository.
+
+To build only the Ballerina package, run:
+
+```bash
+rush build -t ballerina
+```
+
+## Language Server
+
+For local development, the Ballerina language server is not downloaded automatically during `rush build` anymore. Before building the extension, download the bundled language server into `workspaces/ballerina/ballerina-extension/ls`:
+
+```bash
+pnpm --dir workspaces/ballerina/ballerina-extension run download-ls
+```
+
+If you want the latest prerelease instead, run:
+
+```bash
+pnpm --dir workspaces/ballerina/ballerina-extension run download-ls -- --prerelease --replace
+```
+
+If you need a specific release tag such as `v1.8.0.m1`, run:
+
+```bash
+pnpm --dir workspaces/ballerina/ballerina-extension run download-ls -- --tag v1.8.0.m1 --replace
+```
+
+The build will fail with a clear message if the `ls` directory does not contain a `ballerina-language-server*.jar`.
+
+## BI End-to-End Tests
+
+BI Playwright tests are located in `e2e-test/e2e-playwright-tests`.
+
+From this directory (`workspaces/ballerina/ballerina-extension`):
+
+- Run `pnpm run e2e-test:bi` to execute BI Playwright tests.
+- Run `pnpm run e2e-test:bi:download-prerelease` to run BI tests after downloading prerelease VSIXs.

--- a/workspaces/ballerina/ballerina-extension/README.md
+++ b/workspaces/ballerina/ballerina-extension/README.md
@@ -55,11 +55,3 @@ You can configure the Ballerina VS Code extension to get a custom user experienc
 For troubleshooting, see the Ballerina output. To view the Ballerina output tab, click **View**, click **Output,** and select **Ballerina** from the output list. It provides additional information if the plugin fails to detect a Ballerina distribution.  
 
 You can also enable <a href="https://ballerina.io/learn/vs-code-extension/configure-the-extension/#advanced-configurations" target="_blank">debug logs</a> from the Ballerina extension settings to view any issues arising from the extension features.
-
-## BI end-to-end tests
-
-BI Playwright tests are located in `e2e-test/e2e-playwright-tests`.
-
-From this directory (`workspaces/ballerina/ballerina-extension`):
-- Run `pnpm run e2e-test:bi` to execute BI Playwright tests.
-- Run `pnpm run e2e-test:bi:download-prerelease` to run BI tests after downloading prerelease VSIXs.

--- a/workspaces/ballerina/ballerina-extension/package.json
+++ b/workspaces/ballerina/ballerina-extension/package.json
@@ -1412,7 +1412,7 @@
         "test-coverage": "cross-env COVER_CONFIG=html pnpm run test",
         "build-tm-grammar": "js-yaml grammar/ballerina-grammar/syntaxes/ballerina.tmLanguage.yaml > grammar/ballerina-grammar/syntaxes/ballerina.tmLanguage.json",
         "lint": "tslint --fix 'src/**/*{.ts,.tsx}'",
-        "package": "node ../../common-libs/scripts/package-vsix.js",
+        "package": "pnpm run verify-ls && node ../../common-libs/scripts/package-vsix.js",
         "copyFonts": "copyfiles -f ./node_modules/@wso2/font-wso2-vscode/dist/* ./resources/font-wso2-vscode/dist/",
         "copyVSIX": "copyfiles *.vsix ./vsix",
         "copyVSIXToRoot": "copyfiles -f ./vsix/*.vsix ../../..",
@@ -1421,7 +1421,7 @@
         "verify-ls": "node scripts/verify-ls.js",
         "build": "pnpm run compile && pnpm run lint && pnpm run postbuild",
         "rebuild": "pnpm run clean && pnpm run compile && pnpm run postbuild",
-        "postbuild": "pnpm run verify-ls && pnpm run copyFonts && pnpm run copyJSLibs && pnpm run package && pnpm run copyVSIX",
+        "postbuild": "pnpm run copyFonts && pnpm run copyJSLibs && pnpm run package && pnpm run copyVSIX",
         "copyJSLibs": "copyfiles -f ../ballerina-visualizer/build/*.js resources/jslibs && copyfiles -f ../trace-visualizer/build/*.js resources/jslibs"
     },
     "dependencies": {

--- a/workspaces/ballerina/ballerina-extension/package.json
+++ b/workspaces/ballerina/ballerina-extension/package.json
@@ -1419,8 +1419,8 @@
         "download-ls": "node scripts/download-ls.js",
         "download-ls:prerelease": "node scripts/download-ls.js --prerelease --replace",
         "verify-ls": "node scripts/verify-ls.js",
-        "build": "pnpm run compile && pnpm run lint && pnpm run postbuild",
-        "rebuild": "pnpm run clean && pnpm run compile && pnpm run postbuild",
+        "build": "pnpm run verify-ls && pnpm run compile && pnpm run lint && pnpm run postbuild",
+        "rebuild": "pnpm run verify-ls && pnpm run clean && pnpm run compile && pnpm run postbuild",
         "postbuild": "pnpm run copyFonts && pnpm run copyJSLibs && pnpm run package && pnpm run copyVSIX",
         "copyJSLibs": "copyfiles -f ../ballerina-visualizer/build/*.js resources/jslibs && copyfiles -f ../trace-visualizer/build/*.js resources/jslibs"
     },

--- a/workspaces/ballerina/ballerina-extension/package.json
+++ b/workspaces/ballerina/ballerina-extension/package.json
@@ -1418,9 +1418,10 @@
         "copyVSIXToRoot": "copyfiles -f ./vsix/*.vsix ../../..",
         "download-ls": "node scripts/download-ls.js",
         "download-ls:prerelease": "node scripts/download-ls.js --prerelease --replace",
+        "verify-ls": "node scripts/verify-ls.js",
         "build": "pnpm run compile && pnpm run lint && pnpm run postbuild",
         "rebuild": "pnpm run clean && pnpm run compile && pnpm run postbuild",
-        "postbuild": "pnpm run download-ls && pnpm run copyFonts && pnpm run copyJSLibs && pnpm run package && pnpm run copyVSIX",
+        "postbuild": "pnpm run verify-ls && pnpm run copyFonts && pnpm run copyJSLibs && pnpm run package && pnpm run copyVSIX",
         "copyJSLibs": "copyfiles -f ../ballerina-visualizer/build/*.js resources/jslibs && copyfiles -f ../trace-visualizer/build/*.js resources/jslibs"
     },
     "dependencies": {

--- a/workspaces/ballerina/ballerina-extension/scripts/download-ls.js
+++ b/workspaces/ballerina/ballerina-extension/scripts/download-ls.js
@@ -121,6 +121,10 @@ function getAuthHeader() {
         return { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` };
     }
 
+    if (process.env.gitPAT) {
+        return { Authorization: `Bearer ${process.env.gitPAT}` };
+    }
+
     return {};
 }
 

--- a/workspaces/ballerina/ballerina-extension/scripts/download-ls.js
+++ b/workspaces/ballerina/ballerina-extension/scripts/download-ls.js
@@ -11,8 +11,18 @@ const GITHUB_REPO_URL = 'https://api.github.com/repos/ballerina-platform/balleri
 const args = process.argv.slice(2);
 const usePrerelease = args.includes('--prerelease') || process.env.isPreRelease === 'true';
 const forceReplace = args.includes('--replace');
+const tagIndex = args.indexOf('--tag');
+const requestedTag = tagIndex >= 0 ? args[tagIndex + 1] : process.env.BALLERINA_LS_TAG;
 
-function checkExistingJar() {
+function getExpectedVersion(tag) {
+    if (!tag) {
+        return undefined;
+    }
+
+    return tag.startsWith('v') ? tag.slice(1) : tag;
+}
+
+function checkExistingJar(expectedVersion) {
     try {
         if (!fs.existsSync(LS_DIR)) {
             return false;
@@ -21,11 +31,22 @@ function checkExistingJar() {
         const files = fs.readdirSync(LS_DIR);
         const jarFiles = files.filter(file => file.includes('ballerina-language-server-') && file.endsWith('.jar'));
 
-        if (jarFiles.length > 0) {
+        if (jarFiles.length === 0) {
+            return false;
+        }
+
+        if (!expectedVersion) {
             console.log(`Ballerina language server JAR already exists in ${path.relative(PROJECT_ROOT, LS_DIR)}`);
             return true;
         }
 
+        const expectedJar = jarFiles.find(file => file === `ballerina-language-server-${expectedVersion}.jar`);
+        if (expectedJar) {
+            console.log(`Ballerina language server JAR for version ${expectedVersion} already exists in ${path.relative(PROJECT_ROOT, LS_DIR)}`);
+            return true;
+        }
+
+        console.log(`Existing language server JAR does not match requested version ${expectedVersion}; downloading requested version.`);
         return false;
     } catch (error) {
         console.error('Error checking existing JAR files:', error.message);
@@ -147,6 +168,15 @@ function getFileSize(filePath) {
 }
 
 async function getLatestRelease(usePrerelease) {
+    if (requestedTag) {
+        const releaseResponse = await httpsRequest(`${GITHUB_REPO_URL}/releases/tags/${encodeURIComponent(requestedTag)}`);
+        try {
+            return JSON.parse(releaseResponse.data);
+        } catch (error) {
+            throw new Error(`Failed to parse release information JSON for tag ${requestedTag}`);
+        }
+    }
+
     if (usePrerelease) {
         // Get all releases and find the latest prerelease
         const releasesResponse = await httpsRequest(`${GITHUB_REPO_URL}/releases`);
@@ -178,11 +208,22 @@ async function getLatestRelease(usePrerelease) {
 
 async function main() {
     try {
-        if (!forceReplace && checkExistingJar()) {
+        if (usePrerelease && requestedTag) {
+            throw new Error('Use either --prerelease or --tag, not both');
+        }
+
+        if (tagIndex >= 0 && !requestedTag) {
+            throw new Error('Missing value for --tag');
+        }
+
+        if (!forceReplace && checkExistingJar(getExpectedVersion(requestedTag))) {
             process.exit(0);
         }
 
-        console.log(`Downloading Ballerina language server${usePrerelease ? ' (prerelease)' : ''}${forceReplace ? ' (force replace)' : ''}...`);
+        const releaseLabel = requestedTag
+            ? ` (tag: ${requestedTag})`
+            : (usePrerelease ? ' (prerelease)' : '');
+        console.log(`Downloading Ballerina language server${releaseLabel}${forceReplace ? ' (force replace)' : ''}...`);
 
         if (forceReplace && fs.existsSync(LS_DIR)) {
             console.log('Force replace enabled: clearing existing language server directory...');
@@ -241,4 +282,4 @@ if (require.main === module) {
     main();
 }
 
-module.exports = { main, checkExistingJar }; 
+module.exports = { main, checkExistingJar };

--- a/workspaces/ballerina/ballerina-extension/scripts/download-ls.js
+++ b/workspaces/ballerina/ballerina-extension/scripts/download-ls.js
@@ -70,12 +70,7 @@ function checkExistingJar(expectedVersion) {
 
 function httpsRequest(url, options = {}) {
     return new Promise((resolve, reject) => {
-        const authHeader = {};
-        if (process.env.CHOREO_BOT_TOKEN) {
-            authHeader['Authorization'] = `Bearer ${process.env.CHOREO_BOT_TOKEN}`;
-        } else if (process.env.GITHUB_TOKEN) {
-            authHeader['Authorization'] = `Bearer ${process.env.GITHUB_TOKEN}`;
-        }
+        const authHeader = getAuthHeader();
 
         const req = https.request(url, {
             ...options,
@@ -117,6 +112,18 @@ function httpsRequest(url, options = {}) {
     });
 }
 
+function getAuthHeader() {
+    if (process.env.CHOREO_BOT_TOKEN) {
+        return { Authorization: `Bearer ${process.env.CHOREO_BOT_TOKEN}` };
+    }
+
+    if (process.env.GITHUB_TOKEN) {
+        return { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` };
+    }
+
+    return {};
+}
+
 function downloadFile(url, outputPath, maxRedirects = 5) {
     return new Promise((resolve, reject) => {
         const file = fs.createWriteStream(outputPath);
@@ -125,7 +132,8 @@ function downloadFile(url, outputPath, maxRedirects = 5) {
             const req = https.request(requestUrl, {
                 headers: {
                     'User-Agent': 'Ballerina-LS-Downloader',
-                    'Accept': 'application/octet-stream'
+                    'Accept': 'application/octet-stream',
+                    ...getAuthHeader()
                 }
             }, (res) => {
                 if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
@@ -141,10 +149,50 @@ function downloadFile(url, outputPath, maxRedirects = 5) {
                 }
 
                 if (res.statusCode >= 200 && res.statusCode < 300) {
+                    const totalBytes = Number(res.headers['content-length'] || 0);
+                    let downloadedBytes = 0;
+                    let lastLoggedAt = Date.now();
+
+                    const formatBytes = (bytes) => {
+                        if (bytes < 1024) {
+                            return `${bytes} B`;
+                        }
+
+                        if (bytes < 1024 * 1024) {
+                            return `${(bytes / 1024).toFixed(1)} KB`;
+                        }
+
+                        return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+                    };
+
+                    res.on('data', (chunk) => {
+                        downloadedBytes += chunk.length;
+
+                        const now = Date.now();
+                        if (now - lastLoggedAt < 2000) {
+                            return;
+                        }
+
+                        lastLoggedAt = now;
+
+                        if (totalBytes > 0) {
+                            const percentage = ((downloadedBytes / totalBytes) * 100).toFixed(1);
+                            console.log(`Downloaded ${formatBytes(downloadedBytes)} / ${formatBytes(totalBytes)} (${percentage}%)`);
+                            return;
+                        }
+
+                        console.log(`Downloaded ${formatBytes(downloadedBytes)}`);
+                    });
+
                     res.pipe(file);
 
                     file.on('finish', () => {
                         file.close();
+                        if (totalBytes > 0) {
+                            console.log(`Downloaded ${formatBytes(downloadedBytes)} / ${formatBytes(totalBytes)} (100.0%)`);
+                        } else {
+                            console.log(`Downloaded ${formatBytes(downloadedBytes)}`);
+                        }
                         resolve();
                     });
 

--- a/workspaces/ballerina/ballerina-extension/scripts/download-ls.js
+++ b/workspaces/ballerina/ballerina-extension/scripts/download-ls.js
@@ -12,7 +12,21 @@ const args = process.argv.slice(2);
 const usePrerelease = args.includes('--prerelease') || process.env.isPreRelease === 'true';
 const forceReplace = args.includes('--replace');
 const tagIndex = args.indexOf('--tag');
-const requestedTag = tagIndex >= 0 ? args[tagIndex + 1] : process.env.BALLERINA_LS_TAG;
+
+function getTagValue(cliArgs, index) {
+    if (index < 0) {
+        return process.env.BALLERINA_LS_TAG;
+    }
+
+    const value = cliArgs[index + 1];
+    if (!value || value.startsWith('-')) {
+        return undefined;
+    }
+
+    return value;
+}
+
+const requestedTag = getTagValue(args, tagIndex);
 
 function getExpectedVersion(tag) {
     if (!tag) {

--- a/workspaces/ballerina/ballerina-extension/scripts/verify-ls.js
+++ b/workspaces/ballerina/ballerina-extension/scripts/verify-ls.js
@@ -20,7 +20,9 @@ const jarName = getBundledLanguageServerJar();
 
 if (!jarName) {
     console.error(`Bundled Ballerina language server JAR not found in ${path.relative(projectRoot, lsDir)}.`);
-    console.error('Download it before building the VSIX: pnpm run download-ls');
+    console.error('Download it before building the VSIX:');
+    console.error('  cd workspaces/ballerina/ballerina-extension && pnpm run download-ls');
+    console.error('  pnpm --filter ./workspaces/ballerina/ballerina-extension run download-ls');
     process.exit(1);
 }
 

--- a/workspaces/ballerina/ballerina-extension/scripts/verify-ls.js
+++ b/workspaces/ballerina/ballerina-extension/scripts/verify-ls.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const projectRoot = path.join(__dirname, '..');
+const lsDir = path.join(projectRoot, 'ls');
+
+function getBundledLanguageServerJar() {
+    if (!fs.existsSync(lsDir)) {
+        return undefined;
+    }
+
+    return fs.readdirSync(lsDir).find((file) =>
+        /^ballerina-language-server.*\.jar$/.test(file)
+    );
+}
+
+const jarName = getBundledLanguageServerJar();
+
+if (!jarName) {
+    console.error(`Bundled Ballerina language server JAR not found in ${path.relative(projectRoot, lsDir)}.`);
+    console.error('Download it before building the VSIX: pnpm run download-ls');
+    process.exit(1);
+}
+
+console.log(`Using bundled Ballerina language server: ${jarName}`);


### PR DESCRIPTION
## Summary
  - Remove the bundled Ballerina language server download from normal `rush build` so local builds no
  longer fetch release artifacts implicitly.
  - Add a pre-package LS validation step that fails fast if `workspaces/ballerina/ballerina-extension/ls`
  does not contain a `ballerina-language-server*.jar`.
  - Add release workflow inputs to choose the Ballerina language-server source:
    - `latest`
    - `pre-release`
    - `specific-tag`
  - Move contributor guidance into `workspaces/ballerina/ballerina-extension/DEVELOPMENT_SETUP.md`.

<img width="380" height="721" alt="Screenshot 2026-04-03 at 13 40 51" src="https://github.com/user-attachments/assets/b57cc7b8-a021-4717-a8a9-28a0db459e0a" />

  ## Developer workflow
  - Run `rush install` once after cloning.
  - Use `rush build` for a full repo build.
  - Use `rush build -t ballerina` to build only the Ballerina package.
  - Download the language server explicitly with `pnpm --dir workspaces/ballerina/ballerina-extension run
  download-ls`.
  - Use `--prerelease --replace` or `--tag v1.8.0.m1 --replace` when needed.

  ## Notes
  - Release builds still download the selected LS before packaging.
  - `specific-tag` requires `ballerinaLSTag`.

  ## Verification
  - `node --check workspaces/ballerina/ballerina-extension/scripts/download-ls.js`
  - `node --check workspaces/ballerina/ballerina-extension/scripts/verify-ls.js`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workflow configuration inputs to specify Ballerina Language Server release source (latest, pre-release, or specific tag).

* **Documentation**
  * Added comprehensive development setup guide for the Ballerina extension, covering build commands and language server configuration.

* **Chores**
  * Enhanced build process with language server verification step to ensure proper setup before compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->