### PR TITLE
feat: separate LS download from build, add release.properties

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -6,9 +6,6 @@ inputs:
   enableCache:
     default: true
     type: boolean
-  enableLSCache:
-    default: false
-    type: boolean
   ballerinaLSTag:
     description: 'Override LS tag (latest, prerelease, or specific tag like v1.8.0.m1). If empty, reads from release.properties.'
     default: ''
@@ -203,31 +200,8 @@ runs:
           exit 1
         fi
         printf 'tag=%s\n' "$TAG" >> "$GITHUB_OUTPUT"
-        if [ "$TAG" = "latest" ] || [ "$TAG" = "prerelease" ]; then
-          echo "cacheable=false" >> "$GITHUB_OUTPUT"
-        else
-          echo "cacheable=true" >> "$GITHUB_OUTPUT"
-        fi
       env:
         OVERRIDE_TAG: ${{ inputs.ballerinaLSTag }}
-
-    - name: Restore Ballerina LS from cache
-      id: ballerina-ls-cache
-      if: ${{ inputs.enableLSCache == 'true' && steps.bal-ls-version.outputs.cacheable == 'true' }}
-      uses: actions/cache@v4
-      with:
-        path: workspaces/ballerina/ballerina-extension/ls
-        key: ballerina-ls-${{ steps.bal-ls-version.outputs.tag }}
-        retention-days: 1
-
-    - name: Download Ballerina LS
-      if: ${{ steps.bal-ls-version.outputs.cacheable != 'true' || steps.ballerina-ls-cache.outputs.cache-hit != 'true' }}
-      shell: bash
-      run: |
-        pnpm --dir workspaces/ballerina/ballerina-extension run download-ls -- --tag "$LS_TAG" --replace
-      env:
-        LS_TAG: ${{ steps.bal-ls-version.outputs.tag }}
-        GITHUB_TOKEN: ${{ inputs.token }}
 
     - name: Build repo
       shell: bash
@@ -236,6 +210,8 @@ runs:
         node common/scripts/install-run-rush.js build --verbose
       env:
         isPreRelease: ${{ inputs.isPreRelease == 'true' }}
+        BALLERINA_LS_TAG: ${{ steps.bal-ls-version.outputs.tag }}
+        GITHUB_TOKEN: ${{ inputs.token }}
         BALLERINA_AUTH_ORG: ${{ inputs.BALLERINA_AUTH_ORG }}
         BALLERINA_AUTH_CLIENT_ID: ${{ inputs.BALLERINA_AUTH_CLIENT_ID }}
         BALLERINA_DEV_COPLIOT_ROOT_URL: ${{ inputs.BALLERINA_DEV_COPLIOT_ROOT_URL }}

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -202,13 +202,18 @@ runs:
           echo "::error::ls.tag is empty in release.properties. Please set a valid tag (e.g., latest, prerelease, or v1.8.0.m1)."
           exit 1
         fi
-        echo "tag=$TAG" >> $GITHUB_OUTPUT
+        printf 'tag=%s\n' "$TAG" >> "$GITHUB_OUTPUT"
+        if [ "$TAG" = "latest" ] || [ "$TAG" = "prerelease" ]; then
+          echo "cacheable=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "cacheable=true" >> "$GITHUB_OUTPUT"
+        fi
       env:
         OVERRIDE_TAG: ${{ inputs.ballerinaLSTag }}
 
     - name: Restore Ballerina LS from cache
       id: ballerina-ls-cache
-      if: ${{ inputs.enableLSCache == 'true' }}
+      if: ${{ inputs.enableLSCache == 'true' && steps.bal-ls-version.outputs.cacheable == 'true' }}
       uses: actions/cache@v4
       with:
         path: workspaces/ballerina/ballerina-extension/ls
@@ -216,7 +221,7 @@ runs:
         retention-days: 1
 
     - name: Download Ballerina LS
-      if: ${{ steps.ballerina-ls-cache.outputs.cache-hit != 'true' }}
+      if: ${{ steps.bal-ls-version.outputs.cacheable != 'true' || steps.ballerina-ls-cache.outputs.cache-hit != 'true' }}
       shell: bash
       run: |
         pnpm --dir workspaces/ballerina/ballerina-extension run download-ls -- --tag "$LS_TAG" --replace

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -9,6 +9,10 @@ inputs:
   enableLSCache:
     default: false
     type: boolean
+  ballerinaLSTag:
+    description: 'Override LS tag (latest, prerelease, or specific tag like v1.8.0.m1). If empty, reads from release.properties.'
+    default: ''
+    type: string
   ballerina:
     description: Update Ballerina extension version
     type: boolean
@@ -154,6 +158,14 @@ runs:
         isPreRelease: ${{ inputs.isPreRelease }}
         version: ${{ inputs.version }}
 
+    - name: Update version - Hurl Client
+      if: ${{ inputs.hurl-client == 'true' }}
+      uses: ./.github/actions/updateVersion
+      with:
+        path: "hurl-client/hurl-client-extension"
+        isPreRelease: ${{ inputs.isPreRelease }}
+        version: ${{ inputs.version }}
+
     - name: Copy .env.example to .env
       shell: bash
       run: |
@@ -171,14 +183,46 @@ runs:
         key: mi-ls
         retention-days: 1
 
+    - name: Read Ballerina LS version
+      id: bal-ls-version
+      shell: bash
+      run: |
+        LS_PROPS="workspaces/ballerina/ballerina-extension/release.properties"
+        if [ -n "$OVERRIDE_TAG" ]; then
+          TAG="$OVERRIDE_TAG"
+          echo "Using override LS tag: $TAG"
+        elif [ -f "$LS_PROPS" ]; then
+          TAG=$(grep '^ls\.tag=' "$LS_PROPS" | cut -d'=' -f2 | tr -d '[:space:]')
+          echo "Using LS tag from release.properties: $TAG"
+        else
+          TAG="latest"
+          echo "release.properties not found, defaulting to latest"
+        fi
+        if [ -z "$TAG" ]; then
+          echo "::error::ls.tag is empty in release.properties. Please set a valid tag (e.g., latest, prerelease, or v1.8.0.m1)."
+          exit 1
+        fi
+        echo "tag=$TAG" >> $GITHUB_OUTPUT
+      env:
+        OVERRIDE_TAG: ${{ inputs.ballerinaLSTag }}
+
     - name: Restore Ballerina LS from cache
       id: ballerina-ls-cache
       if: ${{ inputs.enableLSCache == 'true' }}
       uses: actions/cache@v4
       with:
         path: workspaces/ballerina/ballerina-extension/ls
-        key: ballerina-ls
+        key: ballerina-ls-${{ steps.bal-ls-version.outputs.tag }}
         retention-days: 1
+
+    - name: Download Ballerina LS
+      if: ${{ steps.ballerina-ls-cache.outputs.cache-hit != 'true' }}
+      shell: bash
+      run: |
+        pnpm --dir workspaces/ballerina/ballerina-extension run download-ls -- --tag "$LS_TAG" --replace
+      env:
+        LS_TAG: ${{ steps.bal-ls-version.outputs.tag }}
+        GITHUB_TOKEN: ${{ inputs.token }}
 
     - name: Build repo
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -204,7 +204,6 @@ jobs:
         with:
           isPreRelease: ${{ inputs.isPreRelease }}
           enableCache: ${{ inputs.enableCache }}
-          enableLSCache: ${{ !inputs.isReleaseBuild }}
           ballerina: ${{ inputs.ballerina }}
           choreo: ${{ inputs.choreo }}
           wso2-platform: ${{ inputs.wso2-platform }}

--- a/workspaces/ballerina/ballerina-extension/DEVELOPMENT_SETUP.md
+++ b/workspaces/ballerina/ballerina-extension/DEVELOPMENT_SETUP.md
@@ -1,0 +1,71 @@
+# Ballerina Extension Development Setup
+
+## Initial Setup
+
+Run `rush install` once after cloning the repository to install dependencies and set up the workspace.
+
+## Build
+
+Use `rush build` for a full build of the repository.
+
+To build only the Ballerina package, run:
+
+```bash
+rush build -t ballerina
+```
+
+## Language Server
+
+The Ballerina language server is **not downloaded automatically** during `rush build`. Before building the extension, download the bundled language server into `workspaces/ballerina/ballerina-extension/ls`:
+
+```bash
+pnpm --dir workspaces/ballerina/ballerina-extension run download-ls
+```
+
+To download a specific version by Git tag:
+
+```bash
+pnpm --dir workspaces/ballerina/ballerina-extension run download-ls -- --tag v1.8.0.m1 --replace
+```
+
+To download the latest prerelease:
+
+```bash
+pnpm --dir workspaces/ballerina/ballerina-extension run download-ls -- --tag prerelease --replace
+```
+
+The `--replace` flag clears the existing `ls/` directory before downloading.
+
+The build will fail with a clear message if the `ls` directory does not contain a `ballerina-language-server*.jar`.
+
+## CI/CD Pipeline Configuration
+
+Pipelines read configuration from `release.properties` in this directory:
+
+```properties
+# Language server tag
+ls.tag=latest
+# Product-integrator branch for version update PRs (leave empty to skip)
+integrator.branch=
+```
+
+To pin a specific LS version for a branch, update `ls.tag`:
+
+```properties
+ls.tag=v1.8.0.m1
+```
+
+To enable automatic PRs to product-integrator after daily builds, set the target branch:
+
+```properties
+integrator.branch=5.0.x
+```
+
+## BI End-to-End Tests
+
+BI Playwright tests are located in `e2e-test/e2e-playwright-tests`.
+
+From this directory (`workspaces/ballerina/ballerina-extension`):
+
+- Run `pnpm run e2e-test:bi` to execute BI Playwright tests.
+- Run `pnpm run e2e-test:bi:download-prerelease` to run BI tests after downloading prerelease VSIXs.

--- a/workspaces/ballerina/ballerina-extension/package.json
+++ b/workspaces/ballerina/ballerina-extension/package.json
@@ -1427,11 +1427,10 @@
         "copyVSIX": "copyfiles *.vsix ./vsix",
         "copyVSIXToRoot": "copyfiles -f ./vsix/*.vsix ../../..",
         "download-ls": "node scripts/download-ls.js",
-        "download-ls:prerelease": "node scripts/download-ls.js --prerelease --replace",
-        "verify-ls": "node scripts/verify-ls.js",
-        "build": "pnpm run verify-ls && pnpm run compile && pnpm run lint && pnpm run postbuild",
-        "rebuild": "pnpm run verify-ls && pnpm run clean && pnpm run compile && pnpm run postbuild",
-        "postbuild": "pnpm run copyFonts && pnpm run copyJSLibs && pnpm run package && pnpm run copyVSIX",
+        "download-ls:prerelease": "node scripts/download-ls.js --tag prerelease --replace",
+        "build": "pnpm run compile && pnpm run lint && pnpm run postbuild",
+        "rebuild": "pnpm run clean && pnpm run compile && pnpm run postbuild",
+        "postbuild": "pnpm run download-ls && pnpm run copyFonts && pnpm run copyJSLibs && pnpm run package && pnpm run copyVSIX",
         "copyJSLibs": "copyfiles -f ../ballerina-visualizer/build/*.js resources/jslibs && copyfiles -f ../ballerina-visualizer/build/images/* resources/jslibs/images && copyfiles -f ../trace-visualizer/build/*.js resources/jslibs"
     },
     "dependencies": {

--- a/workspaces/ballerina/ballerina-extension/package.json
+++ b/workspaces/ballerina/ballerina-extension/package.json
@@ -1428,9 +1428,10 @@
         "copyVSIXToRoot": "copyfiles -f ./vsix/*.vsix ../../..",
         "download-ls": "node scripts/download-ls.js",
         "download-ls:prerelease": "node scripts/download-ls.js --prerelease --replace",
-        "build": "pnpm run compile && pnpm run lint && pnpm run postbuild",
-        "rebuild": "pnpm run clean && pnpm run compile && pnpm run postbuild",
-        "postbuild": "pnpm run download-ls && pnpm run copyFonts && pnpm run copyJSLibs && pnpm run package && pnpm run copyVSIX",
+        "verify-ls": "node scripts/verify-ls.js",
+        "build": "pnpm run verify-ls && pnpm run compile && pnpm run lint && pnpm run postbuild",
+        "rebuild": "pnpm run verify-ls && pnpm run clean && pnpm run compile && pnpm run postbuild",
+        "postbuild": "pnpm run copyFonts && pnpm run copyJSLibs && pnpm run package && pnpm run copyVSIX",
         "copyJSLibs": "copyfiles -f ../ballerina-visualizer/build/*.js resources/jslibs && copyfiles -f ../ballerina-visualizer/build/images/* resources/jslibs/images && copyfiles -f ../trace-visualizer/build/*.js resources/jslibs"
     },
     "dependencies": {

--- a/workspaces/ballerina/ballerina-extension/release.properties
+++ b/workspaces/ballerina/ballerina-extension/release.properties
@@ -1,0 +1,5 @@
+# CI/CD pipeline configuration for Ballerina extension.
+# Language server: "latest", "prerelease", or specific Git tag (e.g., v1.8.0.m1).
+ls.tag=v1.7.0.alpha6
+# Product-integrator branch for version update PRs. Leave empty to skip.
+integrator.branch=5.0.x

--- a/workspaces/ballerina/ballerina-extension/scripts/download-ls.js
+++ b/workspaces/ballerina/ballerina-extension/scripts/download-ls.js
@@ -258,8 +258,11 @@ async function main() {
             return tag.startsWith('v') ? tag.slice(1) : tag;
         }
 
-        if (!forceReplace && checkExistingJar(getExpectedVersion(requestedTag))) {
-            process.exit(0);
+        // For concrete tags, check if the version already exists before fetching release info
+        if (!forceReplace && requestedTag && requestedTag !== 'latest' && requestedTag !== 'prerelease') {
+            if (checkExistingJar(getExpectedVersion(requestedTag))) {
+                process.exit(0);
+            }
         }
 
         const releaseLabel = requestedTag
@@ -278,6 +281,16 @@ async function main() {
 
         console.log('Fetching release information...');
         const releaseData = await getLatestRelease(usePrerelease);
+
+        // For floating tags, check if the concrete version already exists
+        if (!forceReplace && (!requestedTag || requestedTag === 'latest' || requestedTag === 'prerelease')) {
+            const concreteVersion = releaseData.tag_name.startsWith('v') 
+                ? releaseData.tag_name.slice(1) 
+                : releaseData.tag_name;
+            if (checkExistingJar(concreteVersion)) {
+                process.exit(0);
+            }
+        }
 
         const jarAsset = releaseData.assets?.find(asset =>
             asset.name.includes('ballerina-language-server-') &&

--- a/workspaces/ballerina/ballerina-extension/scripts/download-ls.js
+++ b/workspaces/ballerina/ballerina-extension/scripts/download-ls.js
@@ -192,7 +192,14 @@ async function getLatestRelease(usePrerelease) {
         }
     }
 
-    const effectivePrerelease = (requestedTag === 'prerelease') || usePrerelease;
+    const effectivePrerelease = requestedTag
+        ? requestedTag === 'prerelease'
+        : usePrerelease;
+    
+    // Warn if env var conflicts with explicit --tag argument
+    if (requestedTag && requestedTag !== 'prerelease' && usePrerelease) {
+        console.warn(`Warning: --tag ${requestedTag} specified but isPreRelease=true in environment. Using --tag value.`);
+    }
 
     if (effectivePrerelease) {
         // Get all releases and find the latest prerelease
@@ -234,8 +241,10 @@ async function getLatestRelease(usePrerelease) {
 
 async function main() {
     try {
-        if (requestedTag && requestedTag !== 'latest' && requestedTag !== 'prerelease' && usePrerelease) {
-            throw new Error('Use either --prerelease or --tag <specific-tag>, not both');
+        // If an explicit --tag was provided, it takes precedence (validation happens in effectivePrerelease logic above)
+        if (!requestedTag && usePrerelease) {
+            // No explicit tag, falling back to isPreRelease env var
+            console.log('Using isPreRelease env var');
         }
 
         if (tagIndex >= 0 && !requestedTag) {

--- a/workspaces/ballerina/ballerina-extension/scripts/download-ls.js
+++ b/workspaces/ballerina/ballerina-extension/scripts/download-ls.js
@@ -9,7 +9,6 @@ const LS_DIR = path.join(PROJECT_ROOT, 'ls');
 const GITHUB_REPO_URL = 'https://api.github.com/repos/ballerina-platform/ballerina-language-server';
 
 const args = process.argv.slice(2);
-const usePrerelease = args.includes('--prerelease') || process.env.isPreRelease === 'true';
 const forceReplace = args.includes('--replace');
 
 const tagIndex = args.indexOf('--tag');
@@ -27,7 +26,8 @@ function getTagValue(cliArgs, index) {
     return value;
 }
 
-const requestedTag = getTagValue(args, tagIndex);
+// Tag resolution priority: --tag flag > BALLERINA_LS_TAG env var > default (latest)
+const requestedTag = getTagValue(args, tagIndex) || process.env.BALLERINA_LS_TAG || undefined;
 
 function checkExistingJar(expectedVersion) {
     try {
@@ -182,7 +182,7 @@ function getFileSize(filePath) {
     }
 }
 
-async function getLatestRelease(usePrerelease) {
+async function getLatestRelease() {
     if (requestedTag && requestedTag !== 'latest' && requestedTag !== 'prerelease') {
         const releaseResponse = await httpsRequest(`${GITHUB_REPO_URL}/releases/tags/${encodeURIComponent(requestedTag)}`);
         try {
@@ -192,16 +192,7 @@ async function getLatestRelease(usePrerelease) {
         }
     }
 
-    const effectivePrerelease = requestedTag
-        ? requestedTag === 'prerelease'
-        : usePrerelease;
-    
-    // Warn if env var conflicts with explicit --tag argument
-    if (requestedTag && requestedTag !== 'prerelease' && usePrerelease) {
-        console.warn(`Warning: --tag ${requestedTag} specified but isPreRelease=true in environment. Using --tag value.`);
-    }
-
-    if (effectivePrerelease) {
+    if (requestedTag === 'prerelease') {
         // Get all releases and find the latest prerelease
         const releasesResponse = await httpsRequest(`${GITHUB_REPO_URL}/releases`);
         let releases;
@@ -241,13 +232,7 @@ async function getLatestRelease(usePrerelease) {
 
 async function main() {
     try {
-        // If an explicit --tag was provided, it takes precedence (validation happens in effectivePrerelease logic above)
-        if (!requestedTag && usePrerelease) {
-            // No explicit tag, falling back to isPreRelease env var
-            console.log('Using isPreRelease env var');
-        }
-
-        if (tagIndex >= 0 && !requestedTag) {
+        if (tagIndex >= 0 && !getTagValue(args, tagIndex)) {
             throw new Error('Missing value for --tag');
         }
 
@@ -265,9 +250,7 @@ async function main() {
             }
         }
 
-        const releaseLabel = requestedTag
-            ? ` (tag: ${requestedTag})`
-            : (usePrerelease ? ' (prerelease)' : '');
+        const releaseLabel = requestedTag ? ` (tag: ${requestedTag})` : '';
         console.log(`Downloading Ballerina language server${releaseLabel}${forceReplace ? ' (force replace)' : ''}...`);
 
         if (forceReplace && fs.existsSync(LS_DIR)) {
@@ -280,7 +263,7 @@ async function main() {
         }
 
         console.log('Fetching release information...');
-        const releaseData = await getLatestRelease(usePrerelease);
+        const releaseData = await getLatestRelease();
 
         if (!releaseData?.tag_name) {
             throw new Error('Invalid release data: missing tag_name');

--- a/workspaces/ballerina/ballerina-extension/scripts/download-ls.js
+++ b/workspaces/ballerina/ballerina-extension/scripts/download-ls.js
@@ -12,7 +12,24 @@ const args = process.argv.slice(2);
 const usePrerelease = args.includes('--prerelease') || process.env.isPreRelease === 'true';
 const forceReplace = args.includes('--replace');
 
-function checkExistingJar() {
+const tagIndex = args.indexOf('--tag');
+
+function getTagValue(cliArgs, index) {
+    if (index < 0) {
+        return undefined;
+    }
+
+    const value = cliArgs[index + 1];
+    if (!value || value.startsWith('-')) {
+        return undefined;
+    }
+
+    return value;
+}
+
+const requestedTag = getTagValue(args, tagIndex);
+
+function checkExistingJar(expectedVersion) {
     try {
         if (!fs.existsSync(LS_DIR)) {
             return false;
@@ -21,11 +38,22 @@ function checkExistingJar() {
         const files = fs.readdirSync(LS_DIR);
         const jarFiles = files.filter(file => file.includes('ballerina-language-server-') && file.endsWith('.jar'));
 
-        if (jarFiles.length > 0) {
+        if (jarFiles.length === 0) {
+            return false;
+        }
+
+        if (!expectedVersion) {
             console.log(`Ballerina language server JAR already exists in ${path.relative(PROJECT_ROOT, LS_DIR)}`);
             return true;
         }
 
+        const expectedJar = jarFiles.find(file => file === `ballerina-language-server-${expectedVersion}.jar`);
+        if (expectedJar) {
+            console.log(`Ballerina language server JAR for version ${expectedVersion} already exists in ${path.relative(PROJECT_ROOT, LS_DIR)}`);
+            return true;
+        }
+
+        console.log(`Existing language server JAR does not match requested version ${expectedVersion}; downloading requested version.`);
         return false;
     } catch (error) {
         console.error('Error checking existing JAR files:', error.message);
@@ -33,14 +61,21 @@ function checkExistingJar() {
     }
 }
 
+function getAuthHeader() {
+    if (process.env.CHOREO_BOT_TOKEN) {
+        return { Authorization: `Bearer ${process.env.CHOREO_BOT_TOKEN}` };
+    }
+
+    if (process.env.GITHUB_TOKEN) {
+        return { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` };
+    }
+
+    return {};
+}
+
 function httpsRequest(url, options = {}) {
     return new Promise((resolve, reject) => {
-        const authHeader = {};
-        if (process.env.CHOREO_BOT_TOKEN) {
-            authHeader['Authorization'] = `Bearer ${process.env.CHOREO_BOT_TOKEN}`;
-        } else if (process.env.GITHUB_TOKEN) {
-            authHeader['Authorization'] = `Bearer ${process.env.GITHUB_TOKEN}`;
-        }
+        const authHeader = getAuthHeader();
 
         const req = https.request(url, {
             ...options,
@@ -90,7 +125,8 @@ function downloadFile(url, outputPath, maxRedirects = 5) {
             const req = https.request(requestUrl, {
                 headers: {
                     'User-Agent': 'Ballerina-LS-Downloader',
-                    'Accept': 'application/octet-stream'
+                    'Accept': 'application/octet-stream',
+                    ...getAuthHeader()
                 }
             }, (res) => {
                 if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
@@ -147,7 +183,18 @@ function getFileSize(filePath) {
 }
 
 async function getLatestRelease(usePrerelease) {
-    if (usePrerelease) {
+    if (requestedTag && requestedTag !== 'latest' && requestedTag !== 'prerelease') {
+        const releaseResponse = await httpsRequest(`${GITHUB_REPO_URL}/releases/tags/${encodeURIComponent(requestedTag)}`);
+        try {
+            return JSON.parse(releaseResponse.data);
+        } catch (error) {
+            throw new Error(`Failed to parse release information JSON for tag ${requestedTag}`);
+        }
+    }
+
+    const effectivePrerelease = (requestedTag === 'prerelease') || usePrerelease;
+
+    if (effectivePrerelease) {
         // Get all releases and find the latest prerelease
         const releasesResponse = await httpsRequest(`${GITHUB_REPO_URL}/releases`);
         let releases;
@@ -166,23 +213,50 @@ async function getLatestRelease(usePrerelease) {
         }
         return prerelease;
     } else {
-        // Get the latest stable release
-        const releaseResponse = await httpsRequest(`${GITHUB_REPO_URL}/releases/latest`);
+        // Get the latest stable release; fall back to newest release if none is marked stable
         try {
+            const releaseResponse = await httpsRequest(`${GITHUB_REPO_URL}/releases/latest`);
             return JSON.parse(releaseResponse.data);
         } catch (error) {
-            throw new Error('Failed to parse release information JSON');
+            if (error.message.includes('404')) {
+                console.log('No stable release found, fetching the most recent release...');
+                const releasesResponse = await httpsRequest(`${GITHUB_REPO_URL}/releases?per_page=1`);
+                const releases = JSON.parse(releasesResponse.data);
+                if (!releases.length) {
+                    throw new Error('No releases found in the repository');
+                }
+                return releases[0];
+            }
+            throw error;
         }
     }
 }
 
 async function main() {
     try {
-        if (!forceReplace && checkExistingJar()) {
+        if (requestedTag && requestedTag !== 'latest' && requestedTag !== 'prerelease' && usePrerelease) {
+            throw new Error('Use either --prerelease or --tag <specific-tag>, not both');
+        }
+
+        if (tagIndex >= 0 && !requestedTag) {
+            throw new Error('Missing value for --tag');
+        }
+
+        function getExpectedVersion(tag) {
+            if (!tag || tag === 'latest' || tag === 'prerelease') {
+                return undefined;
+            }
+            return tag.startsWith('v') ? tag.slice(1) : tag;
+        }
+
+        if (!forceReplace && checkExistingJar(getExpectedVersion(requestedTag))) {
             process.exit(0);
         }
 
-        console.log(`Downloading Ballerina language server${usePrerelease ? ' (prerelease)' : ''}${forceReplace ? ' (force replace)' : ''}...`);
+        const releaseLabel = requestedTag
+            ? ` (tag: ${requestedTag})`
+            : (usePrerelease ? ' (prerelease)' : '');
+        console.log(`Downloading Ballerina language server${releaseLabel}${forceReplace ? ' (force replace)' : ''}...`);
 
         if (forceReplace && fs.existsSync(LS_DIR)) {
             console.log('Force replace enabled: clearing existing language server directory...');
@@ -241,4 +315,4 @@ if (require.main === module) {
     main();
 }
 
-module.exports = { main, checkExistingJar }; 
+module.exports = { main, checkExistingJar };

--- a/workspaces/ballerina/ballerina-extension/scripts/download-ls.js
+++ b/workspaces/ballerina/ballerina-extension/scripts/download-ls.js
@@ -282,6 +282,10 @@ async function main() {
         console.log('Fetching release information...');
         const releaseData = await getLatestRelease(usePrerelease);
 
+        if (!releaseData?.tag_name) {
+            throw new Error('Invalid release data: missing tag_name');
+        }
+
         // For floating tags, check if the concrete version already exists
         if (!forceReplace && (!requestedTag || requestedTag === 'latest' || requestedTag === 'prerelease')) {
             const concreteVersion = releaseData.tag_name.startsWith('v') 
@@ -320,6 +324,14 @@ async function main() {
                 const relativePath = path.relative(PROJECT_ROOT, lsJarPath);
                 console.log(`Successfully downloaded Ballerina language server to ${relativePath}`);
                 console.log(`File size: ${fileSize} bytes`);
+                // Remove any stale JARs that aren't the newly downloaded one
+                const staleJars = fs.readdirSync(LS_DIR).filter(f =>
+                    f.includes('ballerina-language-server-') && f.endsWith('.jar') && f !== jarAsset.name
+                );
+                for (const stale of staleJars) {
+                    console.log(`Removing stale language server JAR: ${stale}`);
+                    fs.unlinkSync(path.join(LS_DIR, stale));
+                }
             } else {
                 throw new Error('Downloaded file is empty');
             }

--- a/workspaces/ballerina/ballerina-extension/scripts/verify-ls.js
+++ b/workspaces/ballerina/ballerina-extension/scripts/verify-ls.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const projectRoot = path.join(__dirname, '..');
+const lsDir = path.join(projectRoot, 'ls');
+
+function getBundledLanguageServerJar() {
+    if (!fs.existsSync(lsDir)) {
+        return undefined;
+    }
+
+    return fs.readdirSync(lsDir).find((file) =>
+        /^ballerina-language-server.*\.jar$/.test(file)
+    );
+}
+
+const jarName = getBundledLanguageServerJar();
+
+if (!jarName) {
+    console.error(`Bundled Ballerina language server JAR not found in ${path.relative(projectRoot, lsDir)}.`);
+    console.error('Download it before building:');
+    console.error('  pnpm --dir workspaces/ballerina/ballerina-extension run download-ls');
+    console.error('  pnpm --dir workspaces/ballerina/ballerina-extension run download-ls -- --tag v1.8.0.m1 --replace');
+    process.exit(1);
+}
+
+console.log(`Using bundled Ballerina language server: ${jarName}`);


### PR DESCRIPTION
## Summary

Separates the Ballerina language server download from the build process and adds `release.properties` for pipeline configuration on the `release/bi-1.8.x` branch.

### Changes
- **`release.properties`** — Pipeline config (`ls.tag=v1.7.0.alpha6`, `integrator.branch=5.0.x`)
- **`verify-ls.js`** — Fail-fast check before build ensures LS JAR is present
- **`download-ls.js`** — Added `--tag` flag, auth header support, 404 fallback for prerelease-only repos
- **`package.json`** — Removed `download-ls` from `postbuild`, added `verify-ls` to build/rebuild
- **`action.yml`** — Build action reads `release.properties`, version-aware cache, conditional LS download
- **`DEVELOPMENT_SETUP.md`** — Developer guide for local LS setup

### Related
- PR #1999 (same changes targeting `main` branch)
