### PR TITLE
Fix missing Delete option for APIs in MI Project Explorer context menu

### DIFF
--- a/workspaces/mi/mi-extension/package.json
+++ b/workspaces/mi/mi-extension/package.json
@@ -957,8 +957,8 @@
         },
         {
           "command": "MI.project-explorer.delete",
-          "when": "view == MI.project-explorer && viewItem == api || viewItem == resource || viewItem == endpoint || viewItem == sequence || viewItem == proxy-service || viewItem == inboundEndpoint || viewItem == messageStore || viewItem == message-processor || viewItem == task || viewItem == localEntry || viewItem == template  || viewItem == dataSource || viewItem == data-service || viewItem == data-mapper || viewItem == connection || viewItem == registry-with-metadata || viewItem == registry-without-metadata || viewItem == class-mediator || viewItem == ballerina-module || viewItem == idp-schema",
-          "key": "delete"
+          "when": "view == MI.project-explorer && (viewItem == api || viewItem == resource || viewItem == endpoint || viewItem == sequence || viewItem == proxy-service || viewItem == inboundEndpoint || viewItem == messageStore || viewItem == message-processor || viewItem == task || viewItem == localEntry || viewItem == template || viewItem == dataSource || viewItem == data-service || viewItem == data-mapper || viewItem == connection || viewItem == registry-with-metadata || viewItem == registry-without-metadata || viewItem == class-mediator || viewItem == ballerina-module || viewItem == idp-schema)",
+          "group": "9_cutcopypaste"
         },
         {
           "command": "MI.project-explorer.project-delete",


### PR DESCRIPTION
## Summary

The right-click context menu on artifact rows in the **WSO2 Integrator: MI** Project Explorer (`MI.project-explorer` view) was empty for several artifact types — most visibly for APIs — so users had no way to delete an API from the tree (issue wso2/product-integrator#189).

The `MI.project-explorer.delete` entry under `view/item/context` in `workspaces/mi/mi-extension/package.json` had two distinct defects, and the combination is what removed Delete from the API context menu:

1. **Operator-precedence bug in the `when` clause.** With `&&` binding tighter than `||`, the original
   ```
   view == MI.project-explorer && viewItem == api || viewItem == resource || …
   ```
   parsed as
   ```
   (view == MI.project-explorer && viewItem == api) || viewItem == resource || …
   ```
   so the `view == MI.project-explorer` filter only applied to the first disjunct (`viewItem == api`) and the entry leaked into unrelated views for every other artifact type. This PR wraps the disjunction in parentheses, matching the convention already used by `MI.manage-registry-property` immediately below.
2. **Invalid `key: "delete"` field in place of `group`.** `key` is not a valid property on a `view/item/context` menu entry (it belongs to the `keybindings` contribution point), so the entry had no usable group. The only other menu contribution that matches `viewItem == api` (`MI.project-explorer.open-service-designer`) lives in `group: "inline"` and is rendered as an inline icon, **not** in the popup menu. With Delete also having no popup-eligible group, VSCode's tree found zero secondary-group items for an API row and never opened the popup at all. Replaced with `group: "9_cutcopypaste"` so Delete is rendered in the standard cut/copy/paste/delete bucket VSCode uses for tree contextmenus.

The same fix structurally re-enables Delete for the other artifact types listed in the `when` clause: `resource`, `endpoint`, `sequence`, `proxy-service`, `inboundEndpoint`, `messageStore`, `message-processor`, `task`, `localEntry`, `template`, `dataSource`, `data-service`, `data-mapper`, `connection`, `registry-with-metadata`, `registry-without-metadata`, `class-mediator`, `ballerina-module`, `idp-schema`.

## Test plan

- [x] Open an MI project containing an API in WSO2 Integrator: MI, expand `APIs` in the Project Explorer, right-click the API row → confirm the popup menu opens and contains a `Delete` entry.
- [x] Click `Delete` → confirm the API is removed from the project tree and the corresponding XML file is removed from disk.
- [ ] Repeat for `Sequences`, `Endpoints`, `Proxy Services`, `Inbound Endpoints`, `Message Stores`, `Message Processors`, `Tasks`, `Local Entries`, `Templates`, `Data Sources`, `Data Services`, `Data Mappers`, `Connections`, registry resources, class mediators, ballerina modules, and idp schemas.
- [ ] Right-click on the project root and on category nodes (`APIs`, `Sequences`, …) → confirm `Delete` does **not** appear (the parenthesized clause keeps the entry from matching those `viewItem` values).

Fixes wso2/product-integrator#189

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **UI Improvements**
  * Reorganized the delete command in the project explorer context menu, now grouped with cut and copy/paste operations for improved menu consistency and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->