### PR TITLE
Derive ICP binary path from WSO2 Integrator extension location

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/features/icp/detect.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/icp/detect.ts
@@ -72,7 +72,7 @@ function getPathFromWIExtension(): string | undefined {
  */
 const BASE_DIRS: Record<string, string[]> = {
     linux: ['/usr/share'],
-    darwin: [path.join(homedir(), 'Applications')],
+    darwin: ['/Applications', path.join(homedir(), 'Applications')],
     win32: [
         path.join(process.env.APPDATA || '', 'WSO2', 'Integrator'),
         path.join(process.env.LOCALAPPDATA || '', 'WSO2', 'Integrator'),

--- a/workspaces/ballerina/ballerina-extension/src/features/icp/detect.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/icp/detect.ts
@@ -19,17 +19,56 @@
 import { existsSync, readdirSync } from 'fs';
 import { homedir } from 'os';
 import * as path from 'path';
-import { workspace, window, commands, ConfigurationTarget, env, Uri } from 'vscode';
+import { workspace, window, commands, extensions, ConfigurationTarget, env, Uri } from 'vscode';
 import { ICP_PATH } from '../../core/preferences';
+import { WI_EXTENSION_ID } from '../../utils/config';
 
 const ICP_BIN_RELATIVE = 'components/icp/bin';
 const ICP_SCRIPT_UNIX = 'icp.sh';
 const ICP_SCRIPT_WIN = 'icp.bat';
 
 /**
+ * Derives the ICP binary path from the WSO2 Integrator extension's install location.
+ * When running inside WSO2 Integrator, the extension is bundled within the installation,
+ * so we can walk up from its extensionPath to find the ICP binary — regardless of where
+ * the user installed the product.
+ *
+ * Expected layout:
+ *   <install-root>/resources/app/extensions/<ext-id>/  ← extensionPath
+ *   <install-root>/components/icp/bin/icp.sh           ← what we want
+ *
+ * On macOS the install root is inside the .app bundle:
+ *   <...>/WSO2 Integrator.app/Contents/resources/app/extensions/<ext-id>/
+ *   <...>/WSO2 Integrator.app/Contents/components/icp/bin/icp.sh
+ */
+function getPathFromWIExtension(): string | undefined {
+    const wiExt = extensions.getExtension(WI_EXTENSION_ID);
+    if (!wiExt) {
+        return undefined;
+    }
+
+    const script = process.platform === 'win32' ? ICP_SCRIPT_WIN : ICP_SCRIPT_UNIX;
+
+    // Walk up from extensionPath to the installation root.
+    // extensionPath is typically: <install-root>/resources/app/extensions/<ext-id>
+    // We need to go up 4 levels to reach <install-root>.
+    let dir = wiExt.extensionPath;
+    for (let i = 0; i < 4; i++) {
+        dir = path.dirname(dir);
+    }
+
+    const candidatePath = path.join(dir, ICP_BIN_RELATIVE, script);
+    if (existsSync(candidatePath)) {
+        return candidatePath;
+    }
+
+    return undefined;
+}
+
+/**
  * Default base directories where WSO2 Integrator is installed per OS.
- * The integrator directory name may include a version suffix (e.g., wso2-integrator-1.0.0),
- * so we search within these base directories for a matching folder.
+ * Used as a fallback when the ICP path cannot be derived from the running
+ * WSO2 Integrator extension (e.g., standalone VS Code with ICP installed separately).
  */
 const BASE_DIRS: Record<string, string[]> = {
     linux: ['/usr/share'],
@@ -42,6 +81,13 @@ const BASE_DIRS: Record<string, string[]> = {
 };
 
 function getDefaultPath(): string | undefined {
+    // Try to derive path from the running WSO2 Integrator extension first
+    const wiPath = getPathFromWIExtension();
+    if (wiPath) {
+        return wiPath;
+    }
+
+    // Fallback: scan well-known install directories
     const script = process.platform === 'win32' ? ICP_SCRIPT_WIN : ICP_SCRIPT_UNIX;
     const baseDirs = BASE_DIRS[process.platform];
     if (!baseDirs) {


### PR DESCRIPTION
## Summary
- Derive the ICP binary path from the `wso2.wso2-integrator` extension's install location by walking up 4 levels from its `extensionPath` to the install root, then appending `components/icp/bin/icp.{sh,bat}`.
- Works regardless of where the user installs WSO2 Integrator on macOS, Linux, and Windows — no hardcoded install paths.
- Retains the existing hardcoded directory scan as a fallback for standalone VS Code setups where ICP is installed separately.

## Verified layouts
- macOS: `/Applications/WSO2 Integrator.app/Contents/components/icp/bin/icp.sh`
- Linux: `/usr/share/wso2-integrator/components/icp/bin/icp.sh`
- Windows: `C:\Users\<user>\AppData\Roaming\WSO2\Integrator\components\icp\bin\icp.bat`

All three follow the same `<install-root>/resources/app/extensions/<ext-id>` → `<install-root>/components/icp/bin/` relative layout.

## Test plan
- [ ] Install WSO2 Integrator to the default location on macOS — ICP path auto-detects to `/Applications/WSO2 Integrator.app/Contents/components/icp/bin/icp.sh`
- [ ] Install WSO2 Integrator to a custom location on macOS — ICP path still auto-detects correctly
- [ ] Install WSO2 Integrator on Linux — ICP path auto-detects to `/usr/share/wso2-integrator/components/icp/bin/icp.sh`
- [ ] Install WSO2 Integrator on Windows — ICP path auto-detects to `%APPDATA%\WSO2\Integrator\components\icp\bin\icp.bat`
- [ ] Standalone VS Code (no WI extension) — fallback directory scan still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Integrator Configuration Platform (ICP) detection: the extension now prefers locating ICP via the installed WSO2 Integrator extension for faster, more reliable discovery. If not found, it falls back to scanning standard OS install locations (macOS scanning includes both /Applications and ~/Applications).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->