### PR TITLE
move from field.key to field.types implementation for type and expres…

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/Form/index.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/Form/index.tsx
@@ -548,7 +548,7 @@ export const Form = forwardRef((props: FormProps, _ref) => {
                         defaultValues[field.key] = formValues[field.key] ?? [];
                     }
 
-                    if (field.key === "type") {
+                    if (getPrimaryInputType(field.types)?.fieldType === "TYPE") {
                         // Handle the case where the type is changed via 'Add Type'
                         const existingType = formValues[field.key];
                         const newType = field.value;
@@ -775,8 +775,8 @@ export const Form = forwardRef((props: FormProps, _ref) => {
     // has advance fields
     const hasAdvanceFields = formFields.some((field) => field.advanced && field.enabled && !field.hidden) || advancedChoiceFields.length > 0;
     const variableField = formFields.find((field) => field.key === "variable");
-    const typeField = formFields.find((field) => field.key === "type");
-    const expressionField = formFields.find((field) => field.key === "expression");
+    const typeField = formFields.find((field) => getPrimaryInputType(field.types)?.fieldType === "TYPE");
+    const expressionField = formFields.find((field) => getPrimaryInputType(field.types)?.fieldType === "EXPRESSION");
     const targetTypeField = formFields.find((field) => field.codedata?.kind === "PARAM_FOR_TYPE_INFER");
     const hasParameters = hasRequiredParameters(formFields, selectedNode) || hasOptionalParameters(formFields);
 

--- a/workspaces/ballerina/ballerina-side-panel/src/components/Form/utils.ts
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/Form/utils.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { NodeKind } from "@wso2/ballerina-core";
+import { NodeKind, getPrimaryInputType } from "@wso2/ballerina-core";
 import { FormField, FormImports } from "../..";
 
 // This function allows us to format strings by adding indentation as tabs to the lines
@@ -51,7 +51,7 @@ export function updateFormFieldWithImports(formField: FormField, fieldImports: F
 }
 
 export function isPrioritizedField(field: FormField): boolean {
-    return field.key === "variable" || field.key === "type" || field.codedata?.kind === "PARAM_FOR_TYPE_INFER";
+    return field.key === "variable" || getPrimaryInputType(field.types)?.fieldType === "TYPE" || field.codedata?.kind === "PARAM_FOR_TYPE_INFER";
 }
 
 export function hasRequiredParameters(formFields: FormField[], selectedNode?: NodeKind): boolean {
@@ -76,7 +76,7 @@ export function hasOptionalParameters(formFields: FormField[]): boolean {
 
 export function hasReturnType(formFields: FormField[]): boolean {
     return formFields.some(field => 
-        field.key === "variable" || field.key === "type" || field.codedata?.kind === "PARAM_FOR_TYPE_INFER"
+        field.key === "variable" || getPrimaryInputType(field.types)?.fieldType === "TYPE" || field.codedata?.kind === "PARAM_FOR_TYPE_INFER"
     );
 }
 

--- a/workspaces/ballerina/ballerina-side-panel/src/components/ParamManager/ParamManager.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/ParamManager/ParamManager.tsx
@@ -25,7 +25,7 @@ import { Codicon, ErrorBanner, LinkButton, RequiredFormInput, ThemeColors } from
 import { FormField, FormValues } from '../Form/types';
 import { Controller } from 'react-hook-form';
 import { useFormContext } from '../../context';
-import { Imports, NodeKind } from '@wso2/ballerina-core';
+import { Imports, NodeKind, getPrimaryInputType } from '@wso2/ballerina-core';
 import { useRpcContext } from '@wso2/ballerina-rpc-client';
 import { FieldFactory } from '../editors/FieldFactory';
 import { buildRequiredRule, getFieldKeyForAdvanceProp } from '../editors/utils';
@@ -314,7 +314,7 @@ export function ParamManager(props: ParamManagerProps) {
                                 field.editable = param.identifierEditable;
                                 field.lineRange = param.identifierRange;
                             }
-                            if (field.key === "type" && field.type === "ACTION_TYPE" && param.formValues['isGraphqlId'] !== undefined) {
+                            if (getPrimaryInputType(field.types)?.fieldType === "TYPE" && field.type === "ACTION_TYPE" && param.formValues['isGraphqlId'] !== undefined) {
                                 field.isGraphqlId = param.formValues['isGraphqlId'];
                             }
                         }

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/EditorFactory.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/EditorFactory.tsx
@@ -160,7 +160,7 @@ export const EditorFactory = (props: FormFieldEditorProps) => {
                 handleNewTypeSelected={handleNewTypeSelected}
             />
         );
-    } else if (!field.items && (field.key === "type" || fieldInputType.fieldType === "TYPE") && field.editable) {
+    } else if (!field.items && fieldInputType.fieldType === "TYPE" && field.editable) {
         return (
             <TypeEditor
                 field={field}

--- a/workspaces/ballerina/ballerina-visualizer/src/components/ConnectionSelector/ConnectionConfig.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/components/ConnectionSelector/ConnectionConfig.tsx
@@ -17,7 +17,7 @@
  */
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { FlowNode, LineRange, NodeKind, NodeProperties } from "@wso2/ballerina-core";
+import { FlowNode, LineRange, NodeKind, NodeProperties, getPrimaryInputType } from "@wso2/ballerina-core";
 import { FormField, FormImports, FormValues } from "@wso2/ballerina-side-panel";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { ArtifactForm } from "../../views/BI/Forms/ArtifactForm";
@@ -101,7 +101,7 @@ export function ConnectionConfig(props: ConnectionConfigProps): JSX.Element {
         const { variable, ...restProperties } = connectionNode.properties;
         const fields = convertNodePropertiesToFormFields(restProperties as NodeProperties);
         fields.forEach(field => {
-            if (field.key === "type") {
+            if (getPrimaryInputType(field.types)?.fieldType === "TYPE") {
                 field.hidden = true;
             }
         });

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/AIChatAgent/AIAgentSidePanel.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/AIChatAgent/AIAgentSidePanel.tsx
@@ -41,6 +41,7 @@ import {
     ToolParameterItem,
     NodeProperties,
     Diagnostic,
+    getPrimaryInputType,
 } from "@wso2/ballerina-core";
 
 import {
@@ -395,7 +396,7 @@ export function AIAgentSidePanel(props: BIFlowDiagramProps) {
             } else if (functionNodeTemplate.flowNode?.properties) {
                 functionParameterFields = convertConfig(functionNodeTemplate.flowNode.properties, ["variable"], false);
                 functionParameterFields.forEach((field, idx) => {
-                    if (field.key === "type") {
+                    if (getPrimaryInputType(field.types)?.fieldType === "TYPE") {
                         functionParameterFields[idx].documentation = "The data type this tool will return to the agent.";
                         return;
                     }

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/AIChatAgent/ConfigForm.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/AIChatAgent/ConfigForm.tsx
@@ -20,7 +20,7 @@ import styled from "@emotion/styled";
 import { FormField, FormImports, FormValues } from "@wso2/ballerina-side-panel";
 import { ArtifactForm } from "../Forms/ArtifactForm";
 import { getImportsForProperty } from "../../../utils/bi";
-import { LineRange } from "@wso2/ballerina-core";
+import { LineRange, getPrimaryInputType } from "@wso2/ballerina-core";
 
 const Container = styled.div`
     max-width: 600px;
@@ -76,7 +76,7 @@ export function ConfigForm(props: ConfigProps) {
     }
 
     // type field hide
-    const typeField = formFields.find((field) => field.key === "type");
+    const typeField = formFields.find((field) => getPrimaryInputType(field.types)?.fieldType === "TYPE");
     if (typeField) {
         typeField.enabled = false;
     }

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/AIChatAgent/formUtils.ts
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/AIChatAgent/formUtils.ts
@@ -245,11 +245,11 @@ export function prepareToolInputFields(fields: FormField[]): FormField[] {
             field.advanced = true;
             return;
         }
-        if (field.key === "type") {
+        if (getPrimaryInputType(field.types)?.fieldType === "TYPE") {
             fields[idx].documentation = "The data type this tool will return to the agent.";
             return;
         }
-        if (field.optional == false && field.key != "type") field.value = field.key;
+        if (field.optional == false && getPrimaryInputType(field.types)?.fieldType !== "TYPE") field.value = field.key;
         field.label = `${field.label} Mapping`;
         includedKeys.push(field.key);
     });

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/ArtifactForm/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/ArtifactForm/index.tsx
@@ -229,7 +229,7 @@ export function ArtifactForm(props: ArtifactFormProps) {
         if (type) {
             const typeName = typeof type === 'string' ? type : (type as Type).name;
             setFields(fields.map((field) => {
-                if (field.key === 'type') {
+                if (getPrimaryInputType(field.types)?.fieldType === 'TYPE') {
                     return { ...field, value: typeName };
                 }
                 return field;

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FlowNodeForm/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FlowNodeForm/index.tsx
@@ -1737,7 +1737,7 @@ export const FlowNodeForm = forwardRef<FormExpressionEditorRef, FlowNodeFormProp
     // handle declare variable node form
     if (node?.codedata.node === "VARIABLE") {
         // HACK: make the type field optional for variable declaration form
-        const typeField = fields.find(field => field.key === "type");
+        const typeField = fields.find(field => getPrimaryInputType(field.types)?.fieldType === "TYPE");
         if (typeField) {
             typeField.optional = true;
         }

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/McpToolForm/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/McpToolForm/index.tsx
@@ -103,7 +103,7 @@ export function McpToolForm(props: McpToolFormProps) {
 
         params.forEach((param) => {
             // Find matching field configurations from schema
-            const typeField = paramFields.find((field) => field.key === "type");
+            const typeField = paramFields.find((field) => getPrimaryInputType(field.types)?.fieldType === "TYPE");
             const nameField = paramFields.find((field) => field.key === "variable");
             const defaultField = paramFields.find((field) => field.key === "defaultable");
             const documentationField = paramFields.find((field) => field.key === "documentation");

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/ServiceFunctionForm/utils.ts
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/ServiceFunctionForm/utils.ts
@@ -44,7 +44,7 @@ const getFunctionParametersList = (params: Parameter[], model: FunctionModel | n
     const paramFields = convertSchemaToFormFields(model.schema);
 
     params.forEach(param => {
-        const typeField = paramFields.find(field => field.key === 'type');
+        const typeField = paramFields.find(field => getPrimaryInputType(field.types)?.fieldType === 'TYPE');
         const nameField = paramFields.find(field => field.key === 'variable');
         const defaultField = paramFields.find(field => field.key === 'defaultable');
 

--- a/workspaces/ballerina/ballerina-visualizer/src/views/GraphQLDiagram/OperationForm.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/GraphQLDiagram/OperationForm.tsx
@@ -64,7 +64,7 @@ export function OperationForm(props: OperationFormProps) {
 
         params.forEach(param => {
             // Find matching field configurations from schema
-            const typeField = paramFields.find(field => field.key === 'type');
+            const typeField = paramFields.find(field => getPrimaryInputType(field.types)?.fieldType === 'TYPE');
             const nameField = paramFields.find(field => field.key === 'variable');
             const defaultField = paramFields.find(field => field.key === 'defaultable');
             const documentationField = paramFields.find(field => field.key === 'documentation');


### PR DESCRIPTION
## Purpose
> Previously in form level we have used `field.key` as an identifier for the type fields and expression fields. This is not reliable since the field.key can have different values depending on the context. 

Resolves: https://github.com/wso2/product-integrator/issues/264

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Refactored form field identification throughout the platform to use metadata-driven detection instead of string-based key matching. This enhances consistency and reliability in handling type fields across side panels, visualizers, connection configurations, artifact forms, service designers, and other form components, ensuring more robust form behavior across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->