### PR TITLE
Add daily-build release.properties for release/bi-1.8.x

### DIFF
--- a/.github/daily-build/release.properties
+++ b/.github/daily-build/release.properties
@@ -1,0 +1,8 @@
+# Per-branch config for the Ballerina daily-build workflow.
+# Read by .github/workflows/daily-build-ballerina.yml after checking out this branch.
+
+# Artifact name prefix on ballerina-platform/ballerina-language-server daily-build.yml runs.
+lsArtifactPrefix=daily-build-1.7.x-
+
+# Target branch on wso2/product-integrator for the automated ballerina.extension.version PR.
+productIntegratorBranch=5.0.x

--- a/.github/daily-build/release.properties
+++ b/.github/daily-build/release.properties
@@ -2,7 +2,7 @@
 # Read by .github/workflows/daily-build-ballerina.yml after checking out this branch.
 
 # Artifact name prefix on ballerina-platform/ballerina-language-server daily-build.yml runs.
-lsArtifactPrefix=daily-build-1.7.x-
+lsArtifactPrefix=ballerina-language-server-1.7.0
 
 # Target branch on wso2/product-integrator for the automated ballerina.extension.version PR.
 productIntegratorBranch=5.0.x


### PR DESCRIPTION
## Summary
Adds `.github/daily-build/release.properties` on `release/bi-1.8.x` so the revamped Ballerina daily-build workflow (see wso2/vscode-extensions#2023) can pick up this branch's values after checkout:

- `lsArtifactPrefix=daily-build-1.7.x-` — pulls the LS JAR from the `1.7.x` prefix on `ballerina-platform/ballerina-language-server/.github/workflows/daily-build.yml`.
- `productIntegratorBranch=5.0.x` — target branch for the automated `ballerina.extension.version` update PR.

The companion workflow rewrite PR (#2023) targets `main`; that scheduled workflow checks out this branch and requires this file.

## Test plan
- [ ] Merge #2023 first, then this.
- [ ] `workflow_dispatch` on the daily-build-ballerina workflow from `main` and verify the `release/bi-1.8.x` matrix leg reads the file and produces a VSIX + product-integrator PR to `5.0.x`.