### PR TITLE
Detect conflicting integration project dependencies and clean up pom.xml

### DIFF
--- a/workspaces/mi/mi-extension/src/lang-client/ExtendedLanguageClient.ts
+++ b/workspaces/mi/mi-extension/src/lang-client/ExtendedLanguageClient.ts
@@ -168,6 +168,20 @@ export interface ArtifactType {
     artifactFolder: string;
 }
 
+export interface ConflictingDependency {
+    groupId: string;
+    artifactId: string;
+    version: string;
+    conflictingArtifacts: string[];
+    conflictingConnectors: string[];
+}
+
+export interface LoadDependentResourcesResponse {
+    status: 'SUCCESS' | 'NO_DEPS_FOUND' | 'ERROR' | 'CONFLICT';
+    message: string;
+    conflictingDependencies?: ConflictingDependency[];
+}
+
 export class ExtendedLanguageClient extends LanguageClient {
 
     constructor(id: string, name: string, private projectUri: string, serverOptions: ServerOptions, clientOptions: LanguageClientOptions) {
@@ -385,7 +399,7 @@ export class ExtendedLanguageClient extends LanguageClient {
         return this.sendRequest('synapse/refetchIntegrationProjectDependencies');
     }
 
-    async loadDependentCAppResources(): Promise<string> {
+    async loadDependentCAppResources(): Promise<LoadDependentResourcesResponse> {
         return this.sendRequest('synapse/loadDependentResources');
     }
 

--- a/workspaces/mi/mi-extension/src/lang-client/activator.ts
+++ b/workspaces/mi/mi-extension/src/lang-client/activator.ts
@@ -52,7 +52,7 @@ import { log } from '../util/logger';
 import { getJavaHomeFromConfig, getProjectSetupDetails, isMISetup, isJavaSetup } from '../util/onboardingUtils';
 import { SELECTED_SERVER_PATH } from '../debugger/constants';
 import { extension } from '../MIExtensionContext';
-import { extractCAppDependenciesAsProjects } from '../visualizer/activate';
+import { loadCAppResources } from '../visualizer/activate';
 import vscode from "vscode";
 const exec = util.promisify(require('child_process').exec);
 
@@ -330,8 +330,8 @@ export class MILanguageClient {
                 this.languageClient = new ExtendedLanguageClient('synapseXML', 'Synapse Language Server', this.projectUri,
                     serverOptions, clientOptions);
                 await this.languageClient.start();
-                await extractCAppDependenciesAsProjects(this.projectUri);
-                await this.languageClient?.loadDependentCAppResources();
+                await this.languageClient?.updateConnectorDependencies();
+                await loadCAppResources(this.projectUri, this.languageClient!);
 
                 //Setup autoCloseTags
                 let tagProvider: (document: TextDocument, position: Position) => Thenable<AutoCloseResult> = (document: TextDocument, position: Position) => {

--- a/workspaces/mi/mi-extension/src/rpc-managers/mi-visualizer/rpc-manager.ts
+++ b/workspaces/mi/mi-extension/src/rpc-managers/mi-visualizer/rpc-manager.ts
@@ -90,7 +90,7 @@ import { copy } from 'fs-extra';
 const fs = require('fs');
 import { TextEdit } from "vscode-languageclient";
 import { downloadJavaFromMI, downloadMI, getProjectSetupDetails, getSupportedMIVersionsHigherThan, setPathsInWorkSpace, updateRuntimeVersionsInPom, getMIVersionFromPom, isConsolidatedProject } from '../../util/onboardingUtils';
-import { extractCAppDependenciesAsProjects } from "../../visualizer/activate";
+import { extractCAppDependenciesAsProjects, loadCAppResources } from "../../visualizer/activate";
 import { findMultiModuleProjectsInWorkspaceDir } from "../../util/migrationUtils";
 import { MILanguageClient } from "../../lang-client/activator";
 import { reorderModulesByBuildOrder } from "../../debugger/pomResolver";
@@ -206,23 +206,6 @@ export class MiVisualizerRpcManager implements MIVisualizerAPI {
     }
 
     /**
-     * Extracts CApp dependencies as projects and loads dependent CApp resources.
-     *
-     * @param langClient - The language client instance.
-     */
-    private async _loadCAppResources(langClient: Awaited<ReturnType<typeof MILanguageClient.getInstance>>): Promise<void> {
-        try {
-            await extractCAppDependenciesAsProjects(this.projectUri);
-            const loadResult = await langClient?.loadDependentCAppResources();
-            if (loadResult.startsWith("DUPLICATE ARTIFACTS")) {
-                await window.showWarningMessage(loadResult, { modal: true });
-            }
-        } catch (error) {
-            console.error("Failed to load CApp resources:", error);
-        }
-    }
-
-    /**
      * Reloads the dependencies for the current integration project.
      *
      * @param params - An object containing the parameters for reloading dependencies.
@@ -335,7 +318,7 @@ export class MiVisualizerRpcManager implements MIVisualizerAPI {
                 }
             }
 
-            await this._loadCAppResources(langClient);
+            await loadCAppResources(this.projectUri, langClient);
             const parentDir = path.dirname(this.projectUri)
             if (isConsolidatedProject(parentDir) && params?.isProjectDependenciesUpdated) {
                 await reorderModulesByBuildOrder(path.join(parentDir, 'pom.xml'));
@@ -455,7 +438,7 @@ export class MiVisualizerRpcManager implements MIVisualizerAPI {
     async refetchIntegrationProjectDependencies(): Promise<string> {
         const langClient = await MILanguageClient.getInstance(this.projectUri);
         const res = await langClient.refetchIntegrationProjectDependencies();
-        await this._loadCAppResources(langClient);
+        await loadCAppResources(this.projectUri, langClient);
         return res;
     }
 

--- a/workspaces/mi/mi-extension/src/rpc-managers/mi-visualizer/rpc-manager.ts
+++ b/workspaces/mi/mi-extension/src/rpc-managers/mi-visualizer/rpc-manager.ts
@@ -79,7 +79,7 @@ import { extension } from "../../MIExtensionContext";
 import { DebuggerConfig } from "../../debugger/config";
 import { history } from "../../history";
 import { getStateMachine, navigate, openView, refreshUI } from "../../stateMachine";
-import { goToSource, handleOpenFile, appendContent, selectFolderDialog } from "../../util/fileOperations";
+import { formatAndSavePomDocument, goToSource, handleOpenFile, appendContent, selectFolderDialog } from "../../util/fileOperations";
 import { openPopupView } from "../../stateMachinePopup";
 import { SwaggerServer } from "../../swagger/server";
 import { log, outputChannel } from "../../util/logger";
@@ -856,31 +856,16 @@ export class MiVisualizerRpcManager implements MIVisualizerAPI {
 
             edit.replace(Uri.file(pomPath), range, content);
         }
-        const success = await workspace.applyEdit(edit);
-        // Make sure to save the document after applying the edits
-        if (success) {
-            const document = await workspace.openTextDocument(pomPath);
-            await document.save();
-            // Format the pom content
-            const editorConfig = workspace.getConfiguration('editor');
-            let formattingOptions = {
-                    tabSize: editorConfig.get("tabSize") ?? 4,
-                    insertSpaces: editorConfig.get("insertSpaces") ?? false,
-                    trimTrailingWhitespace: editorConfig.get("trimTrailingWhitespace") ?? false
-                };
-            const edits = await vscode.commands.executeCommand<vscode.TextEdit[]>("vscode.executeFormatDocumentProvider",
-                            vscode.Uri.file(pomPath), formattingOptions);
-            if (edits && edits.length > 0) {
-                const edit = new vscode.WorkspaceEdit();
-                edit.set(vscode.Uri.file(pomPath), edits);
-                await vscode.workspace.applyEdit(edit);
-                await vscode.workspace.openTextDocument(pomPath).then(doc => doc.save());
-            }
-            if (getStateMachine(this.projectUri).context().view === MACHINE_VIEW.Overview) {
-                refreshUI(this.projectUri);
-            }
-        } else {
+        if (!await workspace.applyEdit(edit)) {
             throw new Error("Failed to apply edits to pom.xml");
+        }
+
+        const document = await workspace.openTextDocument(pomPath);
+        await document.save();
+        await formatAndSavePomDocument(pomPath);
+
+        if (getStateMachine(this.projectUri).context().view === MACHINE_VIEW.Overview) {
+            refreshUI(this.projectUri);
         }
     }
 

--- a/workspaces/mi/mi-extension/src/util/fileOperations.ts
+++ b/workspaces/mi/mi-extension/src/util/fileOperations.ts
@@ -1238,13 +1238,17 @@ export async function formatAndSavePomDocument(pomPath: string): Promise<void> {
         insertSpaces: editorConfig.get("insertSpaces") ?? false,
         trimTrailingWhitespace: editorConfig.get("trimTrailingWhitespace") ?? false
     };
-    const edits = await commands.executeCommand<TextEdit[]>(
-        "vscode.executeFormatDocumentProvider", Uri.file(pomPath), formattingOptions
-    );
-    if (edits && edits.length > 0) {
-        const formatEdit = new WorkspaceEdit();
-        formatEdit.set(Uri.file(pomPath), edits);
-        await workspace.applyEdit(formatEdit);
-        await workspace.openTextDocument(pomPath).then(doc => doc.save());
+    try {
+        const edits = await commands.executeCommand<TextEdit[]>(
+            "vscode.executeFormatDocumentProvider", Uri.file(pomPath), formattingOptions
+        );
+        if (edits && edits.length > 0) {
+            const formatEdit = new WorkspaceEdit();
+            formatEdit.set(Uri.file(pomPath), edits);
+            await workspace.applyEdit(formatEdit);
+        }
+    } catch {
+        // Formatter unavailable or not ready — skip formatting, proceed to save
     }
+    await workspace.openTextDocument(pomPath).then(doc => doc.save());
 }

--- a/workspaces/mi/mi-extension/src/util/fileOperations.ts
+++ b/workspaces/mi/mi-extension/src/util/fileOperations.ts
@@ -1230,3 +1230,21 @@ export function updatePomWithParent(pomPath: string, parent: ParentPomInfo) {
     const updatedXml = builder.build(pom);
     fs.writeFileSync(pomPath, updatedXml);
 }
+
+export async function formatAndSavePomDocument(pomPath: string): Promise<void> {
+    const editorConfig = workspace.getConfiguration('editor');
+    const formattingOptions = {
+        tabSize: editorConfig.get("tabSize") ?? 4,
+        insertSpaces: editorConfig.get("insertSpaces") ?? false,
+        trimTrailingWhitespace: editorConfig.get("trimTrailingWhitespace") ?? false
+    };
+    const edits = await commands.executeCommand<TextEdit[]>(
+        "vscode.executeFormatDocumentProvider", Uri.file(pomPath), formattingOptions
+    );
+    if (edits && edits.length > 0) {
+        const formatEdit = new WorkspaceEdit();
+        formatEdit.set(Uri.file(pomPath), edits);
+        await workspace.applyEdit(formatEdit);
+        await workspace.openTextDocument(pomPath).then(doc => doc.save());
+    }
+}

--- a/workspaces/mi/mi-extension/src/visualizer/activate.ts
+++ b/workspaces/mi/mi-extension/src/visualizer/activate.ts
@@ -17,7 +17,7 @@
  */
 
 import * as vscode from 'vscode';
-import { commands, Uri, window, workspace } from 'vscode';
+import { Position, Range, WorkspaceEdit, commands, Uri, window, workspace } from 'vscode';
 import { getStateMachine, navigate, openView, refreshUI } from '../stateMachine';
 import { COMMANDS, LAST_EXPORTED_ZIP_PATH, REFRESH_ENABLED_DOCUMENTS, SWAGGER_LANG_ID, SWAGGER_REL_DIR } from '../constants';
 import { EVENT_TYPE, MACHINE_VIEW, onDocumentSave } from '@wso2/mi-core';
@@ -37,6 +37,7 @@ import { log } from '../util/logger';
 import { CACHED_FOLDER, INTEGRATION_PROJECT_DEPENDENCIES_DIR, isConsolidatedProject } from '../util/onboardingUtils';
 import { extractZip, getHash, zipProjectFolder } from '../util/fileOperations';
 import { MILanguageClient } from '../lang-client/activator';
+import { ConflictingDependency } from '../lang-client/ExtendedLanguageClient';
 import { askForProject } from '../util/workspace';
 
 export function activateVisualizer(context: vscode.ExtensionContext, firstProject: string) {
@@ -425,8 +426,7 @@ export function activateVisualizer(context: vscode.ExtensionContext, firstProjec
                     statusBarItem.text = '$(sync) Updating dependencies...';
                     statusBarItem.show();
                     await langClient?.updateConnectorDependencies();
-                    await extractCAppDependenciesAsProjects(projectUri);
-                    await langClient?.loadDependentCAppResources();
+                    await loadCAppResources(projectUri!, langClient);
                     statusBarItem.hide();
                 }
             }
@@ -615,6 +615,114 @@ export async function extractCAppDependenciesAsProjects(projectUri: string | und
         }
     } catch (error: any) {
         vscode.window.showErrorMessage(`Failed to load integration project dependencies: ${error.message}`);
+    }
+}
+
+async function formatAndSavePomDocument(pomPath: string): Promise<void> {
+    const editorConfig = workspace.getConfiguration('editor');
+    const formattingOptions = {
+        tabSize: editorConfig.get("tabSize") ?? 4,
+        insertSpaces: editorConfig.get("insertSpaces") ?? false,
+        trimTrailingWhitespace: editorConfig.get("trimTrailingWhitespace") ?? false
+    };
+    const edits = await vscode.commands.executeCommand<vscode.TextEdit[]>(
+        "vscode.executeFormatDocumentProvider", Uri.file(pomPath), formattingOptions
+    );
+    if (edits && edits.length > 0) {
+        const formatEdit = new WorkspaceEdit();
+        formatEdit.set(Uri.file(pomPath), edits);
+        await workspace.applyEdit(formatEdit);
+        await workspace.openTextDocument(pomPath).then(doc => doc.save());
+    }
+}
+
+async function removePomEntries(projectUri: string, pomValues: { range: any; value: string }[]): Promise<void> {
+    const pomPath = path.join(projectUri, 'pom.xml');
+    if (!fs.existsSync(pomPath)) {
+        throw new Error("pom.xml not found");
+    }
+
+    const edit = new WorkspaceEdit();
+    for (const pomValue of pomValues) {
+        const range = new Range(
+            new Position(pomValue.range.start.line - 1, pomValue.range.start.character - 1),
+            new Position(pomValue.range.end.line - 1, pomValue.range.end.character - 1)
+        );
+        edit.replace(Uri.file(pomPath), range, pomValue.value);
+    }
+
+    if (!await workspace.applyEdit(edit)) {
+        throw new Error("Failed to apply edits to pom.xml");
+    }
+
+    const document = await workspace.openTextDocument(pomPath);
+    await document.save();
+    await formatAndSavePomDocument(pomPath);
+
+    if (getStateMachine(projectUri).context().view === MACHINE_VIEW.Overview) {
+        refreshUI(projectUri);
+    }
+}
+
+async function handleConflictingCAppArtifacts(
+    projectUri: string,
+    langClient: Awaited<ReturnType<typeof MILanguageClient.getInstance>>,
+    conflictingDeps: ConflictingDependency[]
+): Promise<void> {
+    if (conflictingDeps.length === 0) {
+        return;
+    }
+
+    const depList = conflictingDeps
+        .map(cd => {
+            const dep = `${cd.groupId}:${cd.artifactId}:${cd.version}`;
+            const allConflicting = [...cd.conflictingArtifacts, ...cd.conflictingConnectors];
+            const conflictingList = allConflicting.length > 0
+                ? `\n  ${allConflicting.join(', ')}`
+                : '';
+            return `${dep}${conflictingList}`;
+        })
+        .join('\n');
+    const warningMessage = `Conflicting artifacts were identified with the current project or other dependent projects. Hence, they will be removed from pom.xml if available:\n${depList}`;
+    await window.showWarningMessage(warningMessage, { modal: true });
+
+    const projectDetails = await langClient.getProjectDetails();
+    const existingDependencies = projectDetails.dependencies || {};
+    const allExistingDeps = [
+        ...(existingDependencies.connectorDependencies || []),
+        ...(existingDependencies.integrationProjectDependencies || []),
+        ...(existingDependencies.otherDependencies || [])
+    ];
+
+    // Note: local dependency model uses `artifact` for the artifact ID field,
+    // while the server response uses `artifactId` — these map to the same concept.
+    const dependenciesToRemove = conflictingDeps
+        .map(cd => allExistingDeps.find((dep: any) =>
+            dep.groupId === cd.groupId &&
+            dep.artifact === cd.artifactId &&
+            dep.version === cd.version
+        ))
+        .filter((dep): dep is NonNullable<typeof dep> => dep !== undefined);
+
+    if (dependenciesToRemove.length > 0) {
+        await removePomEntries(projectUri, dependenciesToRemove.map((dep: any) => ({ range: dep.range, value: '' })));
+    }
+}
+
+export async function loadCAppResources(
+    projectUri: string,
+    langClient: Awaited<ReturnType<typeof MILanguageClient.getInstance>>
+): Promise<void> {
+    try {
+        await extractCAppDependenciesAsProjects(projectUri);
+        const response = await langClient.loadDependentCAppResources();
+        if (response.status === 'CONFLICT') {
+            await handleConflictingCAppArtifacts(projectUri, langClient, response.conflictingDependencies ?? []);
+        } else if (response.status === 'ERROR') {
+            vscode.window.showErrorMessage(`Failed to load dependent CApp resources: ${response.message}`);
+        }
+    } catch (error) {
+        console.error("Failed to load CApp resources:", error);
     }
 }
 

--- a/workspaces/mi/mi-extension/src/visualizer/activate.ts
+++ b/workspaces/mi/mi-extension/src/visualizer/activate.ts
@@ -33,7 +33,7 @@ import { VisualizerWebview, webviews } from './webview';
 import * as fs from 'fs';
 import { AiPanelWebview } from '../ai-features/webview';
 import { MiDiagramRpcManager } from '../rpc-managers/mi-diagram/rpc-manager';
-import { log } from '../util/logger';
+import { log, outputChannel } from '../util/logger';
 import { CACHED_FOLDER, INTEGRATION_PROJECT_DEPENDENCIES_DIR, isConsolidatedProject } from '../util/onboardingUtils';
 import { extractZip, formatAndSavePomDocument, getHash, zipProjectFolder } from '../util/fileOperations';
 import { MILanguageClient } from '../lang-client/activator';
@@ -664,9 +664,19 @@ async function handleConflictingCAppArtifacts(
                 : '';
             return `${dep}${conflictingList}`;
         })
-        .join('\n');
-    const warningMessage = `Conflicting artifacts were identified with the current project or other dependent projects. Hence, they will be removed from pom.xml if available:\n${depList}`;
-    await window.showWarningMessage(warningMessage, { modal: true });
+        .join('\n\n');
+
+    const header = "Conflicting artifacts were identified with the current project or other dependent projects. They will be removed from pom.xml if available.";
+    const fullMessage = `${header}\n\n${depList}`;
+
+    outputChannel.appendLine("[Conflicting CApp Artifacts] " + fullMessage);
+
+    const MAX_LENGTH = 500;
+    const displayMessage = fullMessage.length > MAX_LENGTH
+        ? fullMessage.substring(0, MAX_LENGTH) + '\n\n...(truncated, see "WSO2 Integrator: MI" output channel for full details)'
+        : fullMessage;
+
+    await window.showWarningMessage(displayMessage, { modal: true });
 
     const projectDetails = await langClient.getProjectDetails();
     const existingDependencies = projectDetails.dependencies || {};

--- a/workspaces/mi/mi-extension/src/visualizer/activate.ts
+++ b/workspaces/mi/mi-extension/src/visualizer/activate.ts
@@ -679,7 +679,7 @@ async function handleConflictingCAppArtifacts(
     // Note: local dependency model uses `artifact` for the artifact ID field,
     // while the server response uses `artifactId` — these map to the same concept.
     const dependenciesToRemove = conflictingDeps
-        .map(cd => allExistingDeps.find((dep: any) =>
+        .flatMap(cd => allExistingDeps.filter((dep: any) =>
             dep.groupId === cd.groupId &&
             dep.artifact === cd.artifactId &&
             dep.version === cd.version

--- a/workspaces/mi/mi-extension/src/visualizer/activate.ts
+++ b/workspaces/mi/mi-extension/src/visualizer/activate.ts
@@ -684,7 +684,7 @@ async function handleConflictingCAppArtifacts(
             dep.artifact === cd.artifactId &&
             dep.version === cd.version
         ))
-        .filter((dep): dep is NonNullable<typeof dep> => dep !== undefined);
+        .filter((dep): dep is NonNullable<typeof dep> => dep !== undefined && dep.range !== undefined);
 
     if (dependenciesToRemove.length > 0) {
         await removePomEntries(projectUri, dependenciesToRemove.map((dep: any) => ({ range: dep.range, value: '' })));

--- a/workspaces/mi/mi-extension/src/visualizer/activate.ts
+++ b/workspaces/mi/mi-extension/src/visualizer/activate.ts
@@ -35,7 +35,7 @@ import { AiPanelWebview } from '../ai-features/webview';
 import { MiDiagramRpcManager } from '../rpc-managers/mi-diagram/rpc-manager';
 import { log } from '../util/logger';
 import { CACHED_FOLDER, INTEGRATION_PROJECT_DEPENDENCIES_DIR, isConsolidatedProject } from '../util/onboardingUtils';
-import { extractZip, getHash, zipProjectFolder } from '../util/fileOperations';
+import { extractZip, formatAndSavePomDocument, getHash, zipProjectFolder } from '../util/fileOperations';
 import { MILanguageClient } from '../lang-client/activator';
 import { ConflictingDependency } from '../lang-client/ExtendedLanguageClient';
 import { askForProject } from '../util/workspace';
@@ -615,24 +615,6 @@ export async function extractCAppDependenciesAsProjects(projectUri: string | und
         }
     } catch (error: any) {
         vscode.window.showErrorMessage(`Failed to load integration project dependencies: ${error.message}`);
-    }
-}
-
-async function formatAndSavePomDocument(pomPath: string): Promise<void> {
-    const editorConfig = workspace.getConfiguration('editor');
-    const formattingOptions = {
-        tabSize: editorConfig.get("tabSize") ?? 4,
-        insertSpaces: editorConfig.get("insertSpaces") ?? false,
-        trimTrailingWhitespace: editorConfig.get("trimTrailingWhitespace") ?? false
-    };
-    const edits = await vscode.commands.executeCommand<vscode.TextEdit[]>(
-        "vscode.executeFormatDocumentProvider", Uri.file(pomPath), formattingOptions
-    );
-    if (edits && edits.length > 0) {
-        const formatEdit = new WorkspaceEdit();
-        formatEdit.set(Uri.file(pomPath), edits);
-        await workspace.applyEdit(formatEdit);
-        await workspace.openTextDocument(pomPath).then(doc => doc.save());
     }
 }
 


### PR DESCRIPTION
## Purpose
Identifies conflicting entries when adding integration project dependencies, show an error message, and removes existing conflicting entries from pom.xml if present.

Fixes: https://github.com/wso2/mi-vscode/issues/1442

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized CApp resource loader with clear conflict detection and modal details.
  * Typed conflict data drives automatic removal of conflicting entries and view refresh.
  * New document formatting-and-save operation after dependency updates.

* **Bug Fixes**
  * More robust apply-and-save flow when editing project files (now fails fast on apply failure).
  * Improved error handling and clearer user-facing messages during resource loading and dependency refresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->