### PR TITLE
Fix checkpoint restore failure after early abort

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
@@ -535,7 +535,6 @@ export class AgentExecutor extends AICommandExecutor<GenerateAgentCodeRequest> {
                         console.warn("[AgentExecutor] Could not retrieve partial response messages:", e);
                     }
 
-                    // Only save if LLM actually responded — user message without LLM response is meaningless
                     const projectRootPath = this.config.executionContext.workspacePath || this.config.executionContext.projectPath || '';
                     const threadId = 'default';
                     if (partialLLMMessages.length > 0) {
@@ -551,8 +550,9 @@ Generation stopped by user. The last in-progress task was not saved. Files have 
                                 },
                             ],
                         });
-                        updateAndSaveChat(this.config.generationId, Command.Agent, this.config.eventHandler);
                     }
+                    // Emit save_chat so any pre-step-boundary streamed text is persisted into uiResponse.
+                    updateAndSaveChat(this.config.generationId, Command.Agent, this.config.eventHandler);
                     // Clear review state
                     const pendingReview = chatStateStorage.getPendingReviewGeneration(projectRootPath, threadId);
                     if (pendingReview && pendingReview.id === this.config.generationId) {

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/executors/base/AICommandExecutor.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/executors/base/AICommandExecutor.ts
@@ -183,15 +183,6 @@ export abstract class AICommandExecutor<TParams = any> {
         } finally {
             // Stage 6: Always clear active execution on completion (success or error)
             chatStateStorage.clearActiveExecution(projectRootPath, threadId);
-
-            // Remove generation if LLM never responded — no model messages means nothing useful to persist.
-            // Exception: DataMap/TypeCreator commands save via save_chat (webview), not modelMessages.
-            const gen = chatStateStorage.getGeneration(projectRootPath, threadId, this.config.generationId);
-            const command = this.getCommandType();
-            const savesViaWebview = command === Command.DataMap || command === Command.TypeCreator;
-            if (gen && gen.modelMessages.length === 0 && !savesViaWebview) {
-                chatStateStorage.removeGeneration(projectRootPath, threadId, this.config.generationId);
-            }
         }
     }
 

--- a/workspaces/ballerina/ballerina-extension/src/views/ai-panel/chatStateStorage.ts
+++ b/workspaces/ballerina/ballerina-extension/src/views/ai-panel/chatStateStorage.ts
@@ -685,6 +685,31 @@ export class ChatStateStorage {
         for (const generation of thread.generations) {
             if (generation.modelMessages && generation.modelMessages.length > 0) {
                 messages.push(...generation.modelMessages);
+                continue;
+            }
+            // Aborted before modelMessages were persisted — synthesize from userPrompt/uiResponse.
+            if (!generation.userPrompt) {
+                continue;
+            }
+            if (generation.uiResponse) {
+                messages.push({ role: "user", content: generation.userPrompt });
+                messages.push({ role: "assistant", content: generation.uiResponse });
+                messages.push({
+                    role: "user",
+                    content:
+                        `<system-reminder>\n` +
+                        `The previous assistant response was rendered to the user but the request was interrupted before any tool calls, file edits, or tasks were executed. Any actions described were NOT performed — redo them if still required.\n` +
+                        `</system-reminder>`,
+                });
+            } else {
+                messages.push({
+                    role: "user",
+                    content:
+                        `${generation.userPrompt}\n\n` +
+                        `<system-reminder>\n` +
+                        `The previous user message was interrupted before the assistant could respond. No tool calls or file edits were performed.\n` +
+                        `</system-reminder>`,
+                });
             }
         }
 

--- a/workspaces/ballerina/ballerina-extension/src/views/ai-panel/chatStateStorage.ts
+++ b/workspaces/ballerina/ballerina-extension/src/views/ai-panel/chatStateStorage.ts
@@ -681,10 +681,15 @@ export class ChatStateStorage {
     getChatHistoryForLLM(projectRootPath: string, threadId: string): any[] {
         const thread = this.getOrCreateThread(projectRootPath, threadId);
         const messages: any[] = [];
+        const activeGenerationId = this.getActiveExecution(projectRootPath, threadId)?.generationId;
 
         for (const generation of thread.generations) {
             if (generation.modelMessages && generation.modelMessages.length > 0) {
                 messages.push(...generation.modelMessages);
+                continue;
+            }
+            // Skip the live generation — its prompt is appended separately by the caller.
+            if (generation.id === activeGenerationId) {
                 continue;
             }
             // Aborted before modelMessages were persisted — synthesize from userPrompt/uiResponse.


### PR DESCRIPTION
Fixes https://github.com/wso2/product-integrator/issues/1017

- Stop removing the aborted generation in `AICommandExecutor.finally`. Previously, an early abort (before any model messages were saved) dropped the whole generation row and deleted its checkpoint file, so the UI's Restore Checkpoint separator pointed at nothing.
- Always emit `save_chat` on abort in `AgentExecutor`, so any pre-step-boundary streamed text is persisted into `uiResponse`.
- Extend `getChatHistoryForLLM` to surface aborted generations to the LLM — userPrompt + any partial uiResponse, followed by a `<system-reminder>` noting the request was interrupted and no tool calls/file edits ran.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Chat now persists any already-streamed text when an AI run is aborted, so partial assistant output is saved to the UI.
  * Prevents removal of recent AI generations that contain no model messages, avoiding unintended loss of in-progress interactions.
  * Improves reconstruction of chat history for interrupted runs by synthesizing appropriate user/assistant entries so conversations display more clearly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->