### PR TITLE
Fix back button in artifact creation forms navigating to home instead of Add Artifact page

### DIFF
--- a/workspaces/mi/mi-extension/package.json
+++ b/workspaces/mi/mi-extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "WSO2 Integrator: MI",
   "description": "An extension which gives a development environment for designing, developing, debugging, and testing integration solutions.",
   "icon": "resources/images/wso2-micro-integrator-image.png",
-  "version": "3.1.5",
+  "version": "3.1.526032514",
   "publisher": "wso2",
   "engines": {
     "vscode": "^1.100.0"

--- a/workspaces/mi/mi-extension/src/rpc-managers/mi-visualizer/rpc-manager.ts
+++ b/workspaces/mi/mi-extension/src/rpc-managers/mi-visualizer/rpc-manager.ts
@@ -456,12 +456,8 @@ export class MiVisualizerRpcManager implements MIVisualizerAPI {
     }
 
     goBack(): void {
-        if (!getStateMachine(this.projectUri).context().view?.includes("Form")) {
-            const entry = history.pop();
-            navigate(this.projectUri, entry);
-        } else {
-            navigate(this.projectUri);
-        }
+        const entry = history.pop();
+        navigate(this.projectUri, entry);
     }
 
     async fetchSamplesFromGithub(): Promise<GettingStartedData> {

--- a/workspaces/mi/mi-extension/src/test/e2e-playwright-tests/navigationTests/backNavigation.spec.ts
+++ b/workspaces/mi/mi-extension/src/test/e2e-playwright-tests/navigationTests/backNavigation.spec.ts
@@ -1,0 +1,168 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * E2E tests for Issue #820 — Back button in artifact creation forms must
+ * navigate back to the Add Artifact page, NOT to the Project Overview.
+ *
+ * Root cause (fixed in this codebase):
+ *   Defect 1 — goBack() in rpc-manager.ts called navigate(projectUri) with no
+ *     history entry when the view included "Form", always landing on Overview.
+ *   Defect 2 — handleClick() in AddArtifact/index.tsx never pushed the Add
+ *     Artifact view onto the history stack before opening a creation form.
+ *
+ * After the fix:
+ *   - handleClick calls addToHistory({ location: { view: ADD_ARTIFACT } })
+ *     before executing the artifact command.
+ *   - goBack() unconditionally pops the history stack and navigates to the
+ *     popped entry, so the user correctly returns to the Add Artifact page.
+ */
+
+import { test, expect, Frame } from '@playwright/test';
+import { switchToIFrame } from '@wso2/playwright-vscode-tester';
+import { MACHINE_VIEW } from '@wso2/mi-core';
+import { initTest, page } from '../Utils';
+import { AddArtifact } from '../components/AddArtifact';
+import { Overview } from '../components/Overview';
+import { ProjectExplorer } from '../components/ProjectExplorer';
+
+/** Navigate from wherever we are to the Add Artifact page of testProject. */
+async function goToAddArtifact(): Promise<void> {
+    const projectExplorer = new ProjectExplorer(page.page);
+    await projectExplorer.goToOverview('testProject');
+    const overviewPage = new Overview(page.page);
+    await overviewPage.init();
+    await overviewPage.goToAddArtifact();
+}
+
+/** Click an artifact-type card on the Add Artifact page and return the resulting form frame. */
+async function openArtifactForm(artifactType: string, formIframeTitle: string): Promise<Frame> {
+    const addArtifact = new AddArtifact(page.page);
+    await addArtifact.init();
+    await addArtifact.add(artifactType);
+    const frame = await switchToIFrame(formIframeTitle, page.page);
+    if (!frame) {
+        throw new Error(`Failed to switch to "${formIframeTitle}" iframe`);
+    }
+    return frame;
+}
+
+export default function createTests() {
+    test.describe('Back Navigation Tests (Issue #820)', {
+        tag: '@group2',
+    }, async () => {
+        initTest(false, false, false, undefined, undefined, 'group2');
+
+        // ------------------------------------------------------------------
+        // Primary regression — API form "Go Back" button
+        // ------------------------------------------------------------------
+
+        test('Back button from API form navigates to Add Artifact page', async () => {
+            let apiFormFrame: Frame;
+
+            await test.step('Navigate to Add Artifact page', async () => {
+                await goToAddArtifact();
+            });
+
+            await test.step('Open API creation form', async () => {
+                apiFormFrame = await openArtifactForm('API', 'API Form');
+            });
+
+            await test.step('Click the Go Back (←) button', async () => {
+                const goBackBtn = apiFormFrame!.locator('vscode-button[title="Go Back"]');
+                await goBackBtn.waitFor({ state: 'visible', timeout: 10000 });
+                await goBackBtn.click();
+            });
+
+            await test.step('Verify navigation lands on Add Artifact page, not Project Overview', async () => {
+                await page.page.waitForTimeout(2000);
+                const { title: iframeTitle } = await page.getCurrentWebview();
+                console.log(`After Go Back from API Form: iframeTitle="${iframeTitle}"`);
+                // Bug: before fix this was MACHINE_VIEW.Overview — now must be ADD_ARTIFACT.
+                expect(iframeTitle).toBe(MACHINE_VIEW.ADD_ARTIFACT);
+            });
+        });
+
+        // ------------------------------------------------------------------
+        // Negative — Home (⌂) button must still reach Project Overview
+        // ------------------------------------------------------------------
+
+        test('Home button from API form navigates to Project Overview', async () => {
+            let apiFormFrame: Frame;
+
+            await test.step('Navigate to Add Artifact page', async () => {
+                await goToAddArtifact();
+            });
+
+            await test.step('Open API creation form', async () => {
+                apiFormFrame = await openArtifactForm('API', 'API Form');
+            });
+
+            await test.step('Click the Home (⌂) button', async () => {
+                const homeBtn = apiFormFrame!.locator('vscode-button[title="Home"]');
+                await homeBtn.waitFor({ state: 'visible', timeout: 10000 });
+                await homeBtn.click();
+            });
+
+            await test.step('Verify navigation lands on Project Overview (not Add Artifact)', async () => {
+                await page.page.waitForTimeout(2000);
+                const { title: iframeTitle } = await page.getCurrentWebview();
+                console.log(`After Home from API Form: iframeTitle="${iframeTitle}"`);
+                expect(iframeTitle).toBe(MACHINE_VIEW.Overview);
+            });
+        });
+
+        // ------------------------------------------------------------------
+        // Parametrized — "Go Back" from every affected creation form type
+        // ------------------------------------------------------------------
+
+        const artifactFormPairs: Array<{ artifactType: string; formIframeTitle: string }> = [
+            { artifactType: 'Automation', formIframeTitle: 'Task Form' },
+            { artifactType: 'Sequence',   formIframeTitle: 'Sequence Form' },
+            { artifactType: 'Endpoint',   formIframeTitle: 'Endpoint Form' },
+            { artifactType: 'Template',   formIframeTitle: 'Template Form' },
+        ];
+
+        for (const { artifactType, formIframeTitle } of artifactFormPairs) {
+            test(`Back button from ${artifactType} form navigates to Add Artifact page`, async () => {
+                let formFrame: Frame;
+
+                await test.step('Navigate to Add Artifact page', async () => {
+                    await goToAddArtifact();
+                });
+
+                await test.step(`Open ${artifactType} creation form`, async () => {
+                    formFrame = await openArtifactForm(artifactType, formIframeTitle);
+                });
+
+                await test.step('Click the Go Back (←) button', async () => {
+                    const goBackBtn = formFrame!.locator('vscode-button[title="Go Back"]');
+                    await goBackBtn.waitFor({ state: 'visible', timeout: 10000 });
+                    await goBackBtn.click();
+                });
+
+                await test.step('Verify navigation returns to Add Artifact page', async () => {
+                    await page.page.waitForTimeout(2000);
+                    const { title: currentTitle } = await page.getCurrentWebview();
+                    console.log(`After Go Back from ${artifactType} Form: iframeTitle="${currentTitle}"`);
+                    expect(currentTitle).toBe(MACHINE_VIEW.ADD_ARTIFACT);
+                });
+            });
+        }
+    });
+}

--- a/workspaces/mi/mi-extension/src/test/e2e-playwright-tests/test.list.ts
+++ b/workspaces/mi/mi-extension/src/test/e2e-playwright-tests/test.list.ts
@@ -35,6 +35,7 @@ import overviewPageTests from './overviewPageTests/projectSettingPage.spec';
 import openEntryPointArtifact from './overviewPageTests/openEntryPointArtifact.spec';
 import multiWorkspaceTests from './multiWorkspaceTests/multiWorkspace.spec';
 import unitTestSuitTests from './unitTestSuite.spec';
+import backNavigationTests from './navigationTests/backNavigation.spec';
 import { page } from './Utils';
 const fs = require('fs');
 const path = require('path');
@@ -69,6 +70,7 @@ test.describe(dataMapperMediatorTests);
 test.describe(unitTestSuitTests);
 test.describe(dbReportMediatorTests);
 test.describe(artifact430Tests);
+test.describe(backNavigationTests);
 
 test.afterAll(async () => {
     console.log('\n' + '='.repeat(80));

--- a/workspaces/mi/mi-extension/src/test/suite/history.test.ts
+++ b/workspaces/mi/mi-extension/src/test/suite/history.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Unit tests for the History class — covers Issue #820.
+ *
+ * The bug required two fixes:
+ *   1. goBack() must pop from history and navigate to the popped entry.
+ *   2. The Add Artifact view must be pushed to history before a creation form
+ *      is opened, so that goBack() can return the user to it.
+ *
+ * These unit tests verify the History stack behaviour that both fixes rely on.
+ */
+
+import * as assert from 'assert';
+import { History, HistoryEntry } from '@wso2/mi-core';
+import { MACHINE_VIEW } from '@wso2/mi-core';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEntry(view: MACHINE_VIEW): HistoryEntry {
+    return { location: { view } };
+}
+
+const OVERVIEW_ENTRY     = makeEntry(MACHINE_VIEW.Overview);
+const ADD_ARTIFACT_ENTRY = makeEntry(MACHINE_VIEW.ADD_ARTIFACT);
+const API_FORM_ENTRY     = makeEntry(MACHINE_VIEW.APIForm);
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+suite('History — Issue #820', () => {
+    let history: History;
+
+    setup(() => {
+        history = new History();
+    });
+
+    // -----------------------------------------------------------------------
+    // Basic push / pop behaviour
+    // -----------------------------------------------------------------------
+
+    test('pop() on empty history returns undefined', () => {
+        assert.strictEqual(history.pop(), undefined);
+    });
+
+    test('push() and pop() round-trip preserves the entry', () => {
+        history.push(OVERVIEW_ENTRY);
+        const popped = history.pop();
+        assert.deepStrictEqual(popped, OVERVIEW_ENTRY);
+    });
+
+    test('pop() follows LIFO order', () => {
+        history.push(OVERVIEW_ENTRY);
+        history.push(ADD_ARTIFACT_ENTRY);
+        history.push(API_FORM_ENTRY);
+
+        assert.deepStrictEqual(history.pop(), API_FORM_ENTRY);
+        assert.deepStrictEqual(history.pop(), ADD_ARTIFACT_ENTRY);
+        assert.deepStrictEqual(history.pop(), OVERVIEW_ENTRY);
+        assert.strictEqual(history.pop(), undefined);
+    });
+
+    test('get() returns a copy of the stack that does not mutate the original', () => {
+        history.push(OVERVIEW_ENTRY);
+        history.push(ADD_ARTIFACT_ENTRY);
+
+        const snapshot = history.get();
+        snapshot.pop(); // mutate the copy
+
+        assert.strictEqual(history.get().length, 2, 'Original stack must not be mutated');
+    });
+
+    // -----------------------------------------------------------------------
+    // Issue #820 — Add Artifact entry is present before form entry
+    // -----------------------------------------------------------------------
+
+    /**
+     * Simulates the fixed handleClick() flow:
+     *   1. addToHistory(AddArtifact)  ← fix applied
+     *   2. executeCommand opens API Form  [not tracked in history directly]
+     *
+     * Then simulates goBack():
+     *   pop() should return the Add Artifact entry, not Overview.
+     */
+    test('pop() after pushing Overview then AddArtifact returns AddArtifact entry', () => {
+        // Project Overview is always in history first (navigated to via home/init).
+        history.push(OVERVIEW_ENTRY);
+        // handleClick() now calls addToHistory for ADD_ARTIFACT before opening a form.
+        history.push(ADD_ARTIFACT_ENTRY);
+
+        const poppedByGoBack = history.pop();
+
+        assert.deepStrictEqual(
+            poppedByGoBack,
+            ADD_ARTIFACT_ENTRY,
+            'goBack() must return Add Artifact, not Project Overview'
+        );
+        assert.notDeepStrictEqual(
+            poppedByGoBack,
+            OVERVIEW_ENTRY,
+            'goBack() must NOT return Project Overview'
+        );
+    });
+
+    /**
+     * Without the fix, Add Artifact was never pushed to history.
+     * Simulates the pre-fix history state: Overview is the only entry.
+     * pop() would then return Overview — confirming what the bug caused.
+     */
+    test('pop() without AddArtifact in stack returns Overview — documents pre-fix behaviour', () => {
+        // Pre-fix: only Overview in stack; Add Artifact was never pushed.
+        history.push(OVERVIEW_ENTRY);
+
+        const poppedByOldGoBack = history.pop();
+
+        assert.deepStrictEqual(
+            poppedByOldGoBack,
+            OVERVIEW_ENTRY,
+            'Without the fix, pop() would return Overview (the bug)'
+        );
+    });
+
+    /**
+     * Verifies that after go-back, the remaining history contains only
+     * the entries that were in the stack before the user entered the form.
+     */
+    test('history length decreases by 1 after each pop()', () => {
+        history.push(OVERVIEW_ENTRY);
+        history.push(ADD_ARTIFACT_ENTRY);
+
+        assert.strictEqual(history.get().length, 2);
+
+        history.pop();
+        assert.strictEqual(history.get().length, 1);
+
+        history.pop();
+        assert.strictEqual(history.get().length, 0);
+    });
+
+    // -----------------------------------------------------------------------
+    // clear() / clearAndPopulateWith()
+    // -----------------------------------------------------------------------
+
+    test('clear() empties the history stack', () => {
+        history.push(OVERVIEW_ENTRY);
+        history.push(ADD_ARTIFACT_ENTRY);
+        history.clear();
+        assert.strictEqual(history.get().length, 0);
+        assert.strictEqual(history.pop(), undefined);
+    });
+
+    test('clearAndPopulateWith() replaces the stack with a single entry', () => {
+        history.push(OVERVIEW_ENTRY);
+        history.push(ADD_ARTIFACT_ENTRY);
+        history.clearAndPopulateWith(OVERVIEW_ENTRY);
+
+        const stack = history.get();
+        assert.strictEqual(stack.length, 1);
+        assert.deepStrictEqual(stack[0], OVERVIEW_ENTRY);
+    });
+
+    // -----------------------------------------------------------------------
+    // select() — used by breadcrumb navigation
+    // -----------------------------------------------------------------------
+
+    test('select(index) truncates history to the selected entry', () => {
+        history.push(OVERVIEW_ENTRY);
+        history.push(ADD_ARTIFACT_ENTRY);
+        history.push(API_FORM_ENTRY);
+
+        history.select(0); // select Overview
+
+        const stack = history.get();
+        assert.strictEqual(stack.length, 1);
+        assert.deepStrictEqual(stack[0], OVERVIEW_ENTRY);
+    });
+
+    test('select() with an out-of-range index is a no-op', () => {
+        history.push(OVERVIEW_ENTRY);
+        history.push(ADD_ARTIFACT_ENTRY);
+
+        history.select(-1);
+        assert.strictEqual(history.get().length, 2, 'select(-1) must not mutate the stack');
+
+        history.select(99);
+        assert.strictEqual(history.get().length, 2, 'select(99) must not mutate the stack');
+    });
+
+    // -----------------------------------------------------------------------
+    // updateCurrentEntry()
+    // -----------------------------------------------------------------------
+
+    test('updateCurrentEntry() replaces the top of the stack', () => {
+        history.push(OVERVIEW_ENTRY);
+        history.push(ADD_ARTIFACT_ENTRY);
+        history.updateCurrentEntry(API_FORM_ENTRY);
+
+        const stack = history.get();
+        assert.strictEqual(stack.length, 2);
+        assert.deepStrictEqual(stack[1], API_FORM_ENTRY);
+        assert.deepStrictEqual(stack[0], OVERVIEW_ENTRY, 'earlier entries must remain unchanged');
+    });
+
+    test('updateCurrentEntry() on empty history is a no-op', () => {
+        history.updateCurrentEntry(OVERVIEW_ENTRY);
+        assert.strictEqual(history.get().length, 0);
+    });
+});

--- a/workspaces/mi/mi-visualizer/src/views/AddArtifact/index.tsx
+++ b/workspaces/mi/mi-visualizer/src/views/AddArtifact/index.tsx
@@ -147,6 +147,7 @@ export function AddArtifactView() {
     const handleClick = async (key: string) => {
         const dir = path.join(projectUri, "src", "main", "wso2mi", "artifacts", key);
         let entry = { info: { path: dir } };
+        rpcClient.getMiVisualizerRpcClient().addToHistory({ location: { view: MACHINE_VIEW.ADD_ARTIFACT } });
         if (key === "apis") {
             await rpcClient
                 .getMiDiagramRpcClient()


### PR DESCRIPTION
## Summary

Fixes https://github.com/wso2/mi-vscode/issues/820

When a user navigates to the **Add Artifact** page and clicks an artifact type card (e.g. API), the resulting creation form shows two navigation buttons — "Go Back" (←) and "Home" (⌂). Clicking "Go Back" was incorrectly navigating to the **Project Overview** (home page) instead of returning to the **Add Artifact** page — making both buttons behave identically.

### Root Cause — Two Interrelated Defects

**Defect 1 — `goBack()` navigates to Home when current view is a Form**
(`workspaces/mi/mi-extension/src/rpc-managers/mi-visualizer/rpc-manager.ts`)

```typescript
// Before (buggy):
goBack(): void {
    if (!getStateMachine(this.projectUri).context().view?.includes("Form")) {
        const entry = history.pop();
        navigate(this.projectUri, entry);
    } else {
        navigate(this.projectUri);  // ← BUG: navigates to Home without popping history
    }
}
```

When the current view is a creation form, the `else` branch called `navigate(projectUri)` with no history entry, which always resolves to the default/home view.

**Defect 2 — Add Artifact view never pushed itself to history before opening a form**
(`workspaces/mi/mi-visualizer/src/views/AddArtifact/index.tsx`)

When a user clicked an artifact card, `handleClick()` fired a VS Code command to open the creation form but never called `addToHistory()`. So the history stack had no Add Artifact entry to pop back to.

### Fix

| File | Change |
|------|--------|
| `rpc-manager.ts` | Removed the `if (!view?.includes("Form"))` guard — `goBack()` now always pops the history stack and navigates to the popped entry. |
| `AddArtifact/index.tsx` | Added `addToHistory({ location: { view: MACHINE_VIEW.ADD_ARTIFACT } })` at the top of `handleClick()`, before any `executeCommand` call. |

The `addToHistory` call is placed before the `if/else if` chain so it applies to all artifact types (APIs, endpoints, sequences, templates, message stores, etc.).

## Tests Added

- **E2E test** (`navigationTests/backNavigation.spec.ts`): Opens a project, navigates to Add Artifact, clicks the API card, then verifies the "Go Back" button returns to the Add Artifact page (not Project Overview). Also verifies the "Home" button still navigates to Project Overview.
- **Unit tests** (`test/suite/history.test.ts`): Tests the `History` stack behaviour — push/pop round-trips, LIFO order, the fixed flow (AddArtifact entry in stack before form), and the pre-fix scenario (documents the bug).
- Registered the new E2E suite in `test.list.ts`.

## Test Plan

- [x] Verified fix end-to-end via Playwright against running code-server: "Go Back" from API creation form correctly returns to the Add Artifact page (tab title "Add Artifact", artifact cards visible)
- [x] "Home" button from creation form still navigates to Project Overview (not broken by fix)
- [x] Fix applies to all artifact types — `addToHistory` is called before the artifact-type branch, not inside each branch
- [x] Unit tests pass for History stack behavior covering the issue scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved back navigation behavior in artifact creation forms for more consistent navigation flow.
  * Enhanced history tracking when selecting artifacts to add.

* **Chores**
  * Updated extension version to 3.1.526032514.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->