### PR TITLE
Fix repeatable map diagnostics handling in flow forms

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/utils/bi.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/utils/bi.tsx
@@ -385,6 +385,11 @@ function getFormFieldValue(expression: Property, clientName?: string) {
         console.log(">>> client name as set field value", clientName);
         return clientName;
     }
+
+    if (expression.types?.some((type) => type.fieldType === "REPEATABLE_MAP")) {
+        return expression.value as any;
+    }
+
     return (expression.value ?? "") as string;
 }
 

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FlowNodeForm/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FlowNodeForm/index.tsx
@@ -179,6 +179,36 @@ interface FlowNodeFormProps {
     defaultExpandAdvanced?: boolean;
 }
 
+type RepeatableMapEntry = {
+    key: string;
+    value: string;
+};
+
+const getRepeatableMapEntriesFromValue = (value: unknown): RepeatableMapEntry[] => {
+    if (typeof value === "string") {
+        return stringToRawObjectEntries(value);
+    }
+
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+        return Object.entries(value as Record<string, any>).map(([entryKey, entryValue]) => ({
+            key: entryKey,
+            value: typeof entryValue === "object" && entryValue !== null
+                ? String((entryValue as any).value ?? "")
+                : String(entryValue ?? "")
+        }));
+    }
+
+    return [];
+};
+
+const getRepeatableMapDiagnosticsByKey = (value: unknown): Record<string, any> | undefined => {
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+        return value as Record<string, any>;
+    }
+
+    return undefined;
+};
+
 // Styled component for the action button description
 const ActionButtonDescription = styled.div`
     font-size: var(--vscode-font-size);
@@ -540,7 +570,6 @@ export const FlowNodeForm = forwardRef<FormExpressionEditorRef, FlowNodeFormProp
             const updatedField = { ...field };
 
             const isRepeatableList = field.types?.length === 1 && getPrimaryInputType(field.types)?.fieldType === "REPEATABLE_LIST";
-            const isRepeatableMap = field.types?.length === 1 && getPrimaryInputType(field.types)?.fieldType === "REPEATABLE_MAP";
             const selectedInputType = isRepeatableList ? getPrimaryInputType(field.types) : field.types?.find(t => t.selected);
             const isContainingRepeatableList = field.types?.some(t => t.fieldType === "REPEATABLE_LIST");
             const isContainingRepeatableMap = field.types?.some(t => t.fieldType === "REPEATABLE_MAP");
@@ -579,37 +608,27 @@ export const FlowNodeForm = forwardRef<FormExpressionEditorRef, FlowNodeFormProp
                 }
 
                 else if (isContainingRepeatableMap) {
-                    if (!(typeof nodeProperties?.[field.key]?.value === "object")) {
-                        throw new Error(`Expected value for repeatable map field "${field.key}" to be an object, but got ${typeof nodeProperties?.[field.key]?.value}.`);
-                    }
+                    // Diagnostics responses do not preserve a single map shape consistently.
+                    // Optional maps may omit `value`, while populated maps can come back either
+                    // as editor-friendly objects or as serialized source strings.
+                    const repeatableMapDiagnostics = getRepeatableMapDiagnosticsByKey(nodeProperties?.[field.key]?.value);
                     if (selectedInputType?.fieldType === "REPEATABLE_MAP") {
-                        let initialValues: { key: string; value: string }[];
-                        if (typeof data[field.key] === 'string') {
-                            initialValues = stringToRawObjectEntries(data[field.key]);
-                        } else {
-                            // When the value is an object (from FormMapEditorNew), extract entries directly
-                            initialValues = Object.entries(data[field.key] as Record<string, any>).map(([entryKey, entryVal]) => ({
-                                key: entryKey,
-                                value: typeof entryVal === 'object' && entryVal !== null ? String((entryVal as any).value ?? '') : String(entryVal)
-                            }));
-                        }
+                        const initialValues = getRepeatableMapEntriesFromValue(data[field.key]);
                         // Keep value as a Record to match processToOutputFormat shape expected by FormMapEditorNew
                         const outputRecord: Record<string, unknown> = {};
                         initialValues.forEach((val) => {
                             const key = crypto.randomUUID();
-                            propertyDiagnostics = nodeProperties?.[field.key]?.value?.[val.key]?.diagnostics?.diagnostics ?? [];
                             outputRecord[val.key] = {
                                 ...getArraySubFormFieldFromTypes(key, (field.types[0] as any).template.types as InputType[]),
                                 key: `mp-val-${key}`,
                                 value: val.value,
-                                diagnostics: nodeProperties?.[field.key]?.value?.[val.key]?.diagnostics?.diagnostics ?? []
+                                diagnostics: repeatableMapDiagnostics?.[val.key]?.diagnostics?.diagnostics ?? []
                             };
                         });
                         updatedField.value = outputRecord;
                     }
                     else {
                         updatedField.value = data[field.key];
-                        propertyDiagnostics = nodeProperties?.[field.key]?.value?.map((val: any) => val?.diagnostics?.diagnostics ?? []).flat() ?? [];
                     }
                 }
                 else {
@@ -625,6 +644,19 @@ export const FlowNodeForm = forwardRef<FormExpressionEditorRef, FlowNodeFormProp
                 const collectedDiagnostics = (
                     nodeProperties?.[field.key]?.value?.map((val: any) => val?.diagnostics?.diagnostics) ?? []
                 ).flat().filter(Boolean) as Array<{ message?: string; severity?: string }>;
+
+                propertyDiagnostics = collectedDiagnostics.filter((d, i, arr) =>
+                    arr.findIndex(x => x.message === d.message) === i
+                );
+            }
+
+            if (isContainingRepeatableMap && !(Array.isArray(propertyDiagnostics) && propertyDiagnostics.length > 0)) {
+                const collectedDiagnostics = Object.values(
+                    getRepeatableMapDiagnosticsByKey(nodeProperties?.[field.key]?.value) ?? {}
+                )
+                    .map((value: any) => value?.diagnostics?.diagnostics)
+                    .flat()
+                    .filter(Boolean) as Array<{ message?: string; severity?: string }>;
 
                 propertyDiagnostics = collectedDiagnostics.filter((d, i, arr) =>
                     arr.findIndex(x => x.message === d.message) === i


### PR DESCRIPTION
## Summary
- fix BI flow form validation for `REPEATABLE_MAP` fields such as HTTP `headers`
- tolerate diagnostics responses where map values are omitted or returned as serialized strings
- preserve raw repeatable-map values when converting node properties to form fields

## Problem
Saving connector action forms could fail during validation because the diagnostics reconciliation logic assumed repeatable-map values always came back as objects.

In practice, diagnostics responses for optional map fields can return:
- no `value` at all
- an object-form value
- a serialized source string like `{Accept: "application/json"}`

That caused the form to throw before save completed.

## Issue
- Related: wso2/product-integrator#735

## Testing
- `pnpm --dir workspaces/ballerina/ballerina-visualizer exec tsc --noEmit --pretty false -p tsconfig.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of repeatable map form fields to support multiple data formats
  * Enhanced error diagnostics for repeatable map fields with more comprehensive validation feedback

* **Refactor**
  * Optimized repeatable map processing logic for better reliability and consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->