### PR TITLE
Update test command execution to use quoted shell paths

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/features/test-explorer/runner.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/test-explorer/runner.ts
@@ -28,6 +28,7 @@ const fs = require('fs');
 import path from 'path';
 import { EvaluationReportWebview } from '../../views/evaluation-report/webview';
 import { captureGitState, createSnapshot, pinSnapshot, ensureEvalReportsGitignored } from '../../utils/git-utils';
+import { quoteShellPath } from '../../utils/config';
 
 /**
  * Extract project path from a test item
@@ -120,12 +121,12 @@ function buildTestCommand(test: TestItem, executor: string, projectName: string 
         const testsPart = testCaseNames && testCaseNames.length > 0 ? ` --tests ${testCaseNames.join(',')}` : '';
         const projectPart = projectName ? ` ${projectName}` : '';
         const reportDir = projectName ? `${projectName}/tests/evaluation-reports` : 'tests/evaluation-reports';
-        return `${executor} test --groups ${EVALUATION_GROUP} --test-report --test-report-dir=${reportDir}${testsPart}${projectPart}`;
+        return `${quoteShellPath(executor)} test --groups ${EVALUATION_GROUP} --test-report --test-report-dir=${reportDir}${testsPart}${projectPart}`;
     } else {
         // Standard tests use code coverage and optional test filtering
         const testsPart = testCaseNames && testCaseNames.length > 0 ? ` --tests ${testCaseNames.join(',')}` : '';
         const projectPart = projectName ? ` ${projectName}` : '';
-        return `${executor} test --code-coverage${testsPart}${projectPart}`;
+        return `${quoteShellPath(executor)} test --code-coverage${testsPart}${projectPart}`;
     }
 }
 

--- a/workspaces/ballerina/ballerina-extension/src/features/test-explorer/runner.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/test-explorer/runner.ts
@@ -119,13 +119,13 @@ function buildTestCommand(test: TestItem, executor: string, projectName: string 
         const projectPath = getProjectPathFromTestItem(test);
         if (projectPath) { ensureEvalReportsGitignored(projectPath); }
         const testsPart = testCaseNames && testCaseNames.length > 0 ? ` --tests ${testCaseNames.join(',')}` : '';
-        const projectPart = projectName ? ` ${projectName}` : '';
+        const projectPart = projectName ? ` ${quoteShellPath(projectName)}` : '';
         const reportDir = projectName ? `${projectName}/tests/evaluation-reports` : 'tests/evaluation-reports';
-        return `${quoteShellPath(executor)} test --groups ${EVALUATION_GROUP} --test-report --test-report-dir=${reportDir}${testsPart}${projectPart}`;
+        return `${quoteShellPath(executor)} test --groups ${EVALUATION_GROUP} --test-report --test-report-dir=${quoteShellPath(reportDir)}${testsPart}${projectPart}`;
     } else {
         // Standard tests use code coverage and optional test filtering
         const testsPart = testCaseNames && testCaseNames.length > 0 ? ` --tests ${testCaseNames.join(',')}` : '';
-        const projectPart = projectName ? ` ${projectName}` : '';
+        const projectPart = projectName ? ` ${quoteShellPath(projectName)}` : '';
         return `${quoteShellPath(executor)} test --code-coverage${testsPart}${projectPart}`;
     }
 }


### PR DESCRIPTION
## Purpose

This PR fixes the test explorer not running evals/tests in WSO2 Integrator. It updates the `bal test` invocation to use use quoted shell paths when calling the command.

Fixes https://github.com/wso2/product-integrator/issues/811

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test runner reliability and robustness when executing tests with paths containing special characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->