### PR TITLE
Default CHOICE form to the enabled choice on initial render

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/ChoiceForm.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/ChoiceForm.tsx
@@ -56,19 +56,22 @@ export function ChoiceForm(props: ChoiceFormProps) {
     const { form } = useFormContext();
     const { setValue, clearErrors } = form;
 
-    const [selectedOption, setSelectedOption] = useState<number>(1);
+    const [selectedOption, setSelectedOption] = useState<number>(() => {
+        const idx = field.choices?.findIndex(choice => choice.enabled) ?? -1;
+        return idx !== -1 ? idx + 1 : 1;
+    });
 
     const [dynamicFields, setDynamicFields] = useState<FormField[]>([]);
     const [showAdvancedOptions, setShowAdvancedOptions] = useState<boolean>(false);
 
     useEffect(() => {
-        // Find the first enabled choice
+        // Find the first enabled choice and keep the radio selection + form state in sync
         const enabledChoiceIndex = field.choices.findIndex(choice => choice.enabled);
         if (enabledChoiceIndex !== -1) {
             const newSelectedOption = enabledChoiceIndex + 1;
+            setValue(field.key, enabledChoiceIndex);
             if (newSelectedOption !== selectedOption) {
                 setSelectedOption(newSelectedOption);
-                setValue(field.key, enabledChoiceIndex);
             }
         }
     }, [field.choices]);


### PR DESCRIPTION
selectedOption was hardcoded to 1 on first render, so the radio always showed the first choice ("Create new") until a post-mount useEffect could swap it. For the FTP init second-time flow - where the backend marks "Use existing" as enabled - users saw Create new selected instead of Use existing. Lazy-initialize selectedOption from the enabled choice so the initial render already reflects the backend's selection, and always call setValue in the sync effect so the form field stores the numeric index used by handleOnSubmit (avoiding a string-vs-number mismatch when no state change is needed).

https://github.com/user-attachments/assets/8586971d-422d-46e8-b13f-084f7c62344e

<img width="2138" height="1496" alt="Change-choice" src="https://github.com/user-attachments/assets/56943999-c5ff-4739-b179-068791353acc" />
