### PR TITLE
Fix bug in migration ai agent resume functionality

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/features/ai/migration/orchestrator.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/migration/orchestrator.ts
@@ -554,6 +554,22 @@ async function runStagesForPackage(opts: StageRunnerOpts): Promise<void> {
 
         // Start transcript recording for this stage
         const isWorkspaceValidation = stageIdPrefix.includes("workspace-validation");
+
+        // Skip stages already fully completed in a previous run
+        if (transcriptWriter?.isStageCompleted(packageRelPath ?? "", i, isWorkspaceValidation)) {
+            console.log(`[MigrationEnhancement] Skipping already-completed stage: ${stage.name}`);
+            eventHandler({ type: "content_block", content: `\n\n---\n\n⏭️ **${stage.name}** already completed — skipping.\n\n` });
+            continue;
+        }
+
+        // For partially-completed stages, inject transcript content as a resume preamble
+        const partialTranscript = transcriptWriter?.readStageTranscript(packageRelPath ?? "", i, isWorkspaceValidation);
+        if (partialTranscript) {
+            const resumeHeader = `## ⚠️ STAGE RESUME — Previous partial work is shown below. Continue from where it left off.\n\n`;
+            stages[i] = { ...stages[i], prompt: resumeHeader + partialTranscript + "\n\n---\n\n" + stages[i].prompt };
+            console.log(`[MigrationEnhancement] Injected partial transcript for resume: ${stage.name}`);
+        }
+
         if (transcriptWriter) {
             transcriptWriter.startStage(packageRelPath ?? "", i, stage.name, isWorkspaceValidation);
         }

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/migration/transcript-writer.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/migration/transcript-writer.ts
@@ -245,6 +245,38 @@ export class TranscriptWriter {
 
     // ── Helpers ──────────────────────────────────────────────────────────────
 
+    private buildStageFilePath(packageRelPath: string, stageIndex: number, isWorkspaceValidation: boolean): string {
+        const dir = packageRelPath
+            ? path.join(this.transcriptDir, packageRelPath)
+            : this.transcriptDir;
+        const filename = isWorkspaceValidation ? "workspace-validation.md" : `stage${stageIndex + 1}.md`;
+        return path.join(dir, filename);
+    }
+
+    /**
+     * Returns true if the stage transcript file exists and contains a completion marker.
+     */
+    isStageCompleted(packageRelPath: string, stageIndex: number, isWorkspaceValidation = false): boolean {
+        try {
+            const filePath = this.buildStageFilePath(packageRelPath, stageIndex, isWorkspaceValidation);
+            if (!fs.existsSync(filePath)) { return false; }
+            const content = fs.readFileSync(filePath, "utf8");
+            return content.includes("_Completed:");
+        } catch { return false; }
+    }
+
+    /**
+     * Returns the transcript file content for a stage, or null if not found.
+     * Used to inject partial work as a resume preamble when the stage was interrupted.
+     */
+    readStageTranscript(packageRelPath: string, stageIndex: number, isWorkspaceValidation = false): string | null {
+        try {
+            const filePath = this.buildStageFilePath(packageRelPath, stageIndex, isWorkspaceValidation);
+            if (!fs.existsSync(filePath)) { return null; }
+            return fs.readFileSync(filePath, "utf8");
+        } catch { return null; }
+    }
+
     private listStageFiles(dir: string): string[] {
         try {
             if (!fs.existsSync(dir)) { return []; }


### PR DESCRIPTION
## Purpose
$subject. Fix will start the agent from where it was paused exactly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Migration processes now support resuming from partial progress after interruptions, preserving previous work
  * Completed stages are automatically detected and skipped to avoid redundant processing
  * Partial transcript data from previous executions is reused for seamless stage continuation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->