### PR TITLE
Enhance grep command in getPSCommand for case-insensitive search

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/features/tryit/utils.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/tryit/utils.ts
@@ -215,9 +215,9 @@ function getServicePorts(pid: string): number[] {
 function getPSCommand(platform: string, searchStr: string): string {
     switch (platform) {
         case 'darwin':
-            return `ps -A -o comm,pid,command | grep -ie "${searchStr}"`;
+            return `ps -A -o comm,pid,command | grep -iF -e "${searchStr}"`;
         case 'linux':
-            return `ps -A -o comm,pid,cmd | grep -ie "${searchStr}"`;
+            return `ps -A -o comm,pid,cmd | grep -iF -e "${searchStr}"`;
         case 'win32':
             return `powershell -command "Get-CimInstance -query \\"select * from win32_process WHERE commandLine LIKE '%${searchStr.replaceAll("\\", "\\\\")}%'\\" | Format-Table Name,ProcessId,commandLine | Out-String -Width 512"`;
         default:

--- a/workspaces/ballerina/ballerina-extension/src/features/tryit/utils.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/tryit/utils.ts
@@ -215,9 +215,9 @@ function getServicePorts(pid: string): number[] {
 function getPSCommand(platform: string, searchStr: string): string {
     switch (platform) {
         case 'darwin':
-            return `ps -A -o comm,pid,command | grep -e "${searchStr}"`;
+            return `ps -A -o comm,pid,command | grep -ie "${searchStr}"`;
         case 'linux':
-            return `ps -A -o comm,pid,cmd | grep -e "${searchStr}"`;
+            return `ps -A -o comm,pid,cmd | grep -ie "${searchStr}"`;
         case 'win32':
             return `powershell -command "Get-CimInstance -query \\"select * from win32_process WHERE commandLine LIKE '%${searchStr.replaceAll("\\", "\\\\")}%'\\" | Format-Table Name,ProcessId,commandLine | Out-String -Width 512"`;
         default:


### PR DESCRIPTION
## Purpose
> Fix ballerina process finder 

- The function detects running Ballerina services by searching for the JVM process using:

  `ps -A -o comm,pid,command | grep -e "-XX:HeapDumpPath=<projectPath>"`
  
**What went wrong:**

-   On case-insensitive filesystems (e.g. macOS), the path passed by the extension may differ in case from the actual path on disk. For example, the extension might resolve the project path as /Users/user/MyProject while the JVM sets -XX:HeapDumpPath=/Users/user/myproject. Since grep -e is case-sensitive, this mismatch caused the function to return an empty list even when the service was actively running.

  **The fix:**
  Changed grep -e to grep -ie (added -i for case-insensitive matching) on macOS and Linux. This ensures the process is correctly detected regardless of path case differences.
  
  Updated the PR description to reflect the actual change — the implementation uses `grep -iF -e`:
  - `-i`: case-insensitive matching
  - `-F`: fixed-string matching to avoid regex metacharacter issues
  - `-e`: explicitly passes the pattern to prevent the leading `-` in `-XX:HeapDumpPath=` from being misinterpreted as a flag

## Related issues 

https://github.com/wso2/product-integrator/issues/940
https://github.com/wso2/product-integrator/issues/929

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## UI Component Development
> Specify the reason if following are not followed.
- [x] Added reusable UI components to the ui-toolkit. Follow the [intructions](./workspaces/common-libs/ui-toolkit/README.md) when adding the componenent.
- [x] Use ui-toolkit components wherever possible. Run `npm run storybook` from the root directory to view current components.
- [x] Matches with the native VSCode look and feel.

## Manage Icons
> Specify the reason if following are not followed.
- [x] Added Icons to the font-wso2-vscode. Follow the [instructions](./workspaces/common-libs/font-wso2-vscode/README.md).

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search behavior for the Try It feature on macOS and Linux: search is now case-insensitive and treats queries as literal text, making process matching more reliable and user-friendly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->