### PR TITLE
Add secure socket (SSL/TLS) configuration support for MCP tool discovery

### DIFF
--- a/workspaces/ballerina/ballerina-core/src/interfaces/extended-lang-client.ts
+++ b/workspaces/ballerina/ballerina-core/src/interfaces/extended-lang-client.ts
@@ -1846,9 +1846,21 @@ export interface AIToolResponse {
     };
 }
 
+export interface CertConfig {
+    path?: string;
+    password?: string;
+}
+
+export interface SecureSocketConfig {
+    cert?: CertConfig;
+    key?: CertConfig;
+    insecure?: boolean;
+}
+
 export interface McpToolsRequest {
     serviceUrl?: string;
     accessToken?: string;
+    secureSocket?: SecureSocketConfig;
 }
 
 export interface McpToolsResponse {

--- a/workspaces/ballerina/ballerina-core/src/rpc-types/common/interfaces.ts
+++ b/workspaces/ballerina/ballerina-core/src/rpc-types/common/interfaces.ts
@@ -87,6 +87,7 @@ export interface FileOrDirResponse {
 export interface FileOrDirRequest {
     isFile?: boolean;
     filters?: Record<string, string[]>;
+    allowOutsideProject?: boolean;
 }
 
 export interface ShowErrorMessageRequest {

--- a/workspaces/ballerina/ballerina-core/src/rpc-types/common/interfaces.ts
+++ b/workspaces/ballerina/ballerina-core/src/rpc-types/common/interfaces.ts
@@ -86,6 +86,7 @@ export interface FileOrDirResponse {
 }
 export interface FileOrDirRequest {
     isFile?: boolean;
+    filters?: Record<string, string[]>;
 }
 
 export interface ShowErrorMessageRequest {

--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/common/rpc-manager.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/common/rpc-manager.ts
@@ -204,14 +204,14 @@ export class CommonRpcManager implements CommonRPCAPI {
     async selectFileOrDirPath(params: FileOrDirRequest): Promise<FileOrDirResponse> {
         return new Promise(async (resolve) => {
             if (params.isFile) {
-                const selectedFile = await askFilePath();
+                const selectedFile = await askFilePath(params.filters);
                 if (!selectedFile || selectedFile.length === 0) {
                     window.showErrorMessage('A file must be selected');
                     resolve({ path: "" });
                 } else {
                     const filePath = selectedFile[0].fsPath;
                     const projectPath = StateMachine.context().projectPath;
-                    if (projectPath && !filePath.startsWith(projectPath)) {
+                    if (!params.filters && projectPath && !filePath.startsWith(projectPath)) {
                         const resp = await window.showErrorMessage('The selected file is not within your project. Do you want to move it inside the project?', { modal: true }, 'Yes');
                         if (resp === 'Yes') {
                             // Move the file inside the project

--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/common/rpc-manager.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/common/rpc-manager.ts
@@ -211,7 +211,7 @@ export class CommonRpcManager implements CommonRPCAPI {
                 } else {
                     const filePath = selectedFile[0].fsPath;
                     const projectPath = StateMachine.context().projectPath;
-                    if (!params.filters && projectPath && !filePath.startsWith(projectPath)) {
+                    if (!params.allowOutsideProject && projectPath && !filePath.startsWith(projectPath)) {
                         const resp = await window.showErrorMessage('The selected file is not within your project. Do you want to move it inside the project?', { modal: true }, 'Yes');
                         if (resp === 'Yes') {
                             // Move the file inside the project

--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/common/utils.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/common/utils.ts
@@ -91,13 +91,13 @@ export async function askProjectPath() {
     });
 }
 
-export async function askFilePath() {
+export async function askFilePath(filters?: Record<string, string[]>) {
     return await window.showOpenDialog({
         canSelectFiles: true,
         canSelectFolders: false,
         canSelectMany: false,
         defaultUri: Uri.file(StateMachine.context().projectPath  ?? os.homedir()),
-        filters: {
+        filters: filters ?? {
             'Files': ['yaml', 'json', 'yml', 'graphql', 'wsdl']
         },
         title: "Select a file",

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/AIChatAgent/AddMcpServer.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/AIChatAgent/AddMcpServer.tsx
@@ -93,11 +93,20 @@ export function AddMcpServer(props: AddMcpServerProps): JSX.Element {
         return moduleNodes;
     };
 
-    const setupEditMode = (variables: FlowNode[]) => {
+    const setupEditMode = async (variables: FlowNode[]) => {
         const mcpToolKitVariable = variables?.find(
             (v) => v.codedata?.node === "MCP_TOOL_KIT" && v.properties.variable?.value === props.name
         );
         if (!mcpToolKitVariable) return;
+
+        // Resolve relative fileName to absolute path so formDidOpen gets a valid file URI
+        if (mcpToolKitVariable.codedata?.lineRange?.fileName) {
+            const resolvedPath = (await rpcClient.getVisualizerRpcClient().joinProjectPath({
+                segments: [mcpToolKitVariable.codedata.lineRange.fileName]
+            })).filePath;
+            mcpToolKitVariable.codedata.lineRange.fileName = resolvedPath;
+        }
+
         mcpToolKitNodeRef.current = mcpToolKitVariable;
         initializeEditMode();
     };

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/AIChatAgent/AddMcpServer.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/AIChatAgent/AddMcpServer.tsx
@@ -300,7 +300,6 @@ export function AddMcpServer(props: AddMcpServerProps): JSX.Element {
                 projectPathUriRef.current,
                 agentFilePathRef.current
             );
-
             // Set toolSource BEFORE setToolsInclude to prevent the useEffect from triggering a duplicate fetch
             setToolSource(resolution.canResolve ? 'auto-fetched' : 'saved-mock');
             setToolsInclude("selected");
@@ -327,7 +326,11 @@ export function AddMcpServer(props: AddMcpServerProps): JSX.Element {
                 displayMockTools(permittedTools);
             }
         } finally {
-            isInitializingEditModeRef.current = false;
+            // Delay clearing the flag so the FlowNodeForm's initial onChange burst
+            // (which fires for every field after the form mounts) doesn't reset toolSource.
+            setTimeout(() => {
+                isInitializingEditModeRef.current = false;
+            }, 0);
         }
     };
 

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/AIChatAgent/Mcp/DiscoverToolsModal.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/AIChatAgent/Mcp/DiscoverToolsModal.tsx
@@ -402,6 +402,7 @@ export const DiscoverToolsModal: React.FC<DiscoverToolsModalProps> = ({
                                         setAuthType(newAuthType);
                                         if (newAuthType === "none") {
                                             setAuthToken("");
+                                            setShowAuthToken(false);
                                         }
                                     }}
                                     disabled={loadingDiscovery}
@@ -464,8 +465,9 @@ export const DiscoverToolsModal: React.FC<DiscoverToolsModalProps> = ({
                                                 label="Path"
                                                 placeholder="Enter path or browse to select a certificate file..."
                                                 selectedPath={certPath}
-                                                onChange={(value: string) => setCertPath(value)}
+                                                onChange={(value: string) => { if (!insecure) setCertPath(value); }}
                                                 onSelect={async () => {
+                                                    if (insecure) return;
                                                     const result = await rpcClient.getCommonRpcClient()
                                                         .selectFileOrDirPath({
                                                             isFile: true,
@@ -474,7 +476,7 @@ export const DiscoverToolsModal: React.FC<DiscoverToolsModalProps> = ({
                                                         });
                                                     if (result?.path) setCertPath(result.path);
                                                 }}
-                                                sx={{ opacity: insecure ? 0.5 : 1 }}
+                                                sx={{ opacity: insecure ? 0.5 : 1, pointerEvents: insecure ? 'none' : 'auto' }}
                                             />
                                             <PasswordFieldWrapper style={{ opacity: insecure ? 0.5 : 1 }}>
                                                 <TextField
@@ -506,8 +508,9 @@ export const DiscoverToolsModal: React.FC<DiscoverToolsModalProps> = ({
                                                 label="Path"
                                                 placeholder="Enter path or browse to select a key file..."
                                                 selectedPath={keyPath}
-                                                onChange={(value: string) => setKeyPath(value)}
+                                                onChange={(value: string) => { if (!insecure) setKeyPath(value); }}
                                                 onSelect={async () => {
+                                                    if (insecure) return;
                                                     const result = await rpcClient.getCommonRpcClient()
                                                         .selectFileOrDirPath({
                                                             isFile: true,
@@ -516,7 +519,7 @@ export const DiscoverToolsModal: React.FC<DiscoverToolsModalProps> = ({
                                                         });
                                                     if (result?.path) setKeyPath(result.path);
                                                 }}
-                                                sx={{ opacity: insecure ? 0.5 : 1 }}
+                                                sx={{ opacity: insecure ? 0.5 : 1, pointerEvents: insecure ? 'none' : 'auto' }}
                                             />
                                             <PasswordFieldWrapper style={{ opacity: insecure ? 0.5 : 1 }}>
                                                 <TextField
@@ -542,17 +545,6 @@ export const DiscoverToolsModal: React.FC<DiscoverToolsModalProps> = ({
                                     </AdvancedContent>
                                 )}
                             </FormSection>
-
-                            {loadingDiscovery && (
-                                <LoadingMessage padding="12px 0">
-                                    <InlineSpinner />
-                                    Fetching tools from MCP server...
-                                </LoadingMessage>
-                            )}
-
-                            {discoveryError && !loadingDiscovery && (
-                                <ErrorMessage padding="8px 0">{formattedError}</ErrorMessage>
-                            )}
                         </>
                     ) : (
                         <>
@@ -598,6 +590,17 @@ export const DiscoverToolsModal: React.FC<DiscoverToolsModalProps> = ({
                         </>
                     )}
                 </StyledModalContent>
+
+                {currentStep === 1 && loadingDiscovery && (
+                    <LoadingMessage padding="4px 16px">
+                        <InlineSpinner />
+                        Fetching tools from MCP server...
+                    </LoadingMessage>
+                )}
+
+                {currentStep === 1 && discoveryError && !loadingDiscovery && (
+                    <ErrorMessage padding="4px 16px">{formattedError}</ErrorMessage>
+                )}
 
                 <ButtonContainer>
                     {currentStep === 1 ? (

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/AIChatAgent/Mcp/DiscoverToolsModal.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/AIChatAgent/Mcp/DiscoverToolsModal.tsx
@@ -19,8 +19,9 @@
 import React, { useState, useMemo, useCallback } from "react";
 import { createPortal } from "react-dom";
 import styled from "@emotion/styled";
-import { Button, ThemeColors, SearchBox, Codicon, Divider, Typography, TextField, Stepper, Dropdown } from "@wso2/ui-toolkit";
+import { Button, ThemeColors, SearchBox, Codicon, Divider, Typography, TextField, Stepper, Dropdown, CheckBox, DirectorySelector, LinkButton } from "@wso2/ui-toolkit";
 import type { OptionProps } from "@wso2/ui-toolkit";
+import type { SecureSocketConfig } from "@wso2/ballerina-core";
 import type { BallerinaRpcClient } from "@wso2/ballerina-rpc-client";
 import {
     ToolsList,
@@ -68,6 +69,57 @@ const ButtonContainer = styled.div`
     gap: 8px;
 `;
 
+const AdvancedRow = styled.div`
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+`;
+
+const AdvancedToggleContainer = styled.div`
+    display: flex;
+    flex-direction: row;
+    flex-grow: 1;
+    justify-content: flex-end;
+`;
+
+const AdvancedContent = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 4px 0;
+`;
+
+const FieldGroup = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding-top: 4px;
+`;
+
+const FieldGroupLabel = styled(Typography)`
+    font-weight: 600;
+    margin: 0;
+`;
+
+const PasswordFieldWrapper = styled.div`
+    position: relative;
+`;
+
+const PasswordToggle = styled.div`
+    position: absolute;
+    right: 8px;
+    bottom: 6px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    opacity: 0.7;
+    &:hover {
+        opacity: 1;
+    }
+`;
+
 const BackArrow = styled.div`
     cursor: pointer;
     display: flex;
@@ -106,12 +158,23 @@ export const DiscoverToolsModal: React.FC<DiscoverToolsModalProps> = ({
     const [manualServerUrl, setManualServerUrl] = useState("");
     const [authType, setAuthType] = useState<"none" | "bearer">("none");
     const [authToken, setAuthToken] = useState("");
+    const [showAuthToken, setShowAuthToken] = useState(false);
     const [discoveredTools, setDiscoveredTools] = useState<McpTool[]>([]);
     const [selectedDiscoveredTools, setSelectedDiscoveredTools] = useState<Set<string>>(new Set());
     const [loadingDiscovery, setLoadingDiscovery] = useState(false);
     const [discoveryError, setDiscoveryError] = useState("");
     const [searchQuery, setSearchQuery] = useState("");
     const [urlError, setUrlError] = useState("");
+
+    // Advanced SSL configuration
+    const [showAdvanced, setShowAdvanced] = useState(false);
+    const [insecure, setInsecure] = useState(false);
+    const [certPath, setCertPath] = useState("");
+    const [certPassword, setCertPassword] = useState("");
+    const [keyPath, setKeyPath] = useState("");
+    const [keyPassword, setKeyPassword] = useState("");
+    const [showCertPassword, setShowCertPassword] = useState(false);
+    const [showKeyPassword, setShowKeyPassword] = useState(false);
 
     const formattedError = useMemo(() => formatErrorMessage(discoveryError), [discoveryError]);
 
@@ -146,10 +209,25 @@ export const DiscoverToolsModal: React.FC<DiscoverToolsModalProps> = ({
                 ? authToken.trim()
                 : "";
 
+            // Build secure socket config if any SSL fields are set
+            let secureSocket: SecureSocketConfig | undefined;
+            if (insecure || certPath.trim() || keyPath.trim()) {
+                secureSocket = {
+                    insecure,
+                    ...(certPath.trim() && {
+                        cert: { path: certPath.trim(), password: certPassword || undefined }
+                    }),
+                    ...(keyPath.trim() && {
+                        key: { path: keyPath.trim(), password: keyPassword || undefined }
+                    }),
+                };
+            }
+
             // Fetch tools from MCP server
             const response = await rpcClient.getAIAgentRpcClient().getMcpTools({
                 serviceUrl: cleanUrl,
-                accessToken
+                accessToken,
+                secureSocket
             });
 
             if (response.errorMsg) {
@@ -180,7 +258,7 @@ export const DiscoverToolsModal: React.FC<DiscoverToolsModalProps> = ({
         } finally {
             setLoadingDiscovery(false);
         }
-    }, [manualServerUrl, authToken, authType, rpcClient, existingToolNames]);
+    }, [manualServerUrl, authToken, authType, rpcClient, existingToolNames, insecure, certPath, certPassword, keyPath, keyPassword]);
 
     const handleToolSelectionChange = useCallback((toolName: string, isSelected: boolean) => {
         setSelectedDiscoveredTools(prev => {
@@ -221,11 +299,20 @@ export const DiscoverToolsModal: React.FC<DiscoverToolsModalProps> = ({
         setManualServerUrl("");
         setAuthType("none");
         setAuthToken("");
+        setShowAuthToken(false);
         setDiscoveredTools([]);
         setSelectedDiscoveredTools(new Set());
         setDiscoveryError("");
         setSearchQuery("");
         setUrlError("");
+        setShowAdvanced(false);
+        setInsecure(false);
+        setCertPath("");
+        setCertPassword("");
+        setKeyPath("");
+        setKeyPassword("");
+        setShowCertPassword(false);
+        setShowKeyPassword(false);
     }, [discoveredTools, selectedDiscoveredTools, onToolsSelected]);
 
     const handleClose = useCallback(() => {
@@ -234,11 +321,20 @@ export const DiscoverToolsModal: React.FC<DiscoverToolsModalProps> = ({
         setManualServerUrl("");
         setAuthType("none");
         setAuthToken("");
+        setShowAuthToken(false);
         setDiscoveredTools([]);
         setSelectedDiscoveredTools(new Set());
         setDiscoveryError("");
         setSearchQuery("");
         setUrlError("");
+        setShowAdvanced(false);
+        setInsecure(false);
+        setCertPath("");
+        setCertPassword("");
+        setKeyPath("");
+        setKeyPassword("");
+        setShowCertPassword(false);
+        setShowKeyPassword(false);
         onClose();
     }, [onClose]);
 
@@ -308,14 +404,123 @@ export const DiscoverToolsModal: React.FC<DiscoverToolsModalProps> = ({
                                 />
 
                                 {authType === "bearer" && (
-                                    <TextField
-                                        label="Token"
-                                        value={authToken}
-                                        onChange={(e: React.ChangeEvent<HTMLInputElement>) => setAuthToken(e.target.value)}
-                                        disabled={loadingDiscovery}
-                                        description="Enter your bearer token for authentication"
-                                        type="password"
-                                    />
+                                    <PasswordFieldWrapper>
+                                        <TextField
+                                            label="Token"
+                                            value={authToken}
+                                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setAuthToken(e.target.value)}
+                                            disabled={loadingDiscovery}
+                                            description="Enter your bearer token for authentication"
+                                            type={showAuthToken ? "text" : "password"}
+                                        />
+                                        {authToken && (
+                                            <PasswordToggle onClick={() => setShowAuthToken(prev => !prev)}>
+                                                <Codicon name={showAuthToken ? "eye-closed" : "eye"} />
+                                            </PasswordToggle>
+                                        )}
+                                    </PasswordFieldWrapper>
+                                )}
+
+                                <AdvancedRow>
+                                    <Typography variant="body2">Advanced Configurations</Typography>
+                                    <AdvancedToggleContainer>
+                                        <LinkButton
+                                            onClick={() => setShowAdvanced(prev => !prev)}
+                                            sx={{ fontSize: 12, padding: 8, color: ThemeColors.PRIMARY, gap: 4 }}
+                                        >
+                                            <Codicon
+                                                name={showAdvanced ? "chevron-up" : "chevron-down"}
+                                                iconSx={{ fontSize: 12 }}
+                                                sx={{ height: 12 }}
+                                            />
+                                            {showAdvanced ? "Collapse" : "Expand"}
+                                        </LinkButton>
+                                    </AdvancedToggleContainer>
+                                </AdvancedRow>
+
+                                {showAdvanced && (
+                                    <AdvancedContent>
+                                        <CheckBox
+                                            label="Allow Insecure Connection"
+                                            checked={insecure}
+                                            onChange={() => setInsecure(prev => !prev)}
+                                            disabled={loadingDiscovery}
+                                        />
+
+                                        <Divider sx={{ margin: '4px 0' }} />
+                                        <FieldGroup>
+                                            <FieldGroupLabel variant="body2">Certificate</FieldGroupLabel>
+                                            <DirectorySelector
+                                                id="ssl-cert-path"
+                                                label="Path"
+                                                placeholder="Enter path or browse to select a certificate file..."
+                                                selectedPath={certPath}
+                                                onChange={(value: string) => setCertPath(value)}
+                                                onSelect={async () => {
+                                                    const result = await rpcClient.getCommonRpcClient()
+                                                        .selectFileOrDirPath({
+                                                            isFile: true,
+                                                            filters: { 'Certificates': ['pem', 'crt', 'p12', 'pfx', 'jks'] }
+                                                        });
+                                                    if (result?.path) setCertPath(result.path);
+                                                }}
+                                                sx={{ opacity: insecure ? 0.5 : 1 }}
+                                            />
+                                            <PasswordFieldWrapper style={{ opacity: insecure ? 0.5 : 1 }}>
+                                                <TextField
+                                                    label="Password"
+                                                    value={certPassword}
+                                                    onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                                                        setCertPassword(e.target.value)}
+                                                    disabled={loadingDiscovery || insecure}
+                                                    type={showCertPassword ? "text" : "password"}
+                                                    description="Required for .p12/.jks files, optional for .pem/.crt"
+                                                />
+                                                {certPassword && (
+                                                    <PasswordToggle onClick={() => setShowCertPassword(prev => !prev)}>
+                                                        <Codicon name={showCertPassword ? "eye-closed" : "eye"} />
+                                                    </PasswordToggle>
+                                                )}
+                                            </PasswordFieldWrapper>
+                                        </FieldGroup>
+
+                                        <Divider sx={{ margin: '4px 0' }} />
+                                        <FieldGroup>
+                                            <FieldGroupLabel variant="body2">Key</FieldGroupLabel>
+                                            <DirectorySelector
+                                                id="ssl-key-path"
+                                                label="Path"
+                                                placeholder="Enter path or browse to select a key file..."
+                                                selectedPath={keyPath}
+                                                onChange={(value: string) => setKeyPath(value)}
+                                                onSelect={async () => {
+                                                    const result = await rpcClient.getCommonRpcClient()
+                                                        .selectFileOrDirPath({
+                                                            isFile: true,
+                                                            filters: { 'Certificates': ['pem', 'crt', 'p12', 'pfx', 'jks'] }
+                                                        });
+                                                    if (result?.path) setKeyPath(result.path);
+                                                }}
+                                                sx={{ opacity: insecure ? 0.5 : 1 }}
+                                            />
+                                            <PasswordFieldWrapper style={{ opacity: insecure ? 0.5 : 1 }}>
+                                                <TextField
+                                                    label="Password"
+                                                    value={keyPassword}
+                                                    onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                                                        setKeyPassword(e.target.value)}
+                                                    disabled={loadingDiscovery || insecure}
+                                                    type={showKeyPassword ? "text" : "password"}
+                                                    description="Passphrase for the private key or keystore"
+                                                />
+                                                {keyPassword && (
+                                                    <PasswordToggle onClick={() => setShowKeyPassword(prev => !prev)}>
+                                                        <Codicon name={showKeyPassword ? "eye-closed" : "eye"} />
+                                                    </PasswordToggle>
+                                                )}
+                                            </PasswordFieldWrapper>
+                                        </FieldGroup>
+                                    </AdvancedContent>
                                 )}
                             </FormSection>
 

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/AIChatAgent/Mcp/DiscoverToolsModal.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/AIChatAgent/Mcp/DiscoverToolsModal.tsx
@@ -107,7 +107,7 @@ const PasswordFieldWrapper = styled.div`
     position: relative;
 `;
 
-const PasswordToggle = styled.div`
+const PasswordToggle = styled.button`
     position: absolute;
     right: 8px;
     bottom: 6px;
@@ -115,7 +115,12 @@ const PasswordToggle = styled.div`
     display: flex;
     align-items: center;
     opacity: 0.7;
-    &:hover {
+    background: none;
+    border: none;
+    padding: 2px;
+    color: inherit;
+    &:hover,
+    &:focus-visible {
         opacity: 1;
     }
 `;
@@ -414,7 +419,11 @@ export const DiscoverToolsModal: React.FC<DiscoverToolsModalProps> = ({
                                             type={showAuthToken ? "text" : "password"}
                                         />
                                         {authToken && (
-                                            <PasswordToggle onClick={() => setShowAuthToken(prev => !prev)}>
+                                            <PasswordToggle
+                                                onClick={() => setShowAuthToken(prev => !prev)}
+                                                aria-label={showAuthToken ? "Hide token" : "Show token"}
+                                                title={showAuthToken ? "Hide token" : "Show token"}
+                                            >
                                                 <Codicon name={showAuthToken ? "eye-closed" : "eye"} />
                                             </PasswordToggle>
                                         )}
@@ -460,7 +469,8 @@ export const DiscoverToolsModal: React.FC<DiscoverToolsModalProps> = ({
                                                     const result = await rpcClient.getCommonRpcClient()
                                                         .selectFileOrDirPath({
                                                             isFile: true,
-                                                            filters: { 'Certificates': ['pem', 'crt', 'p12', 'pfx', 'jks'] }
+                                                            filters: { 'Certificates': ['pem', 'crt', 'p12', 'pfx', 'jks'] },
+                                                            allowOutsideProject: true
                                                         });
                                                     if (result?.path) setCertPath(result.path);
                                                 }}
@@ -477,7 +487,11 @@ export const DiscoverToolsModal: React.FC<DiscoverToolsModalProps> = ({
                                                     description="Required for .p12/.jks files, optional for .pem/.crt"
                                                 />
                                                 {certPassword && (
-                                                    <PasswordToggle onClick={() => setShowCertPassword(prev => !prev)}>
+                                                    <PasswordToggle
+                                                        onClick={() => setShowCertPassword(prev => !prev)}
+                                                        aria-label={showCertPassword ? "Hide password" : "Show password"}
+                                                        title={showCertPassword ? "Hide password" : "Show password"}
+                                                    >
                                                         <Codicon name={showCertPassword ? "eye-closed" : "eye"} />
                                                     </PasswordToggle>
                                                 )}
@@ -497,7 +511,8 @@ export const DiscoverToolsModal: React.FC<DiscoverToolsModalProps> = ({
                                                     const result = await rpcClient.getCommonRpcClient()
                                                         .selectFileOrDirPath({
                                                             isFile: true,
-                                                            filters: { 'Certificates': ['pem', 'crt', 'p12', 'pfx', 'jks'] }
+                                                            filters: { 'Keystores': ['p12', 'pfx', 'jks'] },
+                                                            allowOutsideProject: true
                                                         });
                                                     if (result?.path) setKeyPath(result.path);
                                                 }}
@@ -514,7 +529,11 @@ export const DiscoverToolsModal: React.FC<DiscoverToolsModalProps> = ({
                                                     description="Passphrase for the private key or keystore"
                                                 />
                                                 {keyPassword && (
-                                                    <PasswordToggle onClick={() => setShowKeyPassword(prev => !prev)}>
+                                                    <PasswordToggle
+                                                        onClick={() => setShowKeyPassword(prev => !prev)}
+                                                        aria-label={showKeyPassword ? "Hide password" : "Show password"}
+                                                        title={showKeyPassword ? "Hide password" : "Show password"}
+                                                    >
                                                         <Codicon name={showKeyPassword ? "eye-closed" : "eye"} />
                                                     </PasswordToggle>
                                                 )}


### PR DESCRIPTION
## Purpose

Related to https://github.com/wso2/product-integrator/issues/491

- Add "Advanced Configurations" section to the Discover MCP Tools modal for SSL/TLS secure socket settings   
- Add password visibility toggle to all sensitive fields (bearer token, cert password, key password)         
- Support custom file filters in the file picker dialog    


https://github.com/user-attachments/assets/f0c1276d-2714-4bb8-a592-19f09faf9eda

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bearer token visibility toggle for auth input
  * Advanced Configurations: SSL/TLS cert/key paths, passwords and an “insecure” option; discovery requests can include secure-socket settings
  * File selection: supports custom filters and optional selection outside the current project

* **Bug Fixes / UX Improvements**
  * Improved loading/error messaging during discovery steps
  * Modal/form reset and initialization fixes to prevent stale/incorrect field values
<!-- end of auto-generated comment: release notes by coderabbit.ai -->