### PR TITLE
Add confirmation modal for agent node deletion with option to remove initialization

### DIFF
--- a/workspaces/ballerina/ballerina-core/src/rpc-types/common/interfaces.ts
+++ b/workspaces/ballerina/ballerina-core/src/rpc-types/common/interfaces.ts
@@ -96,6 +96,7 @@ export interface ShowErrorMessageRequest {
 
 export interface ShowInfoModalRequest {
     message: string;
+    detail?: string;
     items?: string[];
 }
 

--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/common/rpc-manager.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/common/rpc-manager.ts
@@ -301,7 +301,7 @@ export class CommonRpcManager implements CommonRPCAPI {
     }
 
     async showInformationModal(params: ShowInfoModalRequest): Promise<string> {
-        return window.showInformationMessage(params?.message, {modal: true}, ...(params?.items || []));
+        return window.showInformationMessage(params?.message, {modal: true, detail: params?.detail}, ...(params?.items || []));
     }
 
     async showQuickPick(params: ShowQuickPickRequest): Promise<QuickPickItem> {

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/AIChatAgent/utils.ts
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/AIChatAgent/utils.ts
@@ -513,8 +513,9 @@ export const confirmAgentCallDeletion = async (
     const DELETE_AGENT = "Delete Agent";
 
     const userChoice = await rpcClient.getCommonRpcClient().showInformationModal({
-        message:
-            "Removing this node only deletes it from the current diagram. The agent will remain in your project and can be reused elsewhere. Do you want to delete the agent itself as well?",
+        message: "Delete Agent Node?",
+        detail:
+            "Remove this node from the current diagram, or delete the agent entirely from the project.\n\nDeleting the agent will remove its initialization and make it unavailable for reuse.",
         items: [REMOVE_NODE_ONLY, DELETE_AGENT],
     });
 

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/AIChatAgent/utils.ts
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/AIChatAgent/utils.ts
@@ -504,6 +504,27 @@ export const removeMcpServerFromAgentNode = (
     return updatedAgentNode;
 };
 
+// Prompts the user to choose between deleting only the agent call node or also the agent itself.
+// Returns null if the user cancels the modal.
+export const confirmAgentCallDeletion = async (
+    rpcClient: BallerinaRpcClient
+): Promise<{ shouldDeleteAgent: boolean } | null> => {
+    const REMOVE_NODE_ONLY = "Remove This Node Only";
+    const DELETE_AGENT = "Delete Agent";
+
+    const userChoice = await rpcClient.getCommonRpcClient().showInformationModal({
+        message:
+            "Removing this node only deletes it from the current diagram. The agent will remain in your project and can be reused elsewhere. Do you want to delete the agent itself as well?",
+        items: [REMOVE_NODE_ONLY, DELETE_AGENT],
+    });
+
+    if (!userChoice) {
+        return null;
+    }
+
+    return { shouldDeleteAgent: userChoice === DELETE_AGENT };
+};
+
 // remove agent node, model node when removing ag
 export const removeAgentNode = async (agentCallNode: FlowNode, rpcClient: BallerinaRpcClient): Promise<boolean> => {
     if (!agentCallNode || agentCallNode.codedata?.node !== "AGENT_CALL") return false;

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
@@ -1803,7 +1803,10 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
         await updateArtifactLocation(deleteNodeResponse);
 
         if (shouldDeleteAgent) {
-            await removeAgentNode(node, rpcClient);
+            const isAgentRemoved = await removeAgentNode(node, rpcClient);
+            if (!isAgentRemoved) {
+                console.error(">>> Failed to remove agent node after deleting agent call");
+            }
         }
 
         selectedNodeRef.current = undefined;

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
@@ -20,7 +20,7 @@ import { useEffect, useRef, useState, useMemo, useCallback } from "react";
 import { TraceAnimationEvent } from "@wso2/ballerina-core";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import styled from "@emotion/styled";
-import { removeMcpServerFromAgentNode, findAgentNodeFromAgentCallNode, findFlowNode } from "../AIChatAgent/utils";
+import { removeMcpServerFromAgentNode, findAgentNodeFromAgentCallNode, findFlowNode, removeAgentNode, confirmAgentCallDeletion } from "../AIChatAgent/utils";
 import { MemoizedDiagram, setTraceAnimationActive, setTraceAnimationInactive } from "@wso2/bi-diagram";
 import {
     BIAvailableNodesRequest,
@@ -1781,6 +1781,15 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
     }
 
     const handleOnDeleteNode = async (node: FlowNode) => {
+        let shouldDeleteAgent = false;
+        if (node.codedata?.node === "AGENT_CALL") {
+            const result = await confirmAgentCallDeletion(rpcClient);
+            if (!result) {
+                return;
+            }
+            shouldDeleteAgent = result.shouldDeleteAgent;
+        }
+
         setShowProgressIndicator(true);
 
         const deleteNodeResponse = await rpcClient.getBIDiagramRpcClient().deleteFlowNode({
@@ -1792,6 +1801,10 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
         }
 
         await updateArtifactLocation(deleteNodeResponse);
+
+        if (shouldDeleteAgent) {
+            await removeAgentNode(node, rpcClient);
+        }
 
         selectedNodeRef.current = undefined;
         closeSidePanelAndFetchUpdatedFlowModel();

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/FunctionForm/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/FunctionForm/index.tsx
@@ -326,6 +326,8 @@ export function FunctionForm(props: FunctionFormProps) {
                 });
                 fields.push(...oauthFields);
                 oauthSupported = oauthFields.length > 0;
+            } else if (!cancelled) {
+                setIsLoading(false);
             }
 
             if (!cancelled) {

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/FunctionForm/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/FunctionForm/index.tsx
@@ -290,10 +290,13 @@ export function FunctionForm(props: FunctionFormProps) {
             let oauthSupported = false;
             if (isAgentTool || isExistingAgentTool) {
                 let oauthProperties: Awaited<ReturnType<typeof fetchOAuthConfigProperties>> = [];
+                setIsLoading(true);
                 try {
                     oauthProperties = await fetchOAuthConfigProperties(rpcClient, filePath);
                 } catch (error) {
                     console.error("Failed to fetch OAuth config properties:", error);
+                } finally {
+                    if (!cancelled) setIsLoading(false);
                 }
                 if (cancelled) return;
                 oauthConfigPropertiesRef.current = oauthProperties;


### PR DESCRIPTION
## Purpose

Fixes https://github.com/wso2/product-integrator/issues/797

This PR introduces a confirmation modal when deleting an agent node. The modal allows users to choose between:
- Deleting only the agent call node in the current diagram
- Deleting both the agent call node and its associated initialization

https://github.com/user-attachments/assets/bf9545d1-d163-4c04-bba0-6a703b890a1a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added confirmation dialog when deleting AI agent nodes, allowing users to choose between removing just the node or deleting the entire agent.

* **Improvements**
  * Enhanced loading state handling during OAuth configuration retrieval for agent tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->