### PR TITLE
[hurl client] Replace content if file is already open in Import hurl string command

### DIFF
--- a/workspaces/hurl-client/hurl-client-extension/src/extension.ts
+++ b/workspaces/hurl-client/hurl-client-extension/src/extension.ts
@@ -158,14 +158,27 @@ export function activate(context: vscode.ExtensionContext): void {
                     const preparedFileName = sanitizeFileName(options?.fileName, `TryIt`);
                     const untitledUri = vscode.Uri.from({
                         scheme: 'untitled',
-                        path: `${preparedFileName}-${token}.hurl`
+                        path: `${preparedFileName}.hurl`
                     });
+                    // if the same filename is open, replace its content
+                    const existingDoc = vscode.workspace.notebookDocuments.find(doc => doc.uri.toString() === untitledUri.toString());
+                    const dirtyEdit = new vscode.WorkspaceEdit();
+                    if (existingDoc) {
+                        // Replace all cells so re-importing into the same untitled URI refreshes the content.
+                        const fullRange = new vscode.NotebookRange(0, existingDoc.cellCount);
+                        dirtyEdit.set(existingDoc.uri, [
+                            vscode.NotebookEdit.replaceCells(fullRange, notebookData.cells),
+                            vscode.NotebookEdit.updateNotebookMetadata({ generated: true })
+                        ]);
+                        await vscode.workspace.applyEdit(dirtyEdit);
+                        await vscode.window.showNotebookDocument(existingDoc, { viewColumn });
+                        return;
+                    }
                     doc = await vscode.workspace.openNotebookDocument(untitledUri);
 
                     // Mark the notebook dirty immediately so VS Code prompts to save on close even
                     // if the user makes no edits.  Notebook metadata is not written by serializeNotebook
                     // so this has no effect on the saved .hurl file content.
-                    const dirtyEdit = new vscode.WorkspaceEdit();
                     dirtyEdit.set(doc.uri, [vscode.NotebookEdit.updateNotebookMetadata({ generated: true })]);
                     await vscode.workspace.applyEdit(dirtyEdit);
                 } else {


### PR DESCRIPTION
## Purpose
> When users run Import Hurl String multiple times with the same filename, the extension opens separate untitled notebooks instead of updating the already open one. This creates duplicate tabs and makes iterative edits noisy.
## Goals
> Reuse the existing untitled notebook when the same filename is imported again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved imported notebook handling to prevent duplicate documents when re-importing notebooks with the same name; existing notebooks are now updated in place instead of creating new documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->