### PR TITLE
[Data Mapper] Auto expand fields when searching

### DIFF
--- a/workspaces/ballerina/data-mapper/src/components/Diagram/Node/SubMapping/SubMappingItemWidget.tsx
+++ b/workspaces/ballerina/data-mapper/src/components/Diagram/Node/SubMapping/SubMappingItemWidget.tsx
@@ -29,7 +29,7 @@ import { OutputSearchHighlight } from "../commons/Search";
 import { TreeBody } from '../commons/Tree/Tree';
 import { useIONodesStyles } from "../../../styles";
 import { InputNodeTreeItemWidget } from "../Input/InputNodeTreeItemWidget";
-import { useDMExpandedFieldsStore, useDMSubMappingConfigPanelStore } from "../../../../store/store";
+import { useDMCollapsedFieldsStore, useDMExpandedFieldsStore, useDMSubMappingConfigPanelStore } from "../../../../store/store";
 import { DMSubMapping } from "./SubMappingNode";
 import { SubMappingSeparator } from "./SubMappingSeparator";
 import { IOType, TypeKind } from "@wso2/ballerina-core";
@@ -54,6 +54,7 @@ export function SubMappingItemWidget(props: SubMappingItemProps) {
 
     const classes = useIONodesStyles();
     const expandedFieldsStore = useDMExpandedFieldsStore();
+    const collapsedFieldsStore = useDMCollapsedFieldsStore();
     const setSubMappingConfig = useDMSubMappingConfigPanelStore(state => state.setSubMappingConfig);
 
     const [ portState, setPortState ] = useState<PortState>(PortState.Unselected);
@@ -100,12 +101,19 @@ export function SubMappingItemWidget(props: SubMappingItemProps) {
     };
 
     const handleExpand = () => {
+
         const expandedFields = expandedFieldsStore.fields;
+        const collapsedFields = collapsedFieldsStore.fields;
+
         if (expanded) {
             expandedFieldsStore.setFields(expandedFields.filter((element) => element !== id));
+            collapsedFieldsStore.setFields([...collapsedFields, id]);
+
         } else {
             expandedFieldsStore.setFields([...expandedFields, id]);
+            collapsedFieldsStore.setFields(collapsedFields.filter((element) => element !== id));
         }
+
     }
 
     const onMouseEnter = () => {

--- a/workspaces/ballerina/data-mapper/src/components/Diagram/Node/commons/DataMapperNode.ts
+++ b/workspaces/ballerina/data-mapper/src/components/Diagram/Node/commons/DataMapperNode.ts
@@ -330,7 +330,8 @@ export abstract class DataMapperNodeModel extends NodeModel<NodeModelGenerics & 
 		collapseByDefault: boolean
 	) {
 		// Auto-expand all input fields when input search is active
-		if (useDMSearchStore.getState().inputSearch) return false;
+		if (useDMSearchStore.getState().inputSearch) {return false;}
+
 		if ((isArray && !isFocused) || collapseByDefault ){
 			return expandedFields && !expandedFields.includes(portName);
 		}
@@ -349,7 +350,8 @@ export abstract class DataMapperNodeModel extends NodeModel<NodeModelGenerics & 
 		outputId: string
 	): boolean {
 		// Auto-expand all output fields when output search is active
-		if (useDMSearchStore.getState().outputSearch) return false;
+		if (useDMSearchStore.getState().outputSearch) {return false;}
+		
 		if ((isArray && !mapping?.elements?.length) ||
 			(isDeepNested && !hasChildMappingsForOutput(mappings, outputId))) {
 			return expandedFields && !expandedFields.includes(portName);

--- a/workspaces/ballerina/data-mapper/src/components/Diagram/Node/commons/DataMapperNode.ts
+++ b/workspaces/ballerina/data-mapper/src/components/Diagram/Node/commons/DataMapperNode.ts
@@ -316,7 +316,12 @@ export abstract class DataMapperNodeModel extends NodeModel<NodeModelGenerics & 
 		} else {
 			// Auto-expand input node headers when input search is active
 			if (inputSearch) {return false;}
-			return !expandedFields?.includes(portName);
+
+			// Collapse by default only if more than 1 input nodes
+			if(this.context.model.inputs.length > 1) {
+				return !expandedFields?.includes(portName);
+			}
+			return collapsedFields?.includes(portName);
 		}
 	}
 	
@@ -351,7 +356,7 @@ export abstract class DataMapperNodeModel extends NodeModel<NodeModelGenerics & 
 	): boolean {
 		// Auto-expand all output fields when output search is active
 		if (useDMSearchStore.getState().outputSearch) {return false;}
-		
+
 		if ((isArray && !mapping?.elements?.length) ||
 			(isDeepNested && !hasChildMappingsForOutput(mappings, outputId))) {
 			return expandedFields && !expandedFields.includes(portName);

--- a/workspaces/ballerina/data-mapper/src/components/Diagram/Node/commons/DataMapperNode.ts
+++ b/workspaces/ballerina/data-mapper/src/components/Diagram/Node/commons/DataMapperNode.ts
@@ -23,6 +23,7 @@ import { IDataMapperContext } from '../../../../utils/DataMapperContext/DataMapp
 import { MappingMetadata } from '../../Mappings/MappingMetadata';
 import { InputOutputPortModel } from "../../Port";
 import { findMappingByOutput, hasChildMappingsForInput, hasChildMappingsForOutput } from '../../utils/common-utils';
+import { useDMSearchStore } from '../../../../store/store';
 
 export interface DataMapperNodeModelGenerics {
 	PORT: InputOutputPortModel;
@@ -300,11 +301,16 @@ export abstract class DataMapperNodeModel extends NodeModel<NodeModelGenerics & 
 		expandedFields: string[],
 		isFocused: boolean
 	): boolean {
+		const { inputSearch, outputSearch } = useDMSearchStore.getState();
 		// In Inline Data Mapper, the inputs are always collapsed by default except focused view.
 		// Hence we explicitly check expandedFields for input header ports. 
 		if (portType === "IN" || isFocused) {
+			// Auto-expand output node headers when output search is active
+			if (outputSearch) return false;
 			return collapsedFields?.includes(portName);
 		} else {
+			// Auto-expand input node headers when input search is active
+			if (inputSearch) return false;
 			return !expandedFields?.includes(portName);
 		}
 	}
@@ -318,6 +324,8 @@ export abstract class DataMapperNodeModel extends NodeModel<NodeModelGenerics & 
 		isFocused: boolean,
 		collapseByDefault: boolean
 	) {
+		// Auto-expand all input fields when input search is active
+		if (useDMSearchStore.getState().inputSearch) return false;
 		if ((isArray && !isFocused) || collapseByDefault ){
 			return expandedFields && !expandedFields.includes(portName);
 		}
@@ -335,6 +343,8 @@ export abstract class DataMapperNodeModel extends NodeModel<NodeModelGenerics & 
 		mappings: Mapping[],
 		outputId: string
 	): boolean {
+		// Auto-expand all output fields when output search is active
+		if (useDMSearchStore.getState().outputSearch) return false;
 		if ((isArray && !mapping?.elements?.length) ||
 			(isDeepNested && !hasChildMappingsForOutput(mappings, outputId))) {
 			return expandedFields && !expandedFields.includes(portName);

--- a/workspaces/ballerina/data-mapper/src/components/Diagram/Node/commons/DataMapperNode.ts
+++ b/workspaces/ballerina/data-mapper/src/components/Diagram/Node/commons/DataMapperNode.ts
@@ -302,15 +302,20 @@ export abstract class DataMapperNodeModel extends NodeModel<NodeModelGenerics & 
 		isFocused: boolean
 	): boolean {
 		const { inputSearch, outputSearch } = useDMSearchStore.getState();
-		// In Inline Data Mapper, the inputs are always collapsed by default except focused view.
+		// In Data Mapper, the inputs are always collapsed by default except focused view.
 		// Hence we explicitly check expandedFields for input header ports. 
 		if (portType === "IN" || isFocused) {
-			// Auto-expand output node headers when output search is active
-			if (outputSearch) return false;
+			if (isFocused) {
+				// Auto-expand focused input node headers when input search is active
+				if (inputSearch) {return false;}
+			} else {
+				// Auto-expand output node headers when output search is active
+				if (outputSearch) {return false;}
+			}
 			return collapsedFields?.includes(portName);
 		} else {
 			// Auto-expand input node headers when input search is active
-			if (inputSearch) return false;
+			if (inputSearch) {return false;}
 			return !expandedFields?.includes(portName);
 		}
 	}

--- a/workspaces/ballerina/data-mapper/src/components/Diagram/Node/commons/DataMapperNode.ts
+++ b/workspaces/ballerina/data-mapper/src/components/Diagram/Node/commons/DataMapperNode.ts
@@ -302,7 +302,7 @@ export abstract class DataMapperNodeModel extends NodeModel<NodeModelGenerics & 
 		isFocused: boolean
 	): boolean {
 		const { inputSearch, outputSearch } = useDMSearchStore.getState();
-		// In Data Mapper, the inputs are always collapsed by default except focused view.
+		// In Data Mapper, the inputs are always collapsed by default except focused view or when only one input is present.
 		// Hence we explicitly check expandedFields for input header ports. 
 		if (portType === "IN" || isFocused) {
 			if (isFocused) {


### PR DESCRIPTION
## Purpose
> Fixes https://github.com/wso2-enterprise/integration-engineering/issues/1339  
> Additionally, if only one input field exists, it will expand automatically. Previously, all inputs were collapsed by default.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fields now auto-expand during input/output searches, improving visibility of matching mapping options.
  * Collapse behavior refined: ports with a single input stay expanded by default; multi-input ports use collapse-by-default for clarity.
* **Bug Fixes**
  * Expand/collapse toggles are now synchronized so collapsing and expanding sub-mapping items reliably update visible state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->