### PR TITLE
Fix ChoiceForm crash when nested choices array shrinks

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/ChoiceForm.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/ChoiceForm.tsx
@@ -73,6 +73,11 @@ export function ChoiceForm(props: ChoiceFormProps) {
             if (newSelectedOption !== selectedOption) {
                 setSelectedOption(newSelectedOption);
             }
+        } else if (selectedOption > field.choices.length) {
+            // Choices shrank (e.g. protocol switched to one with fewer auth options) and none are enabled;
+            // clamp back to the first option so we don't index out of range.
+            setSelectedOption(1);
+            setValue(field.key, 0);
         }
     }, [field.choices]);
 
@@ -80,6 +85,11 @@ export function ChoiceForm(props: ChoiceFormProps) {
     useEffect(() => {
         const realValue = selectedOption - 1;
         const property = field.choices[realValue];
+        if (!property) {
+            // Stale selectedOption from a previous, larger choices array. The sibling effect
+            // above will resync selectedOption on the next render; bail out to avoid crashing.
+            return;
+        }
         const choiceProperty = convertConfig(property);
         setDynamicFields(choiceProperty);
         if (choiceProperty.length > 0) {


### PR DESCRIPTION
## Summary
- Nested `ChoiceForm` instances are reused across parent CHOICE switches (they reconcile by `field.key`), so `selectedOption` from the previous render can point past the end of a newly shorter `choices` array.
- Repro: in the FTP service wizard, pick SFTP → select **Certificate Based Authentication** (index 2) → switch protocol to FTP (whose authentication CHOICE has only 2 options). The dynamic-fields effect reads `field.choices[2]`, gets `undefined`, and `convertConfig(undefined)` crashes on `undefined.properties`.
- Fix in `ChoiceForm.tsx`: guard the lookup against an out-of-range `selectedOption`, and clamp `selectedOption` back to `1` when the new choices array has no `enabled` option, so the sibling resync effect can take over on the next render.

## Test plan
- [ ] BI Service Wizard → FTP Integration → pick **SFTP** protocol → select **Certificate Based Authentication** → switch protocol to **FTP** → auth should reset to **No Authentication** with no crash.
- [ ] Repeat switching to **FTPS** (also 2 options) and back to **SFTP** to confirm state stays consistent.
- [ ] Verify existing 2-choice auth flows (Basic/None) on FTP and FTPS still behave as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced form stability by fixing crashes that occurred when available options in form fields were modified, removed, or reduced. The form now properly validates and resets to a safe state when previously selected options become unavailable, preventing errors and ensuring a seamless user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->