### PR TITLE
Change ICP port to 9446

### DIFF
--- a/workspaces/ballerina/ballerina-extension/package.json
+++ b/workspaces/ballerina/ballerina-extension/package.json
@@ -91,7 +91,7 @@
                 },
                 "ballerina.icpUrl": {
                     "type": "string",
-                    "default": "https://localhost:9445",
+                    "default": "https://localhost:9446",
                     "description": "URL of the Integration Control Plane (ICP) server."
                 },
                 "ballerina.icpUsername": {

--- a/workspaces/ballerina/ballerina-extension/src/features/icp/activator.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/icp/activator.ts
@@ -21,16 +21,13 @@ import * as cp from 'child_process';
 import { BallerinaExtension } from '../../core';
 import { resolveICPPath } from './detect';
 import { provisionICPSecret } from './setup';
+import { getICPUrl } from './index';
 
 const ICP_START_COMMAND = 'ballerina.icp.start';
 const ICP_STOP_COMMAND = 'ballerina.icp.stop';
 const ICP_FOCUS_COMMAND = 'ballerina.icp.focus';
 const ICP_TASK_NAME = 'ICP Server';
 const ICP_TASK_SOURCE = 'ballerina-icp';
-
-function getICPUrl(): string {
-    return vscode.workspace.getConfiguration('ballerina').get<string>('icpUrl') || 'https://localhost:9445';
-}
 
 function getICPCredentials(): { username: string; password: string } {
     const config = vscode.workspace.getConfiguration('ballerina');

--- a/workspaces/ballerina/ballerina-extension/src/features/icp/index.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/icp/index.ts
@@ -1,2 +1,11 @@
+import { workspace } from 'vscode';
+
+export const ICP_DEFAULT_PORT = 9446;
+export const ICP_DEFAULT_URL = `https://localhost:${ICP_DEFAULT_PORT}`;
+
+export function getICPUrl(): string {
+    return workspace.getConfiguration('ballerina').get<string>('icpUrl') || ICP_DEFAULT_URL;
+}
+
 export { activateICP, isICPServerRunning, ensureICPServerRunning } from './activator';
 export { provisionICPSecret, getStoredICPSecret } from './setup';

--- a/workspaces/ballerina/ballerina-extension/src/features/icp/setup.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/icp/setup.ts
@@ -25,6 +25,7 @@ import * as yaml from 'js-yaml';
 import { workspace, window } from 'vscode';
 import { extension } from '../../BalExtensionContext';
 import { parse, stringify } from '@iarna/toml';
+import { getICPUrl, ICP_DEFAULT_PORT } from './index';
 
 const ICP_SECRET_KEY_PREFIX = 'ICP_ORG_SECRET_';
 const CREATE_ORG_SECRET_MUTATION = JSON.stringify({
@@ -105,10 +106,6 @@ function httpsPost(url: string, body: string, headers: Record<string, string>): 
     });
 }
 
-function getICPUrl(): string {
-    return workspace.getConfiguration('ballerina').get<string>('icpUrl') || 'https://127.0.0.1:9445';
-}
-
 function getICPCredentials(): { username: string; password: string } {
     const config = workspace.getConfiguration('ballerina');
     return {
@@ -123,7 +120,7 @@ function getGraphQLUrl(): string {
         const url = new URL(icpUrl);
         return `${url.origin}/graphql`;
     } catch {
-        return 'https://127.0.0.1:9445/graphql';
+        return `https://127.0.0.1:${ICP_DEFAULT_PORT}/graphql`;
     }
 }
 
@@ -260,7 +257,7 @@ export async function provisionICPSecret(projectPath: string): Promise<string | 
     try {
         const icpUrl = getICPUrl();
         const parsed = new URL(icpUrl);
-        const port = parseInt(parsed.port || '9445', 10);
+        const port = parseInt(parsed.port || String(ICP_DEFAULT_PORT), 10);
         const hostname = parsed.hostname;
 
         const ready = await waitForPort(hostname, port);

--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/icp-service/rpc-manager.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/icp-service/rpc-manager.ts
@@ -30,7 +30,7 @@ import { updateSourceCode } from "../../utils/source-utils";
 import { getOrgAndPackageName } from "../../utils";
 import { parse, stringify } from "@iarna/toml";
 import { getStoredICPSecret } from "../../features/icp/setup";
-import { ensureICPServerRunning, isICPServerRunning } from "../../features/icp";
+import { ensureICPServerRunning, isICPServerRunning, getICPUrl } from "../../features/icp";
 
 const ICP_IMPORTS = [
     'import wso2/icp.runtime.bridge as _;',
@@ -320,7 +320,7 @@ export class ICPServiceRpcManager implements ICPServiceAPI {
 
     async viewInICP(params: ICPEnabledRequest): Promise<ICPEnabledResponse> {
         try {
-            const icpUrl = vscode.workspace.getConfiguration('ballerina').get<string>('icpUrl') || 'https://localhost:9445';
+            const icpUrl = getICPUrl();
 
             if (isICPServerRunning()) {
                 await vscode.env.openExternal(vscode.Uri.parse(icpUrl));


### PR DESCRIPTION
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * Updated the default Integration Control Plane (ICP) endpoint from `https://localhost:9445` to `https://localhost:9446`. Users who have not explicitly configured their `ballerina.icpUrl` setting will now use the new default endpoint port.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->