### PR TITLE
Fix workflow configure button and save artifact type routing

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/bi-diagram/rpc-manager.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/bi-diagram/rpc-manager.ts
@@ -372,6 +372,8 @@ export class BiDiagramRpcManager implements BIDiagramAPI {
                 return { artifactType: DIRECTORY_MAP.NP_FUNCTION };
             case 'WORKFLOW':
                 return { artifactType: DIRECTORY_MAP.WORKFLOW };
+            case 'ACTIVITY':
+                return { artifactType: DIRECTORY_MAP.ACTIVITY };
             // Add other cases as needed
             default:
                 return undefined;

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/DiagramWrapper/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/DiagramWrapper/index.tsx
@@ -296,6 +296,32 @@ export function DiagramWrapper(param: DiagramWrapperProps) {
             return;
         }
 
+        if (isWorkflow) {
+            rpcClient.getVisualizerRpcClient().openView({
+                type: EVENT_TYPE.OPEN_VIEW,
+                location: {
+                    view: MACHINE_VIEW.BIWorkflowForm,
+                    identifier: parentMetadata?.label || "",
+                    documentUri: fileUri,
+                    position: position || currentPosition,
+                }
+            });
+            return;
+        }
+
+        if (isActivity) {
+            rpcClient.getVisualizerRpcClient().openView({
+                type: EVENT_TYPE.OPEN_VIEW,
+                location: {
+                    view: MACHINE_VIEW.BIActivityForm,
+                    identifier: parentMetadata?.label || "",
+                    documentUri: fileUri,
+                    position: position || currentPosition,
+                }
+            });
+            return;
+        }
+
         const context: VisualizerLocation = {
             view:
                 view === FOCUS_FLOW_DIAGRAM_VIEW.NP_FUNCTION
@@ -314,6 +340,8 @@ export function DiagramWrapper(param: DiagramWrapperProps) {
     let isRemote = parentMetadata?.kind === "Remote Function";
     let isAgent = parentMetadata?.kind === "AI Chat Agent" && parentMetadata?.label === "chat";
     let isInitFunction = parentMetadata?.kind === "Function" && parentMetadata?.label === "init";
+    let isWorkflow = parentMetadata?.kind === "Workflow";
+    let isActivity = parentMetadata?.kind === "Activity";
     let isNPFunction = view === FOCUS_FLOW_DIAGRAM_VIEW.NP_FUNCTION;
 
     const handleResourceTryIt = async (methodValue: string, pathValue: string) => {

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/FunctionForm/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/FunctionForm/index.tsx
@@ -490,6 +490,17 @@ export function FunctionForm(props: FunctionFormProps) {
             }
         }
 
+        // Override the node kind so the correct builder (WorkflowBuilder / ActivityBuilder)
+        // is used when generating source code for an existing workflow or activity function.
+        // ModuleNodeAnalyzer returns FUNCTION_DEFINITION for these; using the wrong kind causes
+        // the artifact-update subscription to filter for FUNCTION instead of WORKFLOW/ACTIVITY,
+        // resulting in a 10-second timeout and incorrect source generation (e.g. adds `public`).
+        if (isWorkflow) {
+            flowNode = { ...flowNode, codedata: { ...flowNode.codedata, node: 'WORKFLOW' as NodeKind } };
+        } else if (isActivity) {
+            flowNode = { ...flowNode, codedata: { ...flowNode.codedata, node: 'ACTIVITY' as NodeKind } };
+        }
+
         setFunctionNode(flowNode);
         setIsLoading(false);
         console.log("Existing Function Node: ", flowNode);
@@ -692,6 +703,8 @@ export function FunctionForm(props: FunctionFormProps) {
             return "Natural Function";
         } else if (isWorkflow) {
             return "Workflow";
+        } else if (isActivity) {
+            return "Workflow Activity";
         } else if (isAutomation || functionName === "main") {
             return "Automation";
         }


### PR DESCRIPTION
 ### Problem
 
 Two bugs affected the workflow editing experience in the BI flow diagram:
 
 1. **Configure button opened the wrong form**: Clicking "Configure" on a workflow
    node in the flow diagram opened the generic `BIFunctionForm` instead of
    `BIWorkflowForm`.
 
 2. **Saving an edited workflow caused a 10-second timeout**: After saving, the UI
    would hang then redirect to the package overview with error notifications.
    
    Related Issue: https://github.com/wso2/product-integrator/issues/631
 
 ### Root Cause
 
 Bug 1: `DiagramWrapper.handleEdit()` had no check for `parentMetadata.kind ===
 "Workflow"` or `"Activity"`, so all function-like nodes fell through to the
 generic function form.
 
 Bug 2: `getArtifactDataFromNodeKind()` had no mapping for `'ACTIVITY'`, and the
 `codedata.node` for workflow/activity nodes was not always set correctly before
 subscribing to `ArtifactsUpdated`. The subscription filtered on `FUNCTION`
 artifact type but the LS emits `WORKFLOW` / `ACTIVITY`, so it never matched.
 
 ### Fix
 
 #### `DiagramWrapper/index.tsx`
 - `handleEdit()` now checks `parentMetadata.kind` early and routes `"Workflow"`
   nodes to `BIWorkflowForm` and `"Activity"` nodes to `BIActivityForm`
 
 #### `FunctionForm/index.tsx`
 - `getExistingFunctionNode()` overrides `codedata.node` to `'WORKFLOW'` /
   `'ACTIVITY'` for existing workflow/activity functions as a safety net
 - `getFunctionType()` now returns `"Workflow Activity"` for activity functions
 
 #### `rpc-manager.ts`
 - Added `'ACTIVITY'` → `DIRECTORY_MAP.ACTIVITY` case to
   `getArtifactDataFromNodeKind()` so the `ArtifactsUpdated` subscription matches
   the artifact type emitted by the language server

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Activity node support for BI Diagram functionality.
  * Workflows and Activities now open specialized configuration forms instead of generic forms.
  * Improved activity type recognition when editing diagrams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->