### PR TITLE
Fix mode toggle overflow in expression editor

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/ExpressionEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/ExpressionEditor.tsx
@@ -142,7 +142,7 @@ export namespace S {
     export const HeaderRow = styled.div({
         display: 'flex',
         justifyContent: 'space-between',
-        alignItems: 'flex-start',
+        alignItems: 'flex-end',
         gap: '8px'
     });
 

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/ExpressionEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/ExpressionEditor.tsx
@@ -202,7 +202,9 @@ export namespace S {
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'flex-end',
-        gap: '5px'
+        gap: '5px',
+        flexShrink: 0,
+        width: '112px'
     });
 
     export const EditorMdContainer = styled.div`
@@ -582,22 +584,22 @@ export const ExpressionEditor = (props: ExpressionEditorProps) => {
             >
                 {showHeader && (
                     <S.Header>
-                        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', gap: '8px' }}>
-                            <div>
-                                {field.label && (
-                                    <S.HeaderContainer>
-                                        <S.LabelContainer>
-                                            <S.Label>{field.label}</S.Label>
-                                            {(field.defaultValue && field.defaultValue?.trim() !== "()") && <S.DefaultValue style={{ marginLeft: '8px' }}>{`(Default: ${field.defaultValue}) `}</S.DefaultValue>}
-                                            {(required ?? !field.optional) && <RequiredFormInput />}
-                                            {getPrimaryInputType(field.types)?.ballerinaType && (
-                                                <S.Type style={{ marginLeft: '5px' }} isVisible={focused} title={getPrimaryInputType(field.types)?.ballerinaType}>
-                                                    {sanitizeType(getPrimaryInputType(field.types)?.ballerinaType)}
-                                                </S.Type>
-                                            )}
-                                        </S.LabelContainer>
-                                    </S.HeaderContainer>
-                                )}
+                        {field.label && (
+                            <S.HeaderContainer>
+                                <S.LabelContainer>
+                                    <S.Label>{field.label}</S.Label>
+                                    {(field.defaultValue && field.defaultValue?.trim() !== "()") && <S.DefaultValue style={{ marginLeft: '8px' }}>{`(Default: ${field.defaultValue}) `}</S.DefaultValue>}
+                                    {(required ?? !field.optional) && <RequiredFormInput />}
+                                    {getPrimaryInputType(field.types)?.ballerinaType && (
+                                        <S.Type style={{ marginLeft: '5px' }} isVisible={focused} title={getPrimaryInputType(field.types)?.ballerinaType}>
+                                            {sanitizeType(getPrimaryInputType(field.types)?.ballerinaType)}
+                                        </S.Type>
+                                    )}
+                                </S.LabelContainer>
+                            </S.HeaderContainer>
+                        )}
+                        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '8px' }}>
+                            <div style={{ flex: 1, minWidth: 0 }}>
                                 <S.EditorMdContainer>
                                     {documentation && <ReactMarkdown>{documentation}</ReactMarkdown>}
                                 </S.EditorMdContainer>

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/ExpressionEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/ExpressionEditor.tsx
@@ -139,6 +139,18 @@ export namespace S {
         gap: '4px'
     });
 
+    export const HeaderRow = styled.div({
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'flex-start',
+        gap: '8px'
+    });
+
+    export const HeaderMain = styled.div({
+        flex: 1,
+        minWidth: 0
+    });
+
     export const Type = styled.div<{ isVisible: boolean }>(({ isVisible }) => ({
         color: ThemeColors.PRIMARY,
         fontFamily: 'monospace',
@@ -147,6 +159,7 @@ export namespace S {
         borderRadius: '999px',
         padding: '1px 6px',
         display: 'inline-block',
+        verticalAlign: 'middle',
         userSelect: 'none',
         maxWidth: '120px',
         overflow: 'hidden',
@@ -204,8 +217,7 @@ export namespace S {
         flexDirection: 'column',
         alignItems: 'flex-end',
         gap: '5px',
-        flexShrink: 0,
-        width: '112px'
+        flexShrink: 0
     });
 
     export const EditorMdContainer = styled.div`
@@ -600,12 +612,12 @@ export const ExpressionEditor = (props: ExpressionEditorProps) => {
                                 </S.LabelContainer>
                             </S.HeaderContainer>
                         )}
-                        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '8px' }}>
-                            <div style={{ flex: 1, minWidth: 0 }}>
+                        <S.HeaderRow>
+                            <S.HeaderMain>
                                 <S.EditorMdContainer>
                                     {documentation && <ReactMarkdown>{documentation}</ReactMarkdown>}
                                 </S.EditorMdContainer>
-                            </div>
+                            </S.HeaderMain>
                             {modeSwitcherContext?.isModeSwitcherEnabled && (
                                 <S.FieldInfoSection>
                                     <ModeSwitcher
@@ -617,7 +629,7 @@ export const ExpressionEditor = (props: ExpressionEditorProps) => {
                                     />
                                 </S.FieldInfoSection>
                             )}
-                        </div>
+                        </S.HeaderRow>
                     </S.Header>
                 )}
                 <Controller

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/ExpressionEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/ExpressionEditor.tsx
@@ -166,7 +166,8 @@ export namespace S {
 
     export const Label = styled.label({
         color: 'var(--vscode-editor-foreground)',
-        textTransform: 'capitalize'
+        textTransform: 'capitalize',
+        overflowWrap: 'anywhere'
     });
 
     export const Description = styled.div({
@@ -195,6 +196,7 @@ export namespace S {
         color: var(--vscode-input-placeholderForeground);
         font-family: var(--vscode-editor-font-family);
         font-size: 12px;
+        overflow-wrap: anywhere;
     `;
 
     export const FieldInfoSection = styled.div({
@@ -213,6 +215,7 @@ export namespace S {
         color: var(--vscode-list-deemphasizedForeground);
         border-radius: 4px;
         margin-bottom: 0;
+        overflow-wrap: anywhere;
 
         h1,
         h2,

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/ExpressionEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/ExpressionEditor.tsx
@@ -123,8 +123,7 @@ export namespace S {
     `;
 
     export const LabelContainer = styled.div({
-        display: 'flex',
-        alignItems: 'center'
+        display: 'block'
     });
 
     export const HeaderContainer = styled.div({


### PR DESCRIPTION
## Purpose

Fixes https://github.com/wso2/product-integrator/issues/878

This PR fixes the mode toggle overflow issue in expression editor when there are long form field descriptions or long default values.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/b740d613-d215-4ca3-a976-822ab496644e" />

<br/>

<img width="300" alt="image" src="https://github.com/user-attachments/assets/729e2497-42fd-4787-846f-0f80cedd29f3" />

<br/>

<img width="300" alt="image" src="https://github.com/user-attachments/assets/3bf92eb6-3f69-4c2c-9191-4643a8361434" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked ExpressionEditor header and inline layout to improve alignment, spacing, and conditional rendering of label/type/default sections.
* **Style**
  * Improved text-wrapping and overflow behavior for labels, default values, and editor sections to prevent truncation and preserve layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->