### PR TITLE
Fix Text mode path fields not wrapping input in string literal quotes

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/ExpressionField.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/ExpressionField.tsx
@@ -32,7 +32,7 @@ import { LineRange } from '@wso2/ballerina-core/lib/interfaces/common';
 import { FormField, HelperpaneOnChangeOptions } from '../Form/types';
 import { ChipExpressionEditorComponent } from './MultiModeExpressionEditor/ChipExpressionEditor/components/ChipExpressionEditor';
 import RecordConfigPreviewEditor from './MultiModeExpressionEditor/RecordConfigPreviewEditor/RecordConfigPreviewEditor';
-import { ArrayEditorConfig, BooleanEditorConfig, NumberExpressionEditorConfig, RawTemplateEditorConfig, SQLExpressionEditorConfig, StringTemplateEditorConfig } from './MultiModeExpressionEditor/Configurations';
+import { ArrayEditorConfig, BooleanEditorConfig, NumberExpressionEditorConfig, RawTemplateEditorConfig, SQLExpressionEditorConfig, StringLiteralEditorConfig, StringTemplateEditorConfig } from './MultiModeExpressionEditor/Configurations';
 import NumberExpressionEditor from './MultiModeExpressionEditor/NumberExpressionEditor/NumberEditor';
 import { EnumEditor } from './MultiModeExpressionEditor/EnumEditor/EnumEditor';
 import { SQLExpressionEditor } from './MultiModeExpressionEditor/SqlExpressionEditor/SqlExpressionEditor';
@@ -110,7 +110,7 @@ const EditorRibbon = ({ onClick }: { onClick: () => void }) => {
 export const getEditorConfiguration = (inputMode: InputMode) => {
     switch (inputMode) {
         case InputMode.TEXT:
-            return new StringTemplateEditorConfig();
+            return new StringLiteralEditorConfig();
         case InputMode.TEMPLATE:
             return new RawTemplateEditorConfig();
         case InputMode.NUMBER:

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/Configurations.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/Configurations.tsx
@@ -112,6 +112,51 @@ export class StringTemplateEditorConfig extends ChipExpressionEditorDefaultConfi
     }
 }
 
+export class StringLiteralEditorConfig extends ChipExpressionEditorDefaultConfiguration {
+    getSerializationPrefix() {
+        return '"';
+    }
+    getSerializationSuffix() {
+        return '"';
+    }
+    getAdornment(): ({ onClick }: { onClick?: () => void; }) => JSX.Element {
+        return () => null;
+    }
+    /** Strip outer double-quotes (or legacy string-template wrapper) for display in the editor */
+    serializeValue(value: string): string {
+        if (!value) return value ?? "";
+        const trimmed = value.trim();
+        if (trimmed.startsWith('"') && trimmed.endsWith('"') && trimmed.length >= 2) {
+            try { return JSON.parse(trimmed); } catch { return trimmed.slice(1, -1); }
+        }
+        // Backward-compat: strip legacy string-template wrapper for display
+        if (trimmed.startsWith('string `') && trimmed.endsWith('`')) {
+            return trimmed.slice('string `'.length, -1);
+        }
+        return value;
+    }
+    /** Wrap user input in double quotes for storage as a Ballerina string literal */
+    deserializeValue(value: string): string {
+        if (!value) return value ?? "";
+        const trimmed = value.trim();
+        if (!trimmed) return value;
+        if (trimmed.startsWith('"') && trimmed.endsWith('"')) return value; // already correct
+        // Backward-compat: convert legacy string-template values to double-quoted form
+        if (trimmed.startsWith('string `') && trimmed.endsWith('`')) {
+            return `"${trimmed.slice('string `'.length, -1)}"`;
+        }
+        return `"${value}"`;
+    }
+    getIsValueCompatible(expValue: string) {
+        if (!expValue) return true;
+        const trimmed = expValue.trim();
+        return (
+            (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+            (trimmed.startsWith('string `') && trimmed.endsWith('`')) // backward-compat
+        );
+    }
+}
+
 export class RawTemplateEditorConfig extends ChipExpressionEditorDefaultConfiguration {
     getHelperValue(value: string, token?: ParsedToken): string {
         if (token?.type === TokenType.FUNCTION) return value;

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/FileIntegrationForm/TextExpressionField.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/FileIntegrationForm/TextExpressionField.tsx
@@ -21,7 +21,7 @@ import styled from "@emotion/styled";
 import { debounce } from "lodash";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { Diagnostic, ExpressionProperty, LineRange, PropertyModel, TriggerCharacter, TRIGGER_CHARACTERS } from "@wso2/ballerina-core";
-import { ChipExpressionEditorComponent, FieldProvider, FormField, InputMode, Provider as FormContextProvider, StringTemplateEditorConfig } from "@wso2/ballerina-side-panel";
+import { ChipExpressionEditorComponent, FieldProvider, FormField, InputMode, Provider as FormContextProvider, StringLiteralEditorConfig } from "@wso2/ballerina-side-panel";
 import { ChipExpressionEditorDefaultConfiguration } from "@wso2/ballerina-side-panel/lib/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/ChipExpressionDefaultConfig";
 import WarningPopup from "@wso2/ballerina-side-panel/lib/components/WarningPopup";
 import { CompletionItem, ErrorBanner, ThemeColors, Typography } from "@wso2/ui-toolkit";
@@ -29,7 +29,7 @@ import { getHelperPaneNew } from "../../../HelperPaneNew";
 import { EXPRESSION_EXTRACTION_REGEX } from "../../../../../constants";
 import { calculateExpressionOffsets, convertBalCompletion, removeDuplicateDiagnostics } from "../../../../../utils/bi";
 
-class TextEditorConfig extends StringTemplateEditorConfig {
+class TextEditorConfig extends StringLiteralEditorConfig {
 }
 
 class ExpressionEditorConfig extends ChipExpressionEditorDefaultConfiguration {

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/ListenerConfigForm.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/ListenerConfigForm.tsx
@@ -208,15 +208,32 @@ export function ListenerConfigForm(props: ListenerConfigFormProps) {
 
 export default ListenerConfigForm;
 
+/** Converts legacy Ballerina string-template literals to double-quoted string literals.
+ *  e.g. string `/tmp` → "/tmp"
+ *  This normalises values that were stored before the TEXT-mode editor was updated to
+ *  use StringLiteralEditorConfig instead of StringTemplateEditorConfig.
+ */
+function normalizeStringTemplateToLiteral(value: string): string {
+    const trimmed = value.trim();
+    if (trimmed.startsWith('string `') && trimmed.endsWith('`')) {
+        return `"${trimmed.slice('string `'.length, -1)}"`;
+    }
+    return value;
+}
+
 function convertConfig(listener: ListenerModel): FormField[] {
     const formFields: FormField[] = [];
     for (const key in listener.properties) {
         const expression = listener.properties[key];
         const fieldType = getPrimaryInputType(expression.types)?.fieldType;
         // For MULTIPLE_SELECT, EXPRESSION_SET, and TEXT_SET, read from values array
-        const value = (fieldType === "MULTIPLE_SELECT" || fieldType === "EXPRESSION_SET" || fieldType === "TEXT_SET")
+        let value = (fieldType === "MULTIPLE_SELECT" || fieldType === "EXPRESSION_SET" || fieldType === "TEXT_SET")
             ? (expression.values && expression.values.length > 0 ? expression.values : (expression.value ? [expression.value] : []))
             : expression.value;
+        // Normalise any legacy string-template values stored in TEXT fields to double-quoted string literals
+        if (fieldType === 'TEXT' && typeof value === 'string') {
+            value = normalizeStringTemplateToLiteral(value);
+        }
         const formField: FormField = {
             key: key,
             label: expression?.metadata.label || key.replace(/([a-z])([A-Z])/g, '$1 $2').replace(/^./, str => str.toUpperCase()),


### PR DESCRIPTION
## Summary

- Introduces `StringLiteralEditorConfig` in `Configurations.tsx` that wraps TEXT-mode user input in double-quoted Ballerina string literals (`"/tmp"`) instead of the previous `StringTemplateEditorConfig` behaviour which produced string-template syntax (`string \`/tmp\``) that the LS rejected in listener named-argument positions
- Switches `getEditorConfiguration(InputMode.TEXT)` in `ExpressionField.tsx` to use the new config, fixing the listener config form path field (Local Files / Directory Integration)
- Updates `TextEditorConfig` in `TextExpressionField.tsx` to extend `StringLiteralEditorConfig`, fixing moveTo/post-process path fields in the File Integration handler form
- Adds `normalizeStringTemplateToLiteral` in `ListenerConfigForm.convertConfig` to migrate legacy `string \`...\`` values to `"..."` on load, so existing services re-save correctly without a false dirty-form state

## Related issue

Fixes wso2/product-integrator#625

## Test plan

- [ ] Create a new Directory Integration service; enter `/tmp` in the Path field (Text mode) — confirm no inline error, no compilation error, and `main.bal` contains `path: "/tmp"`
- [ ] Open an existing service whose path was saved in the old `string \`...\`` format — confirm it displays correctly, the form is not marked dirty on open, and re-saving generates `path: "/tmp"`
- [ ] Switch between Text and Expression modes on the path field and confirm the mode-switcher warning and round-trip behaviour work correctly
- [ ] Enter a destination path in the moveTo post-process action (Text mode) and confirm it stores as `"/path/to/dest"`
- [ ] Run the e2e test `file-integration/directory.spec.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added string literal editor configuration for improved text editing support with double-quoted format.

* **Refactor**
  * Updated expression editors across multiple components to use the new string literal configuration.
  * Enhanced backward compatibility by automatically converting legacy string formats to modern standards when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->