### PR TITLE
Add support to edit the Integration/Library titles at the package overview

### DIFF
--- a/workspaces/ballerina/ballerina-core/src/rpc-types/bi-diagram/index.ts
+++ b/workspaces/ballerina/ballerina-core/src/rpc-types/bi-diagram/index.ts
@@ -131,7 +131,8 @@ import {
     ValidateProjectFormRequest,
     ValidateProjectFormResponse,
     SuggestedProjectDefaultsResponse,
-    UpdateProjectTitleRequest
+    UpdateProjectTitleRequest,
+    UpdatePackageTitleRequest
 } from "./interfaces";
 
 export interface BIDiagramAPI {
@@ -221,4 +222,5 @@ export interface BIDiagramAPI {
     deleteOpenApiGeneratedModules: (params: OpenAPIClientDeleteRequest) => Promise<OpenAPIClientDeleteResponse>;
     OpenConfigTomlRequest: (params: OpenConfigTomlRequest) => Promise<void>;
     updateProjectTitle: (params: UpdateProjectTitleRequest) => Promise<void>;
+    updatePackageTitle: (params: UpdatePackageTitleRequest) => Promise<void>;
 }

--- a/workspaces/ballerina/ballerina-core/src/rpc-types/bi-diagram/interfaces.ts
+++ b/workspaces/ballerina/ballerina-core/src/rpc-types/bi-diagram/interfaces.ts
@@ -256,3 +256,8 @@ export interface UpdateProjectTitleRequest {
     projectPath: string;
     title: string;
 }
+
+export interface UpdatePackageTitleRequest {
+    packagePath: string;
+    title: string;
+}

--- a/workspaces/ballerina/ballerina-core/src/rpc-types/bi-diagram/rpc-type.ts
+++ b/workspaces/ballerina/ballerina-core/src/rpc-types/bi-diagram/rpc-type.ts
@@ -133,7 +133,8 @@ import {
     ValidateProjectFormRequest,
     ValidateProjectFormResponse,
     SuggestedProjectDefaultsResponse,
-    UpdateProjectTitleRequest
+    UpdateProjectTitleRequest,
+    UpdatePackageTitleRequest
 } from "./interfaces";
 import { RequestType, NotificationType } from "vscode-messenger-common";
 
@@ -225,3 +226,4 @@ export const deleteOpenApiGeneratedModules: RequestType<OpenAPIClientDeleteReque
 export const openConfigToml: RequestType<OpenConfigTomlRequest, void> = { method: `${_preFix}/openConfigToml` };
 export const getExpressionTokens: RequestType<ExpressionTokensRequest, number[]> = { method: `${_preFix}/getExpressionTokens` };
 export const updateProjectTitle: RequestType<UpdateProjectTitleRequest, void> = { method: `${_preFix}/updateProjectTitle` };
+export const updatePackageTitle: RequestType<UpdatePackageTitleRequest, void> = { method: `${_preFix}/updatePackageTitle` };

--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/bi-diagram/rpc-handler.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/bi-diagram/rpc-handler.ts
@@ -167,7 +167,9 @@ import {
     validateProjectPath,
     getSuggestedProjectDefaults,
     UpdateProjectTitleRequest,
-    updateProjectTitle
+    UpdatePackageTitleRequest,
+    updateProjectTitle,
+    updatePackageTitle
 } from "@wso2/ballerina-core";
 import { Messenger } from "vscode-messenger";
 import { BiDiagramRpcManager } from "./rpc-manager";
@@ -260,5 +262,6 @@ export function registerBiDiagramRpcHandlers(messenger: Messenger) {
     messenger.onRequest(getOpenApiGeneratedModules, (args: OpenAPIGeneratedModulesRequest) => rpcManger.getOpenApiGeneratedModules(args));
     messenger.onRequest(deleteOpenApiGeneratedModules, (args: OpenAPIClientDeleteRequest) => rpcManger.deleteOpenApiGeneratedModules(args));
     messenger.onRequest(updateProjectTitle, (args: UpdateProjectTitleRequest) => rpcManger.updateProjectTitle(args));
+    messenger.onRequest(updatePackageTitle, (args: UpdatePackageTitleRequest) => rpcManger.updatePackageTitle(args));
     messenger.onRequest(getSuggestedProjectDefaults, (args: { isInProject: boolean }) => rpcManger.getSuggestedProjectDefaults(args));
 }

--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/bi-diagram/rpc-manager.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/bi-diagram/rpc-manager.ts
@@ -156,8 +156,10 @@ import {
     PackageTomlValues,
     EVENT_TYPE,
     UpdateProjectTitleRequest,
+    UpdatePackageTitleRequest,
     SuggestedProjectDefaultsResponse,
-    MACHINE_VIEW
+    ProjectInfo,
+    PROJECT_KIND
 } from "@wso2/ballerina-core";
 import * as fs from "fs";
 import * as path from 'path';
@@ -2540,6 +2542,61 @@ export class BiDiagramRpcManager implements BIDiagramAPI {
         } else {
             StateMachine.refreshProjectInfo();
         }
+    }
+
+    async updatePackageTitle(params: UpdatePackageTitleRequest): Promise<void> {
+        const ballerinaTomlPath = path.join(params.packagePath, 'Ballerina.toml');
+        let content: string;
+        try {
+            content = fs.readFileSync(ballerinaTomlPath, 'utf-8');
+        } catch {
+            throw new Error(`Ballerina.toml not found at ${ballerinaTomlPath}`);
+        }
+        let doc: ReturnType<typeof toml.parse>;
+        try {
+            doc = toml.parse(content);
+        } catch (e) {
+            const message = e instanceof Error ? e.message : String(e);
+            throw new Error(`Invalid TOML in ${ballerinaTomlPath}: ${message}`);
+        }
+        const pkg = doc.package;
+        if (
+            pkg !== undefined &&
+            pkg !== null &&
+            typeof pkg === "object" &&
+            !Array.isArray(pkg) &&
+            !(pkg instanceof Date)
+        ) {
+            (pkg as Record<string, unknown>).title = params.title;
+        } else {
+            const existing = (typeof doc.package === "object" && doc.package !== null && !Array.isArray(doc.package))
+                ? (doc.package as Record<string, unknown>)
+                : {};
+            doc.package = { ...existing, title: params.title };
+        }
+        fs.writeFileSync(ballerinaTomlPath, toml.stringify(doc), "utf-8");
+
+        // Update projectInfo so that any subsequent buildProjectsStructure call
+        // (e.g., from the LS file watcher) uses the new title.
+        const currentProjectInfo = StateMachine.context().projectInfo;
+        let updatedProjectInfo: ProjectInfo;
+        if (
+            currentProjectInfo.projectKind === PROJECT_KIND.WORKSPACE_PROJECT &&
+            currentProjectInfo.children &&
+            currentProjectInfo.children.length > 0
+        ) {
+            updatedProjectInfo = {
+                ...currentProjectInfo,
+                children: currentProjectInfo.children.map((child) =>
+                    child.projectPath === params.packagePath
+                        ? { ...child, title: params.title }
+                        : child
+                ),
+            };
+        } else {
+            updatedProjectInfo = { ...currentProjectInfo, title: params.title };
+        }
+        StateMachine.updateProjectInfo(updatedProjectInfo, { silent: true });
     }
 
     async getSuggestedProjectDefaults(params: { isInProject: boolean }): Promise<SuggestedProjectDefaultsResponse> {

--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/bi-diagram/rpc-manager.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/bi-diagram/rpc-manager.ts
@@ -237,6 +237,34 @@ function ensureGitignoreEntry(projectRoot: string): void {
     }
 }
 
+/**
+ * Reads a Ballerina.toml file, sets `doc[section][field] = value`, and writes it back.
+ * Throws if the file is missing or unparseable.
+ */
+function setTomlSectionField(filePath: string, section: string, field: string, value: string): void {
+    let content: string;
+    try {
+        content = fs.readFileSync(filePath, 'utf-8');
+    } catch {
+        throw new Error(`Ballerina.toml not found at ${filePath}`);
+    }
+    let doc: ReturnType<typeof toml.parse>;
+    try {
+        doc = toml.parse(content);
+    } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        throw new Error(`Invalid TOML in ${filePath}: ${message}`);
+    }
+    const sectionObj = doc[section];
+    if (sectionObj !== null && typeof sectionObj === "object" && !Array.isArray(sectionObj)) {
+        (sectionObj as Record<string, unknown>)[field] = value;
+    } else {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (doc as any)[section] = { [field]: value };
+    }
+    fs.writeFileSync(filePath, toml.stringify(doc), "utf-8");
+}
+
 export class BiDiagramRpcManager implements BIDiagramAPI {
     OpenConfigTomlRequest: (params: OpenConfigTomlRequest) => Promise<void>;
 
@@ -2508,34 +2536,7 @@ export class BiDiagramRpcManager implements BIDiagramAPI {
     }
 
     async updateProjectTitle(params: UpdateProjectTitleRequest): Promise<void> {
-        const ballerinaTomlPath = path.join(params.projectPath, 'Ballerina.toml');
-        let content: string;
-        try {
-            content = fs.readFileSync(ballerinaTomlPath, 'utf-8');
-        } catch {
-            throw new Error(`Ballerina.toml not found at ${ballerinaTomlPath}`);
-        }
-        let doc: ReturnType<typeof toml.parse>;
-        try {
-            doc = toml.parse(content);
-        } catch (e) {
-            const message = e instanceof Error ? e.message : String(e);
-            throw new Error(`Invalid TOML in ${ballerinaTomlPath}: ${message}`);
-        }
-        const workspace = doc.workspace;
-        if (
-            workspace !== undefined &&
-            workspace !== null &&
-            typeof workspace === "object" &&
-            !Array.isArray(workspace) &&
-            !(workspace instanceof Date)
-        ) {
-            (workspace as ReturnType<typeof toml.parse>).title = params.title;
-        } else {
-            doc.workspace = { title: params.title };
-        }
-        fs.writeFileSync(ballerinaTomlPath, toml.stringify(doc), "utf-8");
-
+        setTomlSectionField(path.join(params.projectPath, 'Ballerina.toml'), 'workspace', 'title', params.title);
         const currentProjectInfo = StateMachine.context().projectInfo;
         if (currentProjectInfo.projectPath === params.projectPath) {
             StateMachine.updateProjectInfo({ ...currentProjectInfo, title: params.title });
@@ -2545,45 +2546,13 @@ export class BiDiagramRpcManager implements BIDiagramAPI {
     }
 
     async updatePackageTitle(params: UpdatePackageTitleRequest): Promise<void> {
-        const ballerinaTomlPath = path.join(params.packagePath, 'Ballerina.toml');
-        let content: string;
-        try {
-            content = fs.readFileSync(ballerinaTomlPath, 'utf-8');
-        } catch {
-            throw new Error(`Ballerina.toml not found at ${ballerinaTomlPath}`);
-        }
-        let doc: ReturnType<typeof toml.parse>;
-        try {
-            doc = toml.parse(content);
-        } catch (e) {
-            const message = e instanceof Error ? e.message : String(e);
-            throw new Error(`Invalid TOML in ${ballerinaTomlPath}: ${message}`);
-        }
-        const pkg = doc.package;
-        if (
-            pkg !== undefined &&
-            pkg !== null &&
-            typeof pkg === "object" &&
-            !Array.isArray(pkg) &&
-            !(pkg instanceof Date)
-        ) {
-            (pkg as Record<string, unknown>).title = params.title;
-        } else {
-            const existing = (typeof doc.package === "object" && doc.package !== null && !Array.isArray(doc.package))
-                ? (doc.package as Record<string, unknown>)
-                : {};
-            doc.package = { ...existing, title: params.title };
-        }
-        fs.writeFileSync(ballerinaTomlPath, toml.stringify(doc), "utf-8");
-
-        // Update projectInfo so that any subsequent buildProjectsStructure call
-        // (e.g., from the LS file watcher) uses the new title.
+        setTomlSectionField(path.join(params.packagePath, 'Ballerina.toml'), 'package', 'title', params.title);
+        // Update projectInfo so any subsequent buildProjectsStructure call uses the new title.
         const currentProjectInfo = StateMachine.context().projectInfo;
         let updatedProjectInfo: ProjectInfo;
         if (
             currentProjectInfo.projectKind === PROJECT_KIND.WORKSPACE_PROJECT &&
-            currentProjectInfo.children &&
-            currentProjectInfo.children.length > 0
+            currentProjectInfo.children?.length > 0
         ) {
             updatedProjectInfo = {
                 ...currentProjectInfo,

--- a/workspaces/ballerina/ballerina-extension/src/stateMachine.ts
+++ b/workspaces/ballerina/ballerina-extension/src/stateMachine.ts
@@ -150,7 +150,9 @@ const stateMachine = createMachine<MachineContext>(
                     async (context, event) => {
                         // Rebuild project structure with updated project info
                         await buildProjectsStructure(event.projectInfo, StateMachine.langClient(), true);
-                        openView(EVENT_TYPE.OPEN_VIEW, { view: MACHINE_VIEW.WorkspaceOverview });
+                        if (!event.silent) {
+                            openView(EVENT_TYPE.OPEN_VIEW, { view: MACHINE_VIEW.WorkspaceOverview });
+                        }
                     }
                 ]
             },
@@ -863,8 +865,8 @@ export const StateMachine = {
     refreshProjectInfo: () => {
         stateService.send({ type: 'REFRESH_PROJECT_INFO' });
     },
-    updateProjectInfo: (projectInfo: ProjectInfo) => {
-        stateService.send({ type: 'UPDATE_PROJECT_INFO', projectInfo });
+    updateProjectInfo: (projectInfo: ProjectInfo, options?: { silent?: boolean }) => {
+        stateService.send({ type: 'UPDATE_PROJECT_INFO', projectInfo, silent: options?.silent });
     },
     resetToExtensionReady: () => {
         stateService.send({ type: 'RESET_TO_EXTENSION_READY' });

--- a/workspaces/ballerina/ballerina-rpc-client/src/rpc-clients/bi-diagram/rpc-client.ts
+++ b/workspaces/ballerina/ballerina-rpc-client/src/rpc-clients/bi-diagram/rpc-client.ts
@@ -128,7 +128,9 @@ import {
     ValidateProjectFormRequest,
     ValidateProjectFormResponse,
     UpdateProjectTitleRequest,
+    UpdatePackageTitleRequest,
     updateProjectTitle,
+    updatePackageTitle,
     VerifyTypeDeleteRequest,
     VerifyTypeDeleteResponse,
     VisibleTypesRequest,
@@ -578,5 +580,9 @@ export class BiDiagramRpcClient implements BIDiagramAPI {
 
     updateProjectTitle(params: UpdateProjectTitleRequest): Promise<void> {
         return this._messenger.sendRequest(updateProjectTitle, HOST_EXTENSION, params);
+    }
+
+    updatePackageTitle(params: UpdatePackageTitleRequest): Promise<void> {
+        return this._messenger.sendRequest(updatePackageTitle, HOST_EXTENSION, params);
     }
 }

--- a/workspaces/ballerina/ballerina-visualizer/src/components/EditableTitle/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/components/EditableTitle/index.tsx
@@ -1,0 +1,196 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { ReactNode, useCallback, useRef, useState } from "react";
+import styled from "@emotion/styled";
+import { Codicon } from "@wso2/ui-toolkit";
+
+const EditableTitleWrapper = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+    outline: none;
+
+    &:is(:hover, :focus-visible) .edit-title-icon-wrapper {
+        opacity: 1;
+        max-width: 28px;
+    }
+`;
+
+const EditTitleIconWrapper = styled.div`
+    opacity: 0;
+    max-width: 0;
+    overflow: hidden;
+    flex-shrink: 0;
+    transition: opacity 0.2s, max-width 0.2s;
+    display: flex;
+    align-items: center;
+`;
+
+const TitleInput = styled.input<{ $hasError?: boolean }>`
+    font-weight: bold;
+    font-size: 1.5rem;
+    margin-bottom: 0;
+    margin-top: 0;
+    background: transparent;
+    border: none;
+    border-bottom: 2px solid ${({ $hasError }: { $hasError?: boolean }) => $hasError
+        ? 'var(--vscode-inputValidation-errorBorder)'
+        : 'var(--vscode-focusBorder)'};
+    color: var(--vscode-foreground);
+    outline: none;
+    padding: 0;
+    font-family: inherit;
+    min-width: 120px;
+    width: auto;
+    @media (min-width: 768px) {
+        font-size: 1.875rem;
+    }
+`;
+
+const TitleValidationMessage = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 0.72rem;
+    color: var(--vscode-inputValidation-errorForeground, var(--vscode-errorForeground));
+    background: var(--vscode-inputValidation-errorBackground, transparent);
+    border: 1px solid var(--vscode-inputValidation-errorBorder);
+    border-radius: 2px;
+    padding: 2px 6px;
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    white-space: nowrap;
+    z-index: 10;
+`;
+
+interface EditableTitleProps {
+    /** The current title value (used to seed the input and detect no-op edits). */
+    title: string;
+    /** Called with the new title when the user commits. Throw to keep edit mode open. */
+    onCommit: (newTitle: string) => Promise<void>;
+    /** Returns an error message for the given value, or "" if valid. */
+    validate?: (value: string) => string;
+    /** Optional style overrides for the input (e.g. to match a specific font size). */
+    inputStyle?: React.CSSProperties;
+    /** The title element rendered in non-editing state (e.g. <ProjectTitle>). */
+    children: ReactNode;
+}
+
+export function EditableTitle({ title, onCommit, validate, inputStyle, children }: EditableTitleProps) {
+    const [isEditing, setIsEditing] = useState(false);
+    const [inputValue, setInputValue] = useState("");
+    const [error, setError] = useState("");
+    const inputRef = useRef<HTMLInputElement>(null);
+    const wrapperRef = useRef<HTMLDivElement>(null);
+
+    const restoreFocus = () => setTimeout(() => { wrapperRef.current?.focus(); }, 0);
+
+    const startEditing = useCallback(() => {
+        setInputValue(title);
+        setError("");
+        setIsEditing(true);
+        setTimeout(() => { inputRef.current?.select(); }, 0);
+    }, [title]);
+
+    const commitEdit = useCallback(async () => {
+        const trimmed = inputValue.trim();
+        const currentError = validate ? validate(trimmed) : "";
+        if (!trimmed || currentError) {
+            setError("");
+            setIsEditing(false);
+            restoreFocus();
+            return;
+        }
+        if (trimmed === title) {
+            setIsEditing(false);
+            restoreFocus();
+            return;
+        }
+        try {
+            await onCommit(trimmed);
+            setIsEditing(false);
+            restoreFocus();
+        } catch {
+            // Keep edit mode open so the user can correct or cancel.
+        }
+    }, [inputValue, title, onCommit, validate]);
+
+    const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === "Enter") {
+            e.preventDefault();
+            e.currentTarget.blur();
+        } else if (e.key === "Escape") {
+            setError("");
+            setIsEditing(false);
+            restoreFocus();
+        }
+    }, []);
+
+    return (
+        <div style={{ position: "relative" }}>
+            {isEditing ? (
+                <>
+                    <TitleInput
+                        ref={inputRef}
+                        value={inputValue}
+                        size={Math.max(inputValue.length, 8)}
+                        $hasError={!!error}
+                        aria-label="Edit name"
+                        style={inputStyle}
+                        onChange={(e) => {
+                            setInputValue(e.target.value);
+                            setError(validate ? validate(e.target.value) : "");
+                        }}
+                        onKeyDown={handleKeyDown}
+                        onBlur={commitEdit}
+                        autoFocus
+                    />
+                    {error && (
+                        <TitleValidationMessage>
+                            <Codicon name="info" sx={{ fontSize: '12px', flexShrink: 0 }} />
+                            {error}
+                        </TitleValidationMessage>
+                    )}
+                </>
+            ) : (
+                <EditableTitleWrapper
+                    ref={wrapperRef}
+                    role="button"
+                    tabIndex={0}
+                    onClick={startEditing}
+                    onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            startEditing();
+                        }
+                    }}
+                    title="Click to edit name"
+                    aria-label="Edit name"
+                >
+                    {children}
+                    <EditTitleIconWrapper className="edit-title-icon-wrapper">
+                        <Codicon name="edit" sx={{ color: 'var(--vscode-descriptionForeground)', fontSize: '14px', width: '16px' }} />
+                    </EditTitleIconWrapper>
+                </EditableTitleWrapper>
+            )}
+        </div>
+    );
+}

--- a/workspaces/ballerina/ballerina-visualizer/src/components/TitleBar/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/components/TitleBar/index.tsx
@@ -16,13 +16,14 @@
  * under the License.
  */
 
-import { ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import React, { ReactNode, useEffect, useState } from "react";
 import styled from "@emotion/styled";
-import { Codicon, Icon } from "@wso2/ui-toolkit";
+import { Icon } from "@wso2/ui-toolkit";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { BetaSVG } from "../../views/Connectors/Marketplace/BetaSVG";
 import { UndoRedoGroup } from "../UndoRedoGroup";
 import { MACHINE_VIEW } from "@wso2/ballerina-core";
+import { EditableTitle } from "../EditableTitle";
 
 const TitleBarContainer = styled.div`
     display: flex;
@@ -99,65 +100,6 @@ const BetaSVGWrapper = styled.span`
     margin-top: 2px;
 `;
 
-const EditableTitleWrapper = styled.div`
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    cursor: pointer;
-    outline: none;
-
-    &:is(:hover, :focus-visible) .edit-title-icon-wrapper {
-        opacity: 1;
-        max-width: 28px;
-    }
-`;
-
-const EditTitleIconWrapper = styled.div`
-    opacity: 0;
-    max-width: 0;
-    overflow: hidden;
-    transition: opacity 0.2s, max-width 0.2s;
-    display: flex;
-    align-items: center;
-`;
-
-const TitleInput = styled.input<{ $hasError?: boolean }>`
-    font-size: 20px;
-    font-weight: 600;
-    margin: 0;
-    background: transparent;
-    border: none;
-    border-bottom: 2px solid ${({ $hasError }: { $hasError?: boolean }) => $hasError
-        ? 'var(--vscode-inputValidation-errorBorder)'
-        : 'var(--vscode-focusBorder)'};
-    color: var(--vscode-foreground);
-    outline: none;
-    padding: 0;
-    font-family: inherit;
-    min-width: 120px;
-    white-space: nowrap;
-`;
-
-const TitleValidationMessage = styled.div`
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    font-size: 0.72rem;
-    color: var(--vscode-inputValidation-errorForeground, var(--vscode-errorForeground));
-    background: var(--vscode-inputValidation-errorBackground, transparent);
-    border: 1px solid var(--vscode-inputValidation-errorBorder);
-    border-radius: 2px;
-    padding: 2px 6px;
-    margin-top: 2px;
-    position: absolute;
-    top: 100%;
-    left: 0;
-    max-width: 320px;
-    white-space: normal;
-    word-break: break-word;
-    z-index: 10;
-`;
-
 interface TitleBarProps {
     title: string;
     subtitle?: string;
@@ -171,16 +113,19 @@ interface TitleBarProps {
     validateTitle?: (value: string) => string;
 }
 
+// Input style overrides to match the TitleBar's Title styled component (20px, 600 weight).
+const TITLE_BAR_INPUT_STYLE: React.CSSProperties = {
+    fontSize: '20px',
+    fontWeight: '600',
+    whiteSpace: 'nowrap',
+    margin: 0,
+};
+
 export function TitleBar(props: TitleBarProps) {
     const { title, subtitle, subtitleElement, actions, hideBack, hideUndoRedo, onBack, isBetaFeature, onTitleEdit, validateTitle } = props;
     const { rpcClient } = useRpcContext();
 
     const [isDiagramView, setIsDiagramView] = useState(false);
-    const [isEditingTitle, setIsEditingTitle] = useState(false);
-    const [titleInputValue, setTitleInputValue] = useState("");
-    const [titleError, setTitleError] = useState("");
-    const titleInputRef = useRef<HTMLInputElement>(null);
-    const wrapperRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
         rpcClient.getVisualizerLocation().then((res) => {
@@ -191,49 +136,6 @@ export function TitleBar(props: TitleBarProps) {
             }
         });
     }, [title]);
-
-    const startEditingTitle = useCallback(() => {
-        setTitleInputValue(title);
-        setTitleError("");
-        setIsEditingTitle(true);
-        setTimeout(() => { titleInputRef.current?.select(); }, 0);
-    }, [title]);
-
-    const commitTitleEdit = useCallback(async () => {
-        const trimmed = titleInputValue.trim();
-        const liveError = validateTitle ? validateTitle(trimmed) : "";
-        if (!trimmed || liveError) {
-            setTitleError("");
-            setIsEditingTitle(false);
-            setTimeout(() => { wrapperRef.current?.focus(); }, 0);
-            return;
-        }
-        if (trimmed === title) {
-            setIsEditingTitle(false);
-            setTimeout(() => { wrapperRef.current?.focus(); }, 0);
-            return;
-        }
-        // Guard against onTitleEdit being absent at call-time (e.g. prop removed between renders).
-        if (!onTitleEdit) { setIsEditingTitle(false); setTimeout(() => { wrapperRef.current?.focus(); }, 0); return; }
-        try {
-            await onTitleEdit(trimmed);
-            setIsEditingTitle(false);
-            setTimeout(() => { wrapperRef.current?.focus(); }, 0);
-        } catch {
-            // Keep edit mode open so the user can correct or cancel — do not silently discard their input.
-        }
-    }, [titleInputValue, title, onTitleEdit, validateTitle]);
-
-    const handleTitleKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
-        if (e.key === "Enter") {
-            e.preventDefault();
-            e.currentTarget.blur();
-        } else if (e.key === "Escape") {
-            setTitleError("");
-            setIsEditingTitle(false);
-            setTimeout(() => { wrapperRef.current?.focus(); }, 0);
-        }
-    }, []);
 
     const handleBackButtonClick = () => {
         if (onBack) {
@@ -253,52 +155,14 @@ export function TitleBar(props: TitleBarProps) {
                 )}
                 <TitleSection>
                     {onTitleEdit ? (
-                        <div style={{ position: "relative" }}>
-                            {isEditingTitle ? (
-                                <>
-                                    <TitleInput
-                                        ref={titleInputRef}
-                                        value={titleInputValue}
-                                        size={Math.max(titleInputValue.length, 8)}
-                                        $hasError={!!titleError}
-                                        aria-label="Edit name"
-                                        onChange={(e) => {
-                                            setTitleInputValue(e.target.value);
-                                            setTitleError(validateTitle ? validateTitle(e.target.value) : "");
-                                        }}
-                                        onKeyDown={handleTitleKeyDown}
-                                        onBlur={commitTitleEdit}
-                                        autoFocus
-                                    />
-                                    {titleError && (
-                                        <TitleValidationMessage>
-                                            <Codicon name="info" sx={{ fontSize: '12px', flexShrink: 0 }} />
-                                            {titleError}
-                                        </TitleValidationMessage>
-                                    )}
-                                </>
-                            ) : (
-                                <EditableTitleWrapper
-                                    ref={wrapperRef}
-                                    role="button"
-                                    tabIndex={0}
-                                    onClick={startEditingTitle}
-                                    onKeyDown={(e) => {
-                                        if (e.key === "Enter" || e.key === " ") {
-                                            e.preventDefault();
-                                            startEditingTitle();
-                                        }
-                                    }}
-                                    title="Click to edit name"
-                                    aria-label="Edit name"
-                                >
-                                    <Title>{title}</Title>
-                                    <EditTitleIconWrapper className="edit-title-icon-wrapper">
-                                        <Codicon name="edit" sx={{ color: 'var(--vscode-descriptionForeground)', fontSize: '14px', width: '16px' }} />
-                                    </EditTitleIconWrapper>
-                                </EditableTitleWrapper>
-                            )}
-                        </div>
+                        <EditableTitle
+                            title={title}
+                            onCommit={onTitleEdit}
+                            validate={validateTitle}
+                            inputStyle={TITLE_BAR_INPUT_STYLE}
+                        >
+                            <Title>{title}</Title>
+                        </EditableTitle>
                     ) : (
                         <Title>{title}</Title>
                     )}

--- a/workspaces/ballerina/ballerina-visualizer/src/components/TitleBar/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/components/TitleBar/index.tsx
@@ -16,9 +16,9 @@
  * under the License.
  */
 
-import { ReactNode, useEffect, useState } from "react";
+import { ReactNode, useCallback, useEffect, useRef, useState } from "react";
 import styled from "@emotion/styled";
-import { Icon } from "@wso2/ui-toolkit";
+import { Codicon, Icon } from "@wso2/ui-toolkit";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { BetaSVG } from "../../views/Connectors/Marketplace/BetaSVG";
 import { UndoRedoGroup } from "../UndoRedoGroup";
@@ -99,6 +99,65 @@ const BetaSVGWrapper = styled.span`
     margin-top: 2px;
 `;
 
+const EditableTitleWrapper = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+    outline: none;
+
+    &:is(:hover, :focus-visible) .edit-title-icon-wrapper {
+        opacity: 1;
+        max-width: 28px;
+    }
+`;
+
+const EditTitleIconWrapper = styled.div`
+    opacity: 0;
+    max-width: 0;
+    overflow: hidden;
+    transition: opacity 0.2s, max-width 0.2s;
+    display: flex;
+    align-items: center;
+`;
+
+const TitleInput = styled.input<{ $hasError?: boolean }>`
+    font-size: 20px;
+    font-weight: 600;
+    margin: 0;
+    background: transparent;
+    border: none;
+    border-bottom: 2px solid ${({ $hasError }: { $hasError?: boolean }) => $hasError
+        ? 'var(--vscode-inputValidation-errorBorder)'
+        : 'var(--vscode-focusBorder)'};
+    color: var(--vscode-foreground);
+    outline: none;
+    padding: 0;
+    font-family: inherit;
+    min-width: 120px;
+    white-space: nowrap;
+`;
+
+const TitleValidationMessage = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 0.72rem;
+    color: var(--vscode-inputValidation-errorForeground, var(--vscode-errorForeground));
+    background: var(--vscode-inputValidation-errorBackground, transparent);
+    border: 1px solid var(--vscode-inputValidation-errorBorder);
+    border-radius: 2px;
+    padding: 2px 6px;
+    margin-top: 2px;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    max-width: 320px;
+    white-space: normal;
+    word-break: break-word;
+    z-index: 10;
+`;
+
 interface TitleBarProps {
     title: string;
     subtitle?: string;
@@ -108,13 +167,20 @@ interface TitleBarProps {
     hideUndoRedo?: boolean;
     onBack?: () => void; // Override back functionality
     isBetaFeature?: boolean;
+    onTitleEdit?: (newTitle: string) => Promise<void>;
+    validateTitle?: (value: string) => string;
 }
 
 export function TitleBar(props: TitleBarProps) {
-    const { title, subtitle, subtitleElement, actions, hideBack, hideUndoRedo, onBack, isBetaFeature } = props;
+    const { title, subtitle, subtitleElement, actions, hideBack, hideUndoRedo, onBack, isBetaFeature, onTitleEdit, validateTitle } = props;
     const { rpcClient } = useRpcContext();
 
     const [isDiagramView, setIsDiagramView] = useState(false);
+    const [isEditingTitle, setIsEditingTitle] = useState(false);
+    const [titleInputValue, setTitleInputValue] = useState("");
+    const [titleError, setTitleError] = useState("");
+    const titleInputRef = useRef<HTMLInputElement>(null);
+    const wrapperRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
         rpcClient.getVisualizerLocation().then((res) => {
@@ -125,6 +191,49 @@ export function TitleBar(props: TitleBarProps) {
             }
         });
     }, [title]);
+
+    const startEditingTitle = useCallback(() => {
+        setTitleInputValue(title);
+        setTitleError("");
+        setIsEditingTitle(true);
+        setTimeout(() => { titleInputRef.current?.select(); }, 0);
+    }, [title]);
+
+    const commitTitleEdit = useCallback(async () => {
+        const trimmed = titleInputValue.trim();
+        const liveError = validateTitle ? validateTitle(trimmed) : "";
+        if (!trimmed || liveError) {
+            setTitleError("");
+            setIsEditingTitle(false);
+            setTimeout(() => { wrapperRef.current?.focus(); }, 0);
+            return;
+        }
+        if (trimmed === title) {
+            setIsEditingTitle(false);
+            setTimeout(() => { wrapperRef.current?.focus(); }, 0);
+            return;
+        }
+        // Guard against onTitleEdit being absent at call-time (e.g. prop removed between renders).
+        if (!onTitleEdit) { setIsEditingTitle(false); setTimeout(() => { wrapperRef.current?.focus(); }, 0); return; }
+        try {
+            await onTitleEdit(trimmed);
+            setIsEditingTitle(false);
+            setTimeout(() => { wrapperRef.current?.focus(); }, 0);
+        } catch {
+            // Keep edit mode open so the user can correct or cancel — do not silently discard their input.
+        }
+    }, [titleInputValue, title, onTitleEdit, validateTitle]);
+
+    const handleTitleKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === "Enter") {
+            e.preventDefault();
+            e.currentTarget.blur();
+        } else if (e.key === "Escape") {
+            setTitleError("");
+            setIsEditingTitle(false);
+            setTimeout(() => { wrapperRef.current?.focus(); }, 0);
+        }
+    }, []);
 
     const handleBackButtonClick = () => {
         if (onBack) {
@@ -143,7 +252,56 @@ export function TitleBar(props: TitleBarProps) {
                     </IconButton>
                 )}
                 <TitleSection>
-                    <Title>{title}</Title>
+                    {onTitleEdit ? (
+                        <div style={{ position: "relative" }}>
+                            {isEditingTitle ? (
+                                <>
+                                    <TitleInput
+                                        ref={titleInputRef}
+                                        value={titleInputValue}
+                                        size={Math.max(titleInputValue.length, 8)}
+                                        $hasError={!!titleError}
+                                        aria-label="Edit name"
+                                        onChange={(e) => {
+                                            setTitleInputValue(e.target.value);
+                                            setTitleError(validateTitle ? validateTitle(e.target.value) : "");
+                                        }}
+                                        onKeyDown={handleTitleKeyDown}
+                                        onBlur={commitTitleEdit}
+                                        autoFocus
+                                    />
+                                    {titleError && (
+                                        <TitleValidationMessage>
+                                            <Codicon name="info" sx={{ fontSize: '12px', flexShrink: 0 }} />
+                                            {titleError}
+                                        </TitleValidationMessage>
+                                    )}
+                                </>
+                            ) : (
+                                <EditableTitleWrapper
+                                    ref={wrapperRef}
+                                    role="button"
+                                    tabIndex={0}
+                                    onClick={startEditingTitle}
+                                    onKeyDown={(e) => {
+                                        if (e.key === "Enter" || e.key === " ") {
+                                            e.preventDefault();
+                                            startEditingTitle();
+                                        }
+                                    }}
+                                    title="Click to edit name"
+                                    aria-label="Edit name"
+                                >
+                                    <Title>{title}</Title>
+                                    <EditTitleIconWrapper className="edit-title-icon-wrapper">
+                                        <Codicon name="edit" sx={{ color: 'var(--vscode-descriptionForeground)', fontSize: '14px', width: '16px' }} />
+                                    </EditTitleIconWrapper>
+                                </EditableTitleWrapper>
+                            )}
+                        </div>
+                    ) : (
+                        <Title>{title}</Title>
+                    )}
                     {subtitle && <SubTitle>{subtitle}</SubTitle>}
                     {subtitleElement && subtitleElement}
                 </TitleSection>

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
@@ -16,14 +16,13 @@
  * under the License.
  */
 
-import React, { ReactNode, useEffect, useMemo, useState } from "react";
+import React, { ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
     ProjectStructure,
     EVENT_TYPE,
     MACHINE_VIEW,
     BuildMode,
     BI_COMMANDS,
-    SHARED_COMMANDS,
     DIRECTORY_MAP,
 } from "@wso2/ballerina-core";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
@@ -35,7 +34,7 @@ import { VSCodeLink } from "@vscode/webview-ui-toolkit/react";
 import ReactMarkdown from "react-markdown";
 import { IOpenInConsoleCmdParams, WICommandIds } from "@wso2/wso2-platform-core";
 import { AlertBoxWithClose } from "../../AIPanel/AlertBoxWithClose";
-import { getIntegrationTypes } from "./utils";
+import { getIntegrationTypes, validateComponentName } from "./utils";
 import { UndoRedoGroup } from "../../../components/UndoRedoGroup";
 import { usePlatformExtContext } from "../../../providers/platform-ext-ctx-provider";
 import { TopNavigationBar } from "../../../components/TopNavigationBar";
@@ -256,6 +255,67 @@ const ProjectSubtitle = styled.h2`
     @media (min-width: 768px) {
         font-size: 1.875rem;
     }
+`;
+
+const EditableTitleWrapper = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+    outline: none;
+
+    &:is(:hover, :focus-visible) .edit-title-icon-wrapper {
+        opacity: 1;
+        max-width: 28px;
+    }
+`;
+
+const EditTitleIconWrapper = styled.div`
+    opacity: 0;
+    max-width: 0;
+    overflow: hidden;
+    transition: opacity 0.2s, max-width 0.2s;
+    display: flex;
+    align-items: center;
+`;
+
+const TitleInput = styled.input<{ $hasError?: boolean }>`
+    font-weight: bold;
+    font-size: 1.5rem;
+    margin-bottom: 0;
+    margin-top: 0;
+    background: transparent;
+    border: none;
+    border-bottom: 2px solid ${({ $hasError }: { $hasError?: boolean }) => $hasError
+        ? 'var(--vscode-inputValidation-errorBorder)'
+        : 'var(--vscode-focusBorder)'};
+    color: var(--vscode-foreground);
+    outline: none;
+    padding: 0;
+    font-family: inherit;
+    min-width: 120px;
+    width: auto;
+    @media (min-width: 768px) {
+        font-size: 1.875rem;
+    }
+`;
+
+const TitleValidationMessage = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 0.72rem;
+    color: var(--vscode-inputValidation-errorForeground, var(--vscode-errorForeground));
+    background: var(--vscode-inputValidation-errorBackground, transparent);
+    border: 1px solid var(--vscode-inputValidation-errorBorder);
+    border-radius: 2px;
+    padding: 2px 6px;
+    margin-top: 2px;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    white-space: nowrap;
+    z-index: 10;
 `;
 
 const DeployButton = styled.div`
@@ -662,8 +722,12 @@ export function PackageOverview(props: PackageOverviewProps) {
     const [isInProject, setIsInProject] = useState(false);
     const [isLibrary, setIsLibrary] = useState<boolean>(false);
     const [isNPSupported, setIsNPSupported] = useState<boolean>(false);
+    const [isEditingTitle, setIsEditingTitle] = useState(false);
+    const [titleInputValue, setTitleInputValue] = useState("");
+    const [titleError, setTitleError] = useState("");
+    const titleInputRef = useRef<HTMLInputElement>(null);
 
-    const fetchContext = () => {
+    const fetchContext = useCallback(() => {
         rpcClient
             .getBIDiagramRpcClient()
             .getProjectStructure()
@@ -698,20 +762,23 @@ export function PackageOverview(props: PackageOverviewProps) {
             .then((res) => {
                 setReadmeContent(res.content);
             });
-    };
-
-    rpcClient?.onProjectContentUpdated((state: boolean) => {
-        if (state) {
-            fetchContext();
-        }
-    });
+    }, [rpcClient, projectPath]);
 
     useEffect(() => {
         fetchContext();
         showLoginAlert().then((status) => {
             setShowAlert(status);
         });
-    }, [projectPath]);
+    }, [projectPath, fetchContext]);
+
+    useEffect(() => {
+        if (!rpcClient) return;
+        rpcClient.onProjectContentUpdated((state: boolean) => {
+            if (state) {
+                fetchContext();
+            }
+        });
+    }, [projectPath, fetchContext]);
 
     const deployableIntegrationTypes = useMemo(() => {
         return getIntegrationTypes(projectStructure);
@@ -720,6 +787,62 @@ export function PackageOverview(props: PackageOverviewProps) {
     const integrationTitle = useMemo(() => {
         return projectStructure?.projectTitle || projectStructure?.projectName;
     }, [projectStructure]);
+
+    const validateTitle = useCallback((value: string): string => {
+        return validateComponentName(value.trim(), isLibrary) ?? "";
+    }, [isLibrary]);
+
+    const startEditingTitle = useCallback(() => {
+        setTitleInputValue(integrationTitle || "");
+        setTitleError("");
+        setIsEditingTitle(true);
+        setTimeout(() => { titleInputRef.current?.select(); }, 0);
+    }, [integrationTitle]);
+
+    const handleTitleUpdate = useCallback(async (newTitle: string) => {
+        await rpcClient.getBIDiagramRpcClient().updatePackageTitle({
+            packagePath: projectPath,
+            title: newTitle,
+        });
+        // Optimistically update the displayed title immediately.
+        // Do NOT call fetchContext() here — buildProjectsStructure in the backend is async;
+        // calling getProjectStructure() too early would return stale data and overwrite this update.
+        // The backend's notifyCurrentWebview() fires after buildProjectsStructure completes,
+        // which triggers onProjectContentUpdated → fetchContext() as the background confirm.
+        setProjectStructure(prev => prev ? { ...prev, projectTitle: newTitle } : prev);
+    }, [projectPath, rpcClient]);
+
+    // Used only by the standalone HeaderRow (isInProject=false) where PackageOverview
+    // owns the input element and its state.  TitleBar manages its own input, so
+    // passing commitTitleEdit there would always read a stale "" from titleInputValue.
+    const commitTitleEdit = useCallback(async () => {
+        const trimmed = titleInputValue.trim();
+        if (!trimmed || titleError) {
+            setTitleError("");
+            setIsEditingTitle(false);
+            return;
+        }
+        if (trimmed === integrationTitle) {
+            setIsEditingTitle(false);
+            return;
+        }
+        try {
+            await handleTitleUpdate(trimmed);
+            setIsEditingTitle(false);
+        } catch {
+            // keep edit mode open on failure
+        }
+    }, [titleInputValue, titleError, integrationTitle, handleTitleUpdate]);
+
+    const handleTitleKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === "Enter") {
+            e.preventDefault();
+            e.currentTarget.blur();
+        } else if (e.key === "Escape") {
+            setTitleError("");
+            setIsEditingTitle(false);
+        }
+    }, []);
 
     function isEmptyIntegration(): boolean {
         // Filter out connections that start with underscore
@@ -892,11 +1015,56 @@ export function PackageOverview(props: PackageOverviewProps) {
                         subtitle={isLibrary ? "Library" : "Integration"}
                         onBack={handleBack}
                         actions={headerActions}
+                        onTitleEdit={handleTitleUpdate}
+                        validateTitle={validateTitle}
                     />
                 ) : (
                     <HeaderRow>
                         <TitleContainer>
-                            <ProjectTitle>{integrationTitle}</ProjectTitle>
+                            <div style={{ position: "relative" }}>
+                                {isEditingTitle ? (
+                                    <>
+                                        <TitleInput
+                                            ref={titleInputRef}
+                                            value={titleInputValue}
+                                            size={Math.max(titleInputValue.length, 8)}
+                                            $hasError={!!titleError}
+                                            onChange={(e) => {
+                                                setTitleInputValue(e.target.value);
+                                                setTitleError(validateTitle(e.target.value));
+                                            }}
+                                            onKeyDown={handleTitleKeyDown}
+                                            onBlur={commitTitleEdit}
+                                            autoFocus
+                                        />
+                                        {titleError && (
+                                            <TitleValidationMessage>
+                                                <Codicon name="info" sx={{ fontSize: '12px', flexShrink: 0 }} />
+                                                {titleError}
+                                            </TitleValidationMessage>
+                                        )}
+                                    </>
+                                ) : (
+                                    <EditableTitleWrapper
+                                        role="button"
+                                        tabIndex={0}
+                                        onClick={startEditingTitle}
+                                        onKeyDown={(e) => {
+                                            if (e.key === "Enter" || e.key === " ") {
+                                                e.preventDefault();
+                                                startEditingTitle();
+                                            }
+                                        }}
+                                        title="Click to edit name"
+                                        aria-label="Edit name"
+                                    >
+                                        <ProjectTitle>{integrationTitle}</ProjectTitle>
+                                        <EditTitleIconWrapper className="edit-title-icon-wrapper">
+                                            <Codicon name="edit" sx={{ color: 'var(--vscode-descriptionForeground)', fontSize: '14px', width: '16px' }} />
+                                        </EditTitleIconWrapper>
+                                    </EditableTitleWrapper>
+                                )}
+                            </div>
                             <ProjectSubtitle>{isLibrary ? "Library" : "Integration"}</ProjectSubtitle>
                         </TitleContainer>
                         <HeaderControls>

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
@@ -17,6 +17,7 @@
  */
 
 import React, { ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { EditableTitle } from "../../../components/EditableTitle";
 import {
     ProjectStructure,
     EVENT_TYPE,
@@ -255,67 +256,6 @@ const ProjectSubtitle = styled.h2`
     @media (min-width: 768px) {
         font-size: 1.875rem;
     }
-`;
-
-const EditableTitleWrapper = styled.div`
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    cursor: pointer;
-    outline: none;
-
-    &:is(:hover, :focus-visible) .edit-title-icon-wrapper {
-        opacity: 1;
-        max-width: 28px;
-    }
-`;
-
-const EditTitleIconWrapper = styled.div`
-    opacity: 0;
-    max-width: 0;
-    overflow: hidden;
-    transition: opacity 0.2s, max-width 0.2s;
-    display: flex;
-    align-items: center;
-`;
-
-const TitleInput = styled.input<{ $hasError?: boolean }>`
-    font-weight: bold;
-    font-size: 1.5rem;
-    margin-bottom: 0;
-    margin-top: 0;
-    background: transparent;
-    border: none;
-    border-bottom: 2px solid ${({ $hasError }: { $hasError?: boolean }) => $hasError
-        ? 'var(--vscode-inputValidation-errorBorder)'
-        : 'var(--vscode-focusBorder)'};
-    color: var(--vscode-foreground);
-    outline: none;
-    padding: 0;
-    font-family: inherit;
-    min-width: 120px;
-    width: auto;
-    @media (min-width: 768px) {
-        font-size: 1.875rem;
-    }
-`;
-
-const TitleValidationMessage = styled.div`
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    font-size: 0.72rem;
-    color: var(--vscode-inputValidation-errorForeground, var(--vscode-errorForeground));
-    background: var(--vscode-inputValidation-errorBackground, transparent);
-    border: 1px solid var(--vscode-inputValidation-errorBorder);
-    border-radius: 2px;
-    padding: 2px 6px;
-    margin-top: 2px;
-    position: absolute;
-    top: 100%;
-    left: 0;
-    white-space: nowrap;
-    z-index: 10;
 `;
 
 const DeployButton = styled.div`
@@ -722,11 +662,6 @@ export function PackageOverview(props: PackageOverviewProps) {
     const [isInProject, setIsInProject] = useState(false);
     const [isLibrary, setIsLibrary] = useState<boolean>(false);
     const [isNPSupported, setIsNPSupported] = useState<boolean>(false);
-    const [isEditingTitle, setIsEditingTitle] = useState(false);
-    const [titleInputValue, setTitleInputValue] = useState("");
-    const [titleError, setTitleError] = useState("");
-    const titleInputRef = useRef<HTMLInputElement>(null);
-
     const fetchContext = useCallback(() => {
         rpcClient
             .getBIDiagramRpcClient()
@@ -771,14 +706,19 @@ export function PackageOverview(props: PackageOverviewProps) {
         });
     }, [projectPath, fetchContext]);
 
+    // Keep a stable ref so the subscription callback always calls the latest fetchContext
+    // without needing to re-register the listener every time fetchContext changes.
+    const fetchContextRef = useRef(fetchContext);
+    fetchContextRef.current = fetchContext;
+
     useEffect(() => {
         if (!rpcClient) return;
         rpcClient.onProjectContentUpdated((state: boolean) => {
             if (state) {
-                fetchContext();
+                fetchContextRef.current();
             }
         });
-    }, [projectPath, fetchContext]);
+    }, [rpcClient]);
 
     const deployableIntegrationTypes = useMemo(() => {
         return getIntegrationTypes(projectStructure);
@@ -792,13 +732,6 @@ export function PackageOverview(props: PackageOverviewProps) {
         return validateComponentName(value.trim(), isLibrary) ?? "";
     }, [isLibrary]);
 
-    const startEditingTitle = useCallback(() => {
-        setTitleInputValue(integrationTitle || "");
-        setTitleError("");
-        setIsEditingTitle(true);
-        setTimeout(() => { titleInputRef.current?.select(); }, 0);
-    }, [integrationTitle]);
-
     const handleTitleUpdate = useCallback(async (newTitle: string) => {
         await rpcClient.getBIDiagramRpcClient().updatePackageTitle({
             packagePath: projectPath,
@@ -811,38 +744,6 @@ export function PackageOverview(props: PackageOverviewProps) {
         // which triggers onProjectContentUpdated → fetchContext() as the background confirm.
         setProjectStructure(prev => prev ? { ...prev, projectTitle: newTitle } : prev);
     }, [projectPath, rpcClient]);
-
-    // Used only by the standalone HeaderRow (isInProject=false) where PackageOverview
-    // owns the input element and its state.  TitleBar manages its own input, so
-    // passing commitTitleEdit there would always read a stale "" from titleInputValue.
-    const commitTitleEdit = useCallback(async () => {
-        const trimmed = titleInputValue.trim();
-        if (!trimmed || titleError) {
-            setTitleError("");
-            setIsEditingTitle(false);
-            return;
-        }
-        if (trimmed === integrationTitle) {
-            setIsEditingTitle(false);
-            return;
-        }
-        try {
-            await handleTitleUpdate(trimmed);
-            setIsEditingTitle(false);
-        } catch {
-            // keep edit mode open on failure
-        }
-    }, [titleInputValue, titleError, integrationTitle, handleTitleUpdate]);
-
-    const handleTitleKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
-        if (e.key === "Enter") {
-            e.preventDefault();
-            e.currentTarget.blur();
-        } else if (e.key === "Escape") {
-            setTitleError("");
-            setIsEditingTitle(false);
-        }
-    }, []);
 
     function isEmptyIntegration(): boolean {
         // Filter out connections that start with underscore
@@ -1021,50 +922,13 @@ export function PackageOverview(props: PackageOverviewProps) {
                 ) : (
                     <HeaderRow>
                         <TitleContainer>
-                            <div style={{ position: "relative" }}>
-                                {isEditingTitle ? (
-                                    <>
-                                        <TitleInput
-                                            ref={titleInputRef}
-                                            value={titleInputValue}
-                                            size={Math.max(titleInputValue.length, 8)}
-                                            $hasError={!!titleError}
-                                            onChange={(e) => {
-                                                setTitleInputValue(e.target.value);
-                                                setTitleError(validateTitle(e.target.value));
-                                            }}
-                                            onKeyDown={handleTitleKeyDown}
-                                            onBlur={commitTitleEdit}
-                                            autoFocus
-                                        />
-                                        {titleError && (
-                                            <TitleValidationMessage>
-                                                <Codicon name="info" sx={{ fontSize: '12px', flexShrink: 0 }} />
-                                                {titleError}
-                                            </TitleValidationMessage>
-                                        )}
-                                    </>
-                                ) : (
-                                    <EditableTitleWrapper
-                                        role="button"
-                                        tabIndex={0}
-                                        onClick={startEditingTitle}
-                                        onKeyDown={(e) => {
-                                            if (e.key === "Enter" || e.key === " ") {
-                                                e.preventDefault();
-                                                startEditingTitle();
-                                            }
-                                        }}
-                                        title="Click to edit name"
-                                        aria-label="Edit name"
-                                    >
-                                        <ProjectTitle>{integrationTitle}</ProjectTitle>
-                                        <EditTitleIconWrapper className="edit-title-icon-wrapper">
-                                            <Codicon name="edit" sx={{ color: 'var(--vscode-descriptionForeground)', fontSize: '14px', width: '16px' }} />
-                                        </EditTitleIconWrapper>
-                                    </EditableTitleWrapper>
-                                )}
-                            </div>
+                            <EditableTitle
+                                title={integrationTitle}
+                                onCommit={handleTitleUpdate}
+                                validate={validateTitle}
+                            >
+                                <ProjectTitle>{integrationTitle}</ProjectTitle>
+                            </EditableTitle>
                             <ProjectSubtitle>{isLibrary ? "Library" : "Integration"}</ProjectSubtitle>
                         </TitleContainer>
                         <HeaderControls>

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
@@ -713,11 +713,12 @@ export function PackageOverview(props: PackageOverviewProps) {
 
     useEffect(() => {
         if (!rpcClient) return;
-        rpcClient.onProjectContentUpdated((state: boolean) => {
+        const unsubscribe = rpcClient.onProjectContentUpdated((state: boolean) => {
             if (state) {
                 fetchContextRef.current();
             }
         });
+        return unsubscribe;
     }, [rpcClient]);
 
     const deployableIntegrationTypes = useMemo(() => {

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/PackageOverview/utils.ts
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/PackageOverview/utils.ts
@@ -22,6 +22,7 @@ import {
     ProjectStructureResponse,
     ProjectScopeMapping
 } from "@wso2/ballerina-core";
+export { validateComponentName } from "../ProjectForm/utils";
 
 const INTEGRATION_API_MODULES = [
     "http",

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/ProjectForm/AddProjectFormFields.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/ProjectForm/AddProjectFormFields.tsx
@@ -30,6 +30,7 @@ import { AddProjectFormData } from "./types";
 import {
     sanitizePackageName,
     sanitizeProjectHandle,
+    validateComponentName,
     validatePackageName,
     validateOrgName,
     validateProjectHandle
@@ -62,6 +63,7 @@ export function AddProjectFormFields({
     const [packageNameTouched, setPackageNameTouched] = useState(false);
     const [projectHandleTouched, setProjectHandleTouched] = useState(false);
     const [isPackageInfoExpanded, setIsPackageInfoExpanded] = useState(false);
+    const [integrationNameError, setIntegrationNameError] = useState<string | null>(null);
     const [packageNameError, setPackageNameError] = useState<string | null>(null);
     const [orgNameError, setOrgNameError] = useState<string | null>(null);
     const [projectHandleError, setProjectHandleError] = useState<string | null>(null);
@@ -109,6 +111,12 @@ export function AddProjectFormFields({
             isMounted = false;
         };
     }, [organizations, onFormDataChange, rpcClient]);
+
+    // Real-time validation for integration/library name
+    useEffect(() => {
+        const error = validateComponentName(formData.integrationName, formData.isLibrary);
+        setIntegrationNameError(error);
+    }, [formData.integrationName]);
 
     // Effect to trigger validation when requested by parent
     useEffect(() => {
@@ -174,6 +182,7 @@ export function AddProjectFormFields({
                     autoFocus={isInProject}
                     onFocus={(e) => (e.target as HTMLInputElement).select()}
                     required={true}
+                    errorMsg={integrationNameError || ""}
                 />
             </FieldGroup>
 

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/ProjectForm/AddProjectFormFields.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/ProjectForm/AddProjectFormFields.tsx
@@ -116,7 +116,7 @@ export function AddProjectFormFields({
     useEffect(() => {
         const error = validateComponentName(formData.integrationName, formData.isLibrary);
         setIntegrationNameError(error);
-    }, [formData.integrationName]);
+    }, [formData.integrationName, formData.isLibrary]);
 
     // Effect to trigger validation when requested by parent
     useEffect(() => {

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/ProjectForm/utils.ts
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/ProjectForm/utils.ts
@@ -89,6 +89,10 @@ export const validatePackageName = (name: string, integrationName: string): stri
         return "Package name cannot end with an underscore";
     }
 
+    if (name.length < 2) {
+        return `Package name must be at least 2 characters`;
+    }
+
     if (name.endsWith(".")) {
         return "Package name cannot end with a dot";
     }
@@ -123,8 +127,6 @@ export const validateComponentName = (name: string, isLibrary: boolean): string 
 
 export const isFormValidAddProject = (formData: AddProjectFormData, isInProject: boolean): boolean => {
     return (
-        formData.integrationName.length >= 2 &&
-        formData.packageName.length >= 2 &&
         (isInProject || (formData.workspaceName?.length ?? 0) >= 1) &&
         validateComponentName(formData.integrationName, formData.isLibrary) === null &&
         validatePackageName(formData.packageName, formData.integrationName) === null &&

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/ProjectForm/utils.ts
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/ProjectForm/utils.ts
@@ -113,7 +113,7 @@ export const validateComponentName = (name: string, isLibrary: boolean): string 
         return `${componentType} name cannot contain special characters`;
     }
     if (name.length < 3) {
-        return `${componentType} name must be least 3 characters`;
+        return `${componentType} name must be at least 3 characters`;
     }
     if (name.length > COMPONENT_NAME_MAX_LENGTH) {
         return `${componentType} name cannot exceed ${COMPONENT_NAME_MAX_LENGTH} characters`;

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/ProjectForm/utils.ts
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/ProjectForm/utils.ts
@@ -16,9 +16,10 @@
  * under the License.
  */
 
-import { AddProjectFormData, ProjectFormData } from "./types";
+import { AddProjectFormData } from "./types";
 
 export const PROJECT_HANDLE_MAX_LENGTH = 63;
+export const COMPONENT_NAME_MAX_LENGTH = 60;
 
 export const sanitizeProjectHandle = (name: string, { trimTrailing = true } = {}): string => {
     let result = name
@@ -34,12 +35,24 @@ export const sanitizeProjectHandle = (name: string, { trimTrailing = true } = {}
 };
 
 export const validateProjectHandle = (handle: string): string | null => {
-    if (!handle || handle.length === 0) return "Project handle is required";
-    if (handle.length < 2) return "Project handle must be at least 2 characters";
-    if (handle.length > PROJECT_HANDLE_MAX_LENGTH) return `Project handle cannot exceed ${PROJECT_HANDLE_MAX_LENGTH} characters`;
-    if (!/^[a-z0-9-]+$/.test(handle)) return "Project handle can only contain lowercase letters, digits, or hyphens";
-    if (handle.startsWith("-")) return "Project handle cannot start with a hyphen";
-    if (handle.endsWith("-")) return "Project handle cannot end with a hyphen";
+    if (!handle || handle.length === 0) {
+        return "Project handle is required";
+    }
+    if (!/^[a-zA-Z0-9]/.test(handle)) {
+        return "Project handle must start with an alphanumeric character";
+    }
+    if (!/^[a-z0-9-]+$/.test(handle)) {
+        return "Project handle can only contain lowercase letters, digits, or hyphens";
+    }
+    if (handle.length < 2) {
+        return "Project handle must be at least 2 characters";
+    }
+    if (handle.length > PROJECT_HANDLE_MAX_LENGTH) {
+        return `Project handle cannot exceed ${PROJECT_HANDLE_MAX_LENGTH} characters`;
+    }
+    if (handle.endsWith("-")) {
+        return "Project handle cannot end with a hyphen";
+    }
     return null;
 };
 
@@ -87,11 +100,33 @@ export const validatePackageName = (name: string, integrationName: string): stri
     return null; // No error
 };
 
+export const validateComponentName = (name: string, isLibrary: boolean): string | null => {
+    const componentType = isLibrary ? "Library" : "Integration";
+
+    if (!name || name.length === 0) {
+        return `${componentType} name is required`;
+    }
+    if (!/^[a-zA-Z]/.test(name)) {
+        return `${componentType} name must start with an alphabetic letter`;
+    }
+    if (!/^[a-zA-Z0-9 _-]+$/.test(name)) {
+        return `${componentType} name cannot contain special characters`;
+    }
+    if (name.length < 3) {
+        return `${componentType} name must be least 3 characters`;
+    }
+    if (name.length > COMPONENT_NAME_MAX_LENGTH) {
+        return `${componentType} name cannot exceed ${COMPONENT_NAME_MAX_LENGTH} characters`;
+    }
+    return null;
+};
+
 export const isFormValidAddProject = (formData: AddProjectFormData, isInProject: boolean): boolean => {
     return (
         formData.integrationName.length >= 2 &&
         formData.packageName.length >= 2 &&
         (isInProject || (formData.workspaceName?.length ?? 0) >= 1) &&
+        validateComponentName(formData.integrationName, formData.isLibrary) === null &&
         validatePackageName(formData.packageName, formData.integrationName) === null &&
         validateOrgName(formData.orgName) === null &&
         (formData.projectHandle === undefined || validateProjectHandle(formData.projectHandle) === null)

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/WorkspaceOverview/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/WorkspaceOverview/index.tsx
@@ -16,7 +16,8 @@
  * under the License.
  */
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { EditableTitle } from "../../../components/EditableTitle";
 import {
     ProjectStructureResponse,
     SHARED_COMMANDS,
@@ -189,18 +190,6 @@ const TitleContainer = styled.div`
     position: relative;
 `;
 
-const EditableTitleWrapper = styled.div`
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    cursor: pointer;
-
-    &:is(:hover, :focus-visible) .edit-title-icon-wrapper {
-        opacity: 1;
-        max-width: 28px;
-    }
-`;
-
 const ProjectTitle = styled.h1`
     font-weight: bold;
     font-size: 1.5rem;
@@ -210,54 +199,6 @@ const ProjectTitle = styled.h1`
     @media (min-width: 768px) {
         font-size: 1.875rem;
     }
-`;
-
-const TitleInput = styled.input<{ $hasError?: boolean }>`
-    font-weight: bold;
-    font-size: 1.5rem;
-    margin-bottom: 0;
-    margin-top: 0;
-    background: transparent;
-    border: none;
-    border-bottom: 2px solid ${({ $hasError }: { $hasError?: boolean }) => $hasError
-        ? 'var(--vscode-inputValidation-errorBorder)'
-        : 'var(--vscode-focusBorder)'};
-    color: var(--vscode-foreground);
-    outline: none;
-    padding: 0;
-    font-family: inherit;
-    min-width: 120px;
-    width: auto;
-    @media (min-width: 768px) {
-        font-size: 1.875rem;
-    }
-`;
-
-const TitleValidationMessage = styled.div`
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    font-size: 0.72rem;
-    color: var(--vscode-inputValidation-errorForeground, var(--vscode-errorForeground));
-    background: var(--vscode-inputValidation-errorBackground, transparent);
-    border: 1px solid var(--vscode-inputValidation-errorBorder);
-    border-radius: 2px;
-    padding: 2px 6px;
-    position: absolute;
-    top: calc(100% + 4px);
-    left: 0;
-    white-space: nowrap;
-    z-index: 10;
-`;
-
-const EditTitleIconWrapper = styled.div`
-    max-width: 0;
-    overflow: hidden;
-    opacity: 0;
-    transition: max-width 0.15s ease, opacity 0.15s ease;
-    display: flex;
-    align-items: center;
-    flex-shrink: 0;
 `;
 
 const ProjectSubtitle = styled.h2`
@@ -687,10 +628,6 @@ export function WorkspaceOverview() {
     const [readmeContent, setReadmeContent] = React.useState<string>("");
     const [projectCollection, setProjectCollection] = React.useState<ProjectStructureResponse>();
     const [icpStatusByProjectPath, setIcpStatusByProjectPath] = React.useState<Record<string, boolean>>({});
-    const [isEditingTitle, setIsEditingTitle] = useState(false);
-    const [titleInputValue, setTitleInputValue] = useState("");
-    const [titleError, setTitleError] = useState("");
-    const titleInputRef = useRef<HTMLInputElement>(null);
     const [displayedTitle, setDisplayedTitle] = useState("");
     const [titleVisible, setTitleVisible] = useState(true);
 
@@ -854,60 +791,13 @@ export function WorkspaceOverview() {
         return "";
     }, []);
 
-    const startEditingTitle = useCallback(() => {
-        const currentTitle = projectCollection?.workspaceTitle || projectCollection?.workspaceName || "";
-        setTitleInputValue(currentTitle);
-        setTitleError("");
-        setIsEditingTitle(true);
-        setTimeout(() => {
-            titleInputRef.current?.select();
-        }, 0);
-    }, [projectCollection]);
-
-    const commitTitleEdit = useCallback(async () => {
-        const trimmed = titleInputValue.trim();
-        if (!projectCollection?.workspacePath) {
-            setIsEditingTitle(false);
-            return;
-        }
-        // Empty input — silently restore the previous name
-        if (!trimmed) {
-            setTitleError("");
-            setIsEditingTitle(false);
-            return;
-        }
-        // Invalid name — restore previous name instead of saving
-        if (titleError) {
-            setTitleError("");
-            setIsEditingTitle(false);
-            return;
-        }
-        // No change — skip commit
-        const currentTitle = projectCollection?.workspaceTitle || projectCollection?.workspaceName || "";
-        if (trimmed === currentTitle) {
-            setIsEditingTitle(false);
-            return;
-        }
-        try {
-            await rpcClient.getBIDiagramRpcClient().updateProjectTitle({
-                projectPath: projectCollection.workspacePath,
-                title: trimmed
-            });
-            setIsEditingTitle(false);
-        } catch {
-            // keep edit mode open on failure
-        }
-    }, [titleInputValue, titleError, projectCollection, rpcClient]);
-
-    const handleTitleKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
-        if (e.key === "Enter") {
-            e.preventDefault();
-            e.currentTarget.blur();
-        } else if (e.key === "Escape") {
-            setTitleError("");
-            setIsEditingTitle(false);
-        }
-    }, []);
+    const handleTitleUpdate = useCallback(async (newTitle: string) => {
+        if (!projectCollection?.workspacePath) return;
+        await rpcClient.getBIDiagramRpcClient().updateProjectTitle({
+            projectPath: projectCollection.workspacePath,
+            title: newTitle
+        });
+    }, [projectCollection, rpcClient]);
 
     if (!projectCollection) {
         return (
@@ -1034,45 +924,13 @@ export function WorkspaceOverview() {
         <PageLayout>
             <HeaderRow>
                 <TitleContainer>
-                    {isEditingTitle ? (
-                        <>
-                            <TitleInput
-                                ref={titleInputRef}
-                                value={titleInputValue}
-                                size={Math.max(titleInputValue.length, 8)}
-                                $hasError={!!titleError}
-                                onChange={(e) => { setTitleInputValue(e.target.value); setTitleError(validateTitle(e.target.value)); }}
-                                onKeyDown={handleTitleKeyDown}
-                                onBlur={commitTitleEdit}
-                                autoFocus
-                            />
-                            {titleError && (
-                                <TitleValidationMessage>
-                                    <Codicon name="info" sx={{ fontSize: '12px', flexShrink: 0 }} />
-                                    {titleError}
-                                </TitleValidationMessage>
-                            )}
-                        </>
-                    ) : (
-                        <EditableTitleWrapper
-                            role="button"
-                            tabIndex={0}
-                            onClick={startEditingTitle}
-                            onKeyDown={(e) => {
-                                if (e.key === "Enter" || e.key === " ") {
-                                    e.preventDefault();
-                                    startEditingTitle();
-                                }
-                            }}
-                            title="Click to edit project title"
-                            aria-label="Edit project title"
-                        >
-                            <ProjectTitle style={{ opacity: titleVisible ? 1 : 0 }}>{displayedTitle}</ProjectTitle>
-                            <EditTitleIconWrapper className="edit-title-icon-wrapper">
-                                <Codicon name="edit" sx={{ color: 'var(--vscode-descriptionForeground)', fontSize: '14px', width: '16px' }} />
-                            </EditTitleIconWrapper>
-                        </EditableTitleWrapper>
-                    )}
+                    <EditableTitle
+                        title={projectCollection?.workspaceTitle || projectCollection?.workspaceName || ""}
+                        onCommit={handleTitleUpdate}
+                        validate={validateTitle}
+                    >
+                        <ProjectTitle style={{ opacity: titleVisible ? 1 : 0 }}>{displayedTitle}</ProjectTitle>
+                    </EditableTitle>
                     <ProjectSubtitle>Project</ProjectSubtitle>
                 </TitleContainer>
             </HeaderRow>


### PR DESCRIPTION
## Purpose
$title
Addresses: https://github.com/wso2-enterprise/integration-engineering/issues/1247

https://github.com/user-attachments/assets/8072d683-dadf-4a11-bffa-c4cc8ece3352



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reusable inline editable title component added and enabled in title bars, package and workspace views.
  * Remote package-title update API and client call added to save package title edits.

* **Improvements**
  * Title edits commit asynchronously with inline validation and optimistic UI updates.
  * Component name validation tightened with clearer error messages.
  * Project info updates can be applied silently to avoid unwanted view changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->