### PR TITLE
fix types creator existing type diagnostics not fetched issue

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/TypeEditor/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/TypeEditor/index.tsx
@@ -291,6 +291,7 @@ export const FormTypeEditor = (props: FormTypeEditorProps) => {
                     <TypeEditor
                         type={type}
                         rpcClient={rpcClient}
+                        filePath={filePath}
                         isPopupTypeForm={isPopupTypeForm}
                         onTypeChange={onTypeChange}
                         newType={newType}

--- a/workspaces/ballerina/type-editor/src/TypeEditor/Tabs/TypeCreatorTab.tsx
+++ b/workspaces/ballerina/type-editor/src/TypeEditor/Tabs/TypeCreatorTab.tsx
@@ -111,6 +111,7 @@ enum TypeKind {
 interface TypeCreatorTabProps {
     editingType: Type;
     newType: boolean;
+    filePath: string;
     isGraphql: boolean;
     initialTypeKind: TypeNodeKind;
     onTypeSave: (type: Type) => Promise<void>;
@@ -128,7 +129,8 @@ export function TypeCreatorTab(props: TypeCreatorTabProps) {
         onTypeSave,
         isSaving,
         setIsSaving,
-        onTypeChange
+        onTypeChange,
+        filePath
     } = props;
 
     const [type, setType] = useState<Type>(editingType);
@@ -354,7 +356,7 @@ export function TypeCreatorTab(props: TypeCreatorTabProps) {
         });
 
         const response = await rpcClient.getBIDiagramRpcClient().getExpressionDiagnostics({
-            filePath: type?.codedata?.lineRange?.fileName || "types.bal",
+            filePath: type?.codedata?.lineRange?.fileName || filePath,
             context: {
                 expression: value,
                 startLine: {

--- a/workspaces/ballerina/type-editor/src/TypeEditor/TypeEditor.tsx
+++ b/workspaces/ballerina/type-editor/src/TypeEditor/TypeEditor.tsx
@@ -36,6 +36,7 @@ namespace S {
 
 interface TypeEditorProps {
     type?: Type;
+    filePath: string;
     imports?: Imports;
     rpcClient: BallerinaRpcClient;
     onTypeChange: (type: Type, rename?: boolean) => void;
@@ -173,6 +174,7 @@ export function TypeEditor(props: TypeEditorProps) {
                                 isGraphql={isGraphql}
                                 initialTypeKind={initialTypeKind}
                                 onTypeSave={onTypeSave}
+                                filePath={props.filePath}
                                 isSaving={isSaving}
                                 setIsSaving={setIsSaving}
                             />
@@ -192,6 +194,7 @@ export function TypeEditor(props: TypeEditorProps) {
                         <TypeCreatorTab
                             onTypeChange={props.onTypeChange}
                             editingType={type}
+                            filePath={props.filePath}
                             newType={newType}
                             isGraphql={isGraphql}
                             initialTypeKind={initialTypeKind}


### PR DESCRIPTION
## Purpose
When creating a new type, if the provided **type name already existed**, the expected **redeclared name diagnostic** was not shown. Because of this missing validation feedback, the form incorrectly allowed users to save duplicate type definitions.

The root cause was in the diagnostics request flow inside the expression editor, where the **file name was being sent instead of the file path**, preventing the diagnostics engine from resolving the correct file context.

This fix ensures duplicate type names are properly validated and the correct diagnostic is displayed before allowing the form to be saved.

Partially Resolves: https://github.com/wso2/product-integrator/issues/572

---

## Goals
- Ensure **redeclared name diagnostics** are shown when a duplicate type name is entered.
- Prevent saving the form when the type name conflicts with an existing definition.
- Correct the diagnostics request payload to use the proper file context.

---

## Approach
- Fixed the logic to send the **file path instead of the file name** when requesting diagnostics.
- Restored proper file-level diagnostic resolution so duplicate symbol checks work as expected.
- Verified that the **redeclared name diagnostic now appears correctly** for existing type names.
- Ensured the form validation blocks save actions until the duplicate name issue is resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type validation accuracy in the Type Editor by correctly using file path information during type name validation instead of default fallback values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->