### PR TITLE
fix: add placeholder for MCP tool return type field  

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/McpToolForm/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/McpToolForm/index.tsx
@@ -201,6 +201,7 @@ export function McpToolForm(props: McpToolFormProps) {
                 editable: model.returnType.editable,
                 advanced: model.returnType.advanced,
                 documentation: model.returnType.metadata?.description || "",
+                placeholder: model.returnType.metadata?.placeholder || "e.g. string, int, json",
                 value: model.returnType.value,
                 types: model.returnType.types,
             },

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/McpToolForm/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/McpToolForm/index.tsx
@@ -201,7 +201,10 @@ export function McpToolForm(props: McpToolFormProps) {
                 editable: model.returnType.editable,
                 advanced: model.returnType.advanced,
                 documentation: model.returnType.metadata?.description || "",
-                placeholder: model.returnType.metadata?.placeholder || "e.g. string, int, json",
+                placeholder:
+                    model.returnType.placeholder ??
+                    model.returnType.metadata?.placeholder ??
+                    "e.g. string, int, json",
                 value: model.returnType.value,
                 types: model.returnType.types,
             },


### PR DESCRIPTION
  ## Purpose                              
  Fixes wso2/product-integrator#731           
                                                                                                                    
  The return type field in the MCP tool form was displaying `undefined` as placeholder text when a user adds a new
  tool in the MCP service creator.                                                                                  
                                                                                                                    
  ## Goals                                                                                                          
  Show a meaningful placeholder for the return type field instead of `undefined`.                                   
                                                                                                                    
  ## Approach                             
  Added a placeholder property to the returnType field in McpToolForm/index.tsx that falls back to "e.g. string,
  int, json" when no placeholder is defined in the metadata.                                                        
                                          
  ## UI Component Development                                                                                       
  N/A - No new UI components added                                                                                  
                                              
  ## Manage Icons                                                                                                   
  N/A - No new icons added
                                                                                                                    
  ## User stories
  N/A                                                                                                               
                  
  ## Release note
  Fixed undefined placeholder text in MCP tool return type field.
                                              
  ## Documentation                        
  N/A - Minor placeholder fix, no doc impact
                                                                                                                    
  ## Training
  N/A                                                                                                               
                  
  ## Certification
  N/A

  ## Marketing
  N/A
                                              
  ## Automation tests                     
  N/A
                                                                                                                    
  ## Security checks
  - Followed secure coding standards? yes                                                                           
  - Ran FindSecurityBugs plugin? N/A
  - No keys or secrets committed? yes

  ## Samples
  N/A
                                              
  ## Related PRs                          
  N/A
                                                                                                                    
  ## Migrations
  N/A                                                                                                               
                  
  ## Test environment
  N/A

  ## Learning
  N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * The return type input now shows a contextual placeholder (falls back to an example like "e.g. string, int, json") to help users enter valid formats. The placeholder is driven by the form's underlying model so it reflects any available contextual guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->