### PR TITLE
Fix wrong lineRange when deleting flow nodes due to premature import cleanup

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/bi-diagram/rpc-manager.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/bi-diagram/rpc-manager.ts
@@ -76,7 +76,6 @@ import {
     DevantMetadata,
     WorkspaceDevantMetadata,
     ProjectDevantMetadata,
-    Diagnostics,
     EndOfFileRequest,
     ExpressionCompletionsRequest,
     ExpressionCompletionsResponse,
@@ -183,7 +182,7 @@ import { DebugProtocol } from "vscode-debugprotocol";
 import { extension } from "../../BalExtensionContext";
 import { OLD_BACKEND_URL } from "../../features/ai/utils";
 import { fetchWithAuth } from "../../features/ai/utils/ai-client";
-import { cleanAndValidateProject, getCurrentBIProject } from "../../features/config-generator/configGenerator";
+import { getCurrentBIProject } from "../../features/config-generator/configGenerator";
 import { BreakpointManager } from "../../features/debugger/breakpoint-manager";
 import { StateMachine, updateView } from "../../stateMachine";
 import { getAccessToken, getLoginMethod } from "../../utils/ai/auth";
@@ -207,7 +206,6 @@ import { getView } from "../../utils/state-machine-utils";
 import { isLibraryProject } from "../../utils/config";
 import { PlatformExtRpcManager } from "../platform-ext/rpc-manager";
 import { openAIPanelWithPrompt } from "../../views/ai-panel/aiMachine";
-import { checkProjectDiagnostics, removeUnusedImports } from "../ai-panel/repair-utils";
 import { getCurrentBallerinaProject } from "../../utils/project-utils";
 import { CommonRpcManager } from "../common/rpc-manager";
 import * as toml from "@iarna/toml";
@@ -994,8 +992,6 @@ export class BiDiagramRpcManager implements BIDiagramAPI {
 
     async deleteFlowNode(params: BISourceCodeRequest): Promise<UpdatedArtifactsResponse> {
         console.log(">>> requesting bi delete node from ls", params);
-        // Clean project diagnostics before deleting flow node
-        await cleanAndValidateProject(StateMachine.langClient(), StateMachine.context().projectPath);
 
         return new Promise((resolve) => {
             StateMachine.langClient()
@@ -1541,7 +1537,6 @@ export class BiDiagramRpcManager implements BIDiagramAPI {
 
     async deleteByComponentInfo(params: BIDeleteByComponentInfoRequest): Promise<BIDeleteByComponentInfoResponse> {
         console.log(">>> requesting bi delete node from ls by componentInfo", params);
-        const projectDiags: Diagnostics[] = await checkProjectDiagnostics(StateMachine.langClient(), StateMachine.context().projectPath);
 
         const position: NodePosition = {
             startLine: params.component?.startLine,
@@ -1585,25 +1580,7 @@ export class BiDiagramRpcManager implements BIDiagramAPI {
         }
 
 
-        // If there are diagnostics, remove unused imports first, then delete component
-        if (projectDiags.length > 0) {
-            return new Promise((resolve, reject) => {
-                removeUnusedImports(projectDiags, StateMachine.langClient())
-                    .then(() => {
-                        // After removing unused imports, proceed with component deletion
-                        return performDelete();
-                    })
-                    .then((result) => {
-                        resolve(result);
-                    })
-                    .catch((error) => {
-                        reject("Error during delete operation: " + error);
-                    });
-            });
-        } else {
-            // No diagnostics, directly delete component
-            return performDelete();
-        }
+        return performDelete();
     }
 
     async getFormDiagnostics(params: FormDiagnosticsRequest): Promise<FormDiagnosticsResponse> {


### PR DESCRIPTION
## Summary

- Removes `cleanAndValidateProject()` call from `deleteFlowNode()` that was running before the language server delete call
- Removes `removeUnusedImports()` pre-step from `deleteByComponentInfo()` for the same reason
- Cleans up the now-unused imports (`Diagnostics`, `cleanAndValidateProject`, `checkProjectDiagnostics`, `removeUnusedImports`)

## Root Cause

Before calling the LS `deleteFlowNode` / `deleteByComponentInfo`, the extension was clearing unused imports by modifying source files. This shifts line numbers in the file, making the `FlowNode.lineRange` (captured from a prior `getFlowModel` response) stale. The LS then receives a wrong position and the delete fails.

Both LS APIs operate on the AST level and return `textEdits` — they do not require the file to be pre-cleaned of unused imports.

## Related Issue

Fixes: https://github.com/wso2/product-integrator/issues/675

## Test Plan

- [ ] Open a Ballerina integration project with a `REMOTE_ACTION_CALL` node whose import appears unused
- [ ] Click delete on the node in the flow diagram — confirm delete succeeds
- [ ] Test "delete service" in service designer — confirm it deletes correctly
- [ ] Confirm no wrong-line errors in the output channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified the deletion flow in diagram operations by removing pre-deletion validation and cleanup steps, making deletions more direct and streamlined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->