### PR TITLE
Improve download-ls with --tag parameter and version-aware cache key

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -177,7 +177,7 @@ runs:
         node common/scripts/install-run-rush.js build --verbose
       env:
         isPreRelease: ${{ inputs.isPreRelease == 'true' }}
-        BALLERINA_LS_TAG: ${{ inputs.ballerinaLsTag != '' && inputs.ballerinaLsTag || (inputs.isPreRelease == 'true' && 'prerelease' || 'latest') }}
+        BALLERINA_LS_TAG: ${{ inputs.enableLSCache == 'true' && steps.resolve-ballerina-ls-version.outputs.version || (inputs.ballerinaLsTag != '' && inputs.ballerinaLsTag || (inputs.isPreRelease == 'true' && 'prerelease' || 'latest')) }}
         BALLERINA_AUTH_ORG: ${{ inputs.BALLERINA_AUTH_ORG }}
         BALLERINA_AUTH_CLIENT_ID: ${{ inputs.BALLERINA_AUTH_CLIENT_ID }}
         BALLERINA_DEV_COPLIOT_ROOT_URL: ${{ inputs.BALLERINA_DEV_COPLIOT_ROOT_URL }}

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -3,6 +3,11 @@ inputs:
   isPreRelease:
     default: true
     type: boolean
+  ballerinaLsTag:
+    description: Override Ballerina LS download tag (latest, prerelease, v1.5.0). Overrides isPreRelease for LS download.
+    type: string
+    required: false
+    default: ''
   enableCache:
     default: true
     type: boolean
@@ -147,13 +152,22 @@ runs:
         key: mi-ls
         retention-days: 1
 
+    - name: Resolve Ballerina LS version
+      id: resolve-ballerina-ls-version
+      if: ${{ inputs.enableLSCache == 'true' }}
+      shell: bash
+      run: node workspaces/ballerina/ballerina-extension/scripts/download-ls.js --resolve-version
+      env:
+        BALLERINA_LS_TAG: ${{ inputs.ballerinaLsTag != '' && inputs.ballerinaLsTag || (inputs.isPreRelease == 'true' && 'prerelease' || 'latest') }}
+        GITHUB_TOKEN: ${{ inputs.token }}
+
     - name: Restore Ballerina LS from cache
       id: ballerina-ls-cache
       if: ${{ inputs.enableLSCache == 'true' }}
       uses: actions/cache@v4
       with:
         path: workspaces/ballerina/ballerina-extension/ls
-        key: ballerina-ls
+        key: ballerina-ls-${{ steps.resolve-ballerina-ls-version.outputs.version }}
         retention-days: 1
 
     - name: Build repo
@@ -163,6 +177,7 @@ runs:
         node common/scripts/install-run-rush.js build --verbose
       env:
         isPreRelease: ${{ inputs.isPreRelease == 'true' }}
+        BALLERINA_LS_TAG: ${{ inputs.ballerinaLsTag != '' && inputs.ballerinaLsTag || (inputs.isPreRelease == 'true' && 'prerelease' || 'latest') }}
         BALLERINA_AUTH_ORG: ${{ inputs.BALLERINA_AUTH_ORG }}
         BALLERINA_AUTH_CLIENT_ID: ${{ inputs.BALLERINA_AUTH_CLIENT_ID }}
         BALLERINA_DEV_COPLIOT_ROOT_URL: ${{ inputs.BALLERINA_DEV_COPLIOT_ROOT_URL }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,12 @@ on:
       runMIE2ETests:
         type: boolean
         required: false
-        default: false 
+        default: false
+      ballerinaLsTag:
+        description: Override Ballerina LS download tag (latest, prerelease, v1.5.0)
+        type: string
+        required: false
+        default: ''
 
 env:
   ballerina_version: 2201.7.2
@@ -193,6 +198,7 @@ jobs:
         uses: ./.github/actions/build
         with:
           isPreRelease: ${{ inputs.isPreRelease }}
+          ballerinaLsTag: ${{ inputs.ballerinaLsTag }}
           enableCache: ${{ inputs.enableCache }}
           enableLSCache: ${{ !inputs.isReleaseBuild }}
           ballerina: ${{ inputs.ballerina }}

--- a/.github/workflows/release-vsix.yml
+++ b/.github/workflows/release-vsix.yml
@@ -36,6 +36,16 @@ on:
         type: boolean
         required: true
         default: false
+      hurl-client:
+        description: Release Hurl Client extension
+        type: boolean
+        required: true
+        default: false
+      ballerinaLsTag:
+        description: 'Override Ballerina LS download tag (latest, prerelease, v1.5.0). Overrides isPreRelease for LS download.'
+        type: string
+        required: false
+        default: ''
       version:
         type: choice
         description: 'Enter the version type'
@@ -55,6 +65,7 @@ jobs:
     with:
       runOnAWS: true
       isPreRelease: ${{ inputs.isPreRelease }}
+      ballerinaLsTag: ${{ inputs.ballerinaLsTag }}
       enableCache: false
       ballerina: ${{ inputs.ballerina }}
       wso2-platform: ${{ inputs.wso2-platform }}

--- a/workspaces/ballerina/ballerina-extension/package.json
+++ b/workspaces/ballerina/ballerina-extension/package.json
@@ -1211,7 +1211,7 @@
         "copyVSIX": "copyfiles *.vsix ./vsix",
         "copyVSIXToRoot": "copyfiles -f ./vsix/*.vsix ../../..",
         "download-ls": "node scripts/download-ls.js",
-        "download-ls:prerelease": "node scripts/download-ls.js --prerelease --replace",
+        "download-ls:prerelease": "node scripts/download-ls.js --tag prerelease --replace",
         "build": "pnpm run compile && pnpm run lint && pnpm run postbuild",
         "rebuild": "pnpm run clean && pnpm run compile && pnpm run postbuild",
         "postbuild": "if [ \"$isPreRelease\" = \"true\" ]; then pnpm run download-ls --prerelease; else pnpm run download-ls; fi && pnpm run copyFonts && pnpm run copyJSLibs && pnpm run package && pnpm run copyVSIX",

--- a/workspaces/ballerina/ballerina-extension/scripts/download-ls.js
+++ b/workspaces/ballerina/ballerina-extension/scripts/download-ls.js
@@ -198,13 +198,17 @@ async function getRelease(tag) {
             return JSON.parse(releaseResponse.data);
         } catch (error) {
             if (error.message.includes('404')) {
-                console.log('No stable release found, fetching the most recent release...');
-                const releasesResponse = await httpsRequest(`${GITHUB_REPO_URL}/releases?per_page=1`);
+                console.log('No stable release found via /releases/latest, searching for most recent stable release...');
+                const releasesResponse = await httpsRequest(`${GITHUB_REPO_URL}/releases?per_page=30`);
                 const releases = JSON.parse(releasesResponse.data);
-                if (!releases.length) {
-                    throw new Error('No releases found in the repository');
+                const stable = releases.find(r => !r.prerelease && !r.draft);
+                if (stable) return stable;
+                // No stable release exists; use the most recent release (may be a prerelease)
+                if (releases.length) {
+                    console.log('No stable release found; using most recent release as fallback.');
+                    return releases[0];
                 }
-                return releases[0];
+                throw new Error('No releases found in the repository');
             }
             throw error;
         }
@@ -247,7 +251,9 @@ async function main() {
             process.exit(0);
         }
 
-        // For concrete tags: check cache before making any network request
+        // For concrete tags: check cache before making any network request.
+        // Assumes asset filename convention: ballerina-language-server-${version}.jar
+        // where version = tag with leading 'v' stripped (e.g. v1.5.0 → 1.5.0).
         if (!forceReplace && tag !== 'latest' && tag !== 'prerelease') {
             const version = tag.startsWith('v') ? tag.slice(1) : tag;
             if (checkExistingJar(version)) {

--- a/workspaces/ballerina/ballerina-extension/scripts/download-ls.js
+++ b/workspaces/ballerina/ballerina-extension/scripts/download-ls.js
@@ -21,7 +21,7 @@ const tag = getTag();
 const forceReplace = args.includes('--replace');
 const resolveVersionOnly = args.includes('--resolve-version');
 
-function checkExistingJar() {
+function checkExistingJar(expectedVersion) {
     try {
         if (!fs.existsSync(LS_DIR)) {
             return false;
@@ -30,11 +30,17 @@ function checkExistingJar() {
         const files = fs.readdirSync(LS_DIR);
         const jarFiles = files.filter(file => file.includes('ballerina-language-server-') && file.endsWith('.jar'));
 
-        if (jarFiles.length > 0) {
-            console.log(`Ballerina language server JAR already exists in ${path.relative(PROJECT_ROOT, LS_DIR)}`);
+        if (jarFiles.length === 0) {
+            return false;
+        }
+
+        const expectedJar = jarFiles.find(file => file === `ballerina-language-server-${expectedVersion}.jar`);
+        if (expectedJar) {
+            console.log(`Ballerina language server JAR for version ${expectedVersion} already exists in ${path.relative(PROJECT_ROOT, LS_DIR)}`);
             return true;
         }
 
+        console.log(`Existing JAR does not match requested version ${expectedVersion}; downloading.`);
         return false;
     } catch (error) {
         console.error('Error checking existing JAR files:', error.message);
@@ -173,11 +179,20 @@ async function getRelease(tag) {
         }
         return prerelease;
     } else if (tag === 'latest') {
-        const releaseResponse = await httpsRequest(`${GITHUB_REPO_URL}/releases/latest`);
         try {
+            const releaseResponse = await httpsRequest(`${GITHUB_REPO_URL}/releases/latest`);
             return JSON.parse(releaseResponse.data);
         } catch (error) {
-            throw new Error('Failed to parse release information JSON');
+            if (error.message.includes('404')) {
+                console.log('No stable release found, fetching the most recent release...');
+                const releasesResponse = await httpsRequest(`${GITHUB_REPO_URL}/releases?per_page=1`);
+                const releases = JSON.parse(releasesResponse.data);
+                if (!releases.length) {
+                    throw new Error('No releases found in the repository');
+                }
+                return releases[0];
+            }
+            throw error;
         }
     } else {
         // Specific version tag e.g. v1.5.0
@@ -209,8 +224,12 @@ async function main() {
             process.exit(0);
         }
 
-        if (!forceReplace && checkExistingJar()) {
-            process.exit(0);
+        // For concrete tags: check cache before making any network request
+        if (!forceReplace && tag !== 'latest' && tag !== 'prerelease') {
+            const version = tag.startsWith('v') ? tag.slice(1) : tag;
+            if (checkExistingJar(version)) {
+                process.exit(0);
+            }
         }
 
         console.log(`Downloading Ballerina language server (tag: ${tag})${forceReplace ? ' (force replace)' : ''}...`);
@@ -226,6 +245,20 @@ async function main() {
 
         console.log('Fetching release information...');
         const releaseData = await getRelease(tag);
+
+        if (!releaseData?.tag_name) {
+            throw new Error('Invalid release data: missing tag_name');
+        }
+
+        // For floating tags: resolve concrete version, then check cache
+        if (!forceReplace && (tag === 'latest' || tag === 'prerelease')) {
+            const concreteVersion = releaseData.tag_name.startsWith('v')
+                ? releaseData.tag_name.slice(1)
+                : releaseData.tag_name;
+            if (checkExistingJar(concreteVersion)) {
+                process.exit(0);
+            }
+        }
 
         const jarAsset = releaseData.assets?.find(asset =>
             asset.name.includes('ballerina-language-server-') &&
@@ -255,6 +288,15 @@ async function main() {
                 const relativePath = path.relative(PROJECT_ROOT, lsJarPath);
                 console.log(`Successfully downloaded Ballerina language server to ${relativePath}`);
                 console.log(`File size: ${fileSize} bytes`);
+
+                // Remove stale JARs (keep only the one just downloaded)
+                const staleJars = fs.readdirSync(LS_DIR).filter(f =>
+                    f.includes('ballerina-language-server-') && f.endsWith('.jar') && f !== jarAsset.name
+                );
+                staleJars.forEach(f => {
+                    fs.unlinkSync(path.join(LS_DIR, f));
+                    console.log(`Removed stale JAR: ${f}`);
+                });
             } else {
                 throw new Error('Downloaded file is empty');
             }

--- a/workspaces/ballerina/ballerina-extension/scripts/download-ls.js
+++ b/workspaces/ballerina/ballerina-extension/scripts/download-ls.js
@@ -9,8 +9,17 @@ const LS_DIR = path.join(PROJECT_ROOT, 'ls');
 const GITHUB_REPO_URL = 'https://api.github.com/repos/ballerina-platform/ballerina-language-server';
 
 const args = process.argv.slice(2);
-const usePrerelease = args.includes('--prerelease') || process.env.isPreRelease === 'true';
+
+function getTag() {
+    const tagIdx = args.indexOf('--tag');
+    if (tagIdx !== -1 && args[tagIdx + 1]) return args[tagIdx + 1];
+    if (process.env.BALLERINA_LS_TAG) return process.env.BALLERINA_LS_TAG;
+    return 'latest';
+}
+
+const tag = getTag();
 const forceReplace = args.includes('--replace');
+const resolveVersionOnly = args.includes('--resolve-version');
 
 function checkExistingJar() {
     try {
@@ -146,9 +155,8 @@ function getFileSize(filePath) {
     }
 }
 
-async function getLatestRelease(usePrerelease) {
-    if (usePrerelease) {
-        // Get all releases and find the latest prerelease
+async function getRelease(tag) {
+    if (tag === 'prerelease') {
         const releasesResponse = await httpsRequest(`${GITHUB_REPO_URL}/releases`);
         let releases;
         try {
@@ -156,7 +164,6 @@ async function getLatestRelease(usePrerelease) {
         } catch (error) {
             throw new Error('Failed to parse releases information JSON');
         }
-        // Sort releases by published_at date in descending order and find the latest prerelease
         const prerelease = releases
             .filter(release => release.prerelease)
             .sort((a, b) => new Date(b.published_at) - new Date(a.published_at))[0];
@@ -165,24 +172,48 @@ async function getLatestRelease(usePrerelease) {
             throw new Error('No prerelease found');
         }
         return prerelease;
-    } else {
-        // Get the latest stable release
+    } else if (tag === 'latest') {
         const releaseResponse = await httpsRequest(`${GITHUB_REPO_URL}/releases/latest`);
         try {
             return JSON.parse(releaseResponse.data);
         } catch (error) {
             throw new Error('Failed to parse release information JSON');
         }
+    } else {
+        // Specific version tag e.g. v1.5.0
+        const releaseResponse = await httpsRequest(`${GITHUB_REPO_URL}/releases/tags/${tag}`);
+        try {
+            return JSON.parse(releaseResponse.data);
+        } catch (error) {
+            throw new Error(`Failed to parse release information JSON for tag ${tag}`);
+        }
+    }
+}
+
+async function resolveAndOutputVersion(tag) {
+    console.log(`Resolving Ballerina language server version for tag: ${tag}...`);
+    const releaseData = await getRelease(tag);
+    const version = releaseData.tag_name;
+    console.log(`Resolved version: ${version}`);
+    if (process.env.GITHUB_OUTPUT) {
+        fs.appendFileSync(process.env.GITHUB_OUTPUT, `version=${version}\n`);
+    } else {
+        console.log(`::set-output name=version::${version}`);
     }
 }
 
 async function main() {
     try {
+        if (resolveVersionOnly) {
+            await resolveAndOutputVersion(tag);
+            process.exit(0);
+        }
+
         if (!forceReplace && checkExistingJar()) {
             process.exit(0);
         }
 
-        console.log(`Downloading Ballerina language server${usePrerelease ? ' (prerelease)' : ''}${forceReplace ? ' (force replace)' : ''}...`);
+        console.log(`Downloading Ballerina language server (tag: ${tag})${forceReplace ? ' (force replace)' : ''}...`);
 
         if (forceReplace && fs.existsSync(LS_DIR)) {
             console.log('Force replace enabled: clearing existing language server directory...');
@@ -194,7 +225,7 @@ async function main() {
         }
 
         console.log('Fetching release information...');
-        const releaseData = await getLatestRelease(usePrerelease);
+        const releaseData = await getRelease(tag);
 
         const jarAsset = releaseData.assets?.find(asset =>
             asset.name.includes('ballerina-language-server-') &&
@@ -241,4 +272,5 @@ if (require.main === module) {
     main();
 }
 
-module.exports = { main, checkExistingJar }; 
+module.exports = { main, checkExistingJar, getRelease };
+

--- a/workspaces/ballerina/ballerina-extension/scripts/download-ls.js
+++ b/workspaces/ballerina/ballerina-extension/scripts/download-ls.js
@@ -15,15 +15,25 @@ function getTag() {
     if (tagIdx !== -1) {
         const value = args[tagIdx + 1];
         if (!value || value.startsWith('-')) throw new Error('Missing or invalid value for --tag');
-        return value;
+        return { tag: value, explicit: true };
     }
-    if (process.env.BALLERINA_LS_TAG) return process.env.BALLERINA_LS_TAG;
-    return 'latest';
+    if (process.env.BALLERINA_LS_TAG) return { tag: process.env.BALLERINA_LS_TAG, explicit: true };
+    return { tag: 'latest', explicit: false };
 }
 
-const tag = getTag();
+const { tag, explicit: tagExplicit } = getTag();
 const forceReplace = args.includes('--replace');
 const resolveVersionOnly = args.includes('--resolve-version');
+
+function hasAnyJar() {
+    try {
+        if (!fs.existsSync(LS_DIR)) return false;
+        const files = fs.readdirSync(LS_DIR);
+        return files.some(file => file.includes('ballerina-language-server-') && file.endsWith('.jar'));
+    } catch (error) {
+        return false;
+    }
+}
 
 function checkExistingJar(expectedVersion) {
     try {
@@ -228,6 +238,12 @@ async function main() {
     try {
         if (resolveVersionOnly) {
             await resolveAndOutputVersion(tag);
+            process.exit(0);
+        }
+
+        // No explicit tag: any existing JAR is sufficient — skip network call
+        if (!forceReplace && !tagExplicit && hasAnyJar()) {
+            console.log(`Ballerina language server JAR already exists; skipping download (no version specified).`);
             process.exit(0);
         }
 

--- a/workspaces/ballerina/ballerina-extension/scripts/download-ls.js
+++ b/workspaces/ballerina/ballerina-extension/scripts/download-ls.js
@@ -12,7 +12,11 @@ const args = process.argv.slice(2);
 
 function getTag() {
     const tagIdx = args.indexOf('--tag');
-    if (tagIdx !== -1 && args[tagIdx + 1]) return args[tagIdx + 1];
+    if (tagIdx !== -1) {
+        const value = args[tagIdx + 1];
+        if (!value || value.startsWith('-')) throw new Error('Missing or invalid value for --tag');
+        return value;
+    }
     if (process.env.BALLERINA_LS_TAG) return process.env.BALLERINA_LS_TAG;
     return 'latest';
 }
@@ -196,7 +200,7 @@ async function getRelease(tag) {
         }
     } else {
         // Specific version tag e.g. v1.5.0
-        const releaseResponse = await httpsRequest(`${GITHUB_REPO_URL}/releases/tags/${tag}`);
+        const releaseResponse = await httpsRequest(`${GITHUB_REPO_URL}/releases/tags/${encodeURIComponent(tag)}`);
         try {
             return JSON.parse(releaseResponse.data);
         } catch (error) {
@@ -208,6 +212,9 @@ async function getRelease(tag) {
 async function resolveAndOutputVersion(tag) {
     console.log(`Resolving Ballerina language server version for tag: ${tag}...`);
     const releaseData = await getRelease(tag);
+    if (!releaseData?.tag_name) {
+        throw new Error('Invalid release data: missing tag_name');
+    }
     const version = releaseData.tag_name;
     console.log(`Resolved version: ${version}`);
     if (process.env.GITHUB_OUTPUT) {

--- a/workspaces/ballerina/ballerina-extension/scripts/download-ls.js
+++ b/workspaces/ballerina/ballerina-extension/scripts/download-ls.js
@@ -203,12 +203,9 @@ async function getRelease(tag) {
                 const releases = JSON.parse(releasesResponse.data);
                 const stable = releases.find(r => !r.prerelease && !r.draft);
                 if (stable) return stable;
-                // No stable release exists; use the most recent release (may be a prerelease)
-                if (releases.length) {
-                    console.log('No stable release found; using most recent release as fallback.');
-                    return releases[0];
-                }
-                throw new Error('No releases found in the repository');
+                throw new Error(
+                    'No stable release found. Use --tag (or BALLERINA_LS_TAG) to specify a version explicitly (e.g. --tag prerelease or --tag v1.5.0).'
+                );
             }
             throw error;
         }


### PR DESCRIPTION
## Summary

  Replace the `--prerelease` flag and `isPreRelease` env var in `download-ls.js` with a flexible `--tag` parameter that accepts `latest`, `prerelease`, or a specific version tag (e.g., `v1.5.0`). Add
  `BALLERINA_LS_TAG` env var support and a `--resolve-version` mode to emit the concrete release version for use as a cache key.

  **Key changes:**
  - `download-ls.js`: Replace `--prerelease` + `isPreRelease` with `--tag` + `BALLERINA_LS_TAG` env var
  - `getLatestRelease()` → `getRelease(tag)` with 3 branches: `latest` (default), `prerelease`, or specific tag
  - Add `--resolve-version` mode for cache key generation (outputs `tag_name` to `GITHUB_OUTPUT`)
  - Update CI pipelines: add `ballerinaLsTag` input to workflows, thread through to build action
  - Fix cache key from static `ballerina-ls` to version-specific `ballerina-ls-<resolved-version>`

  