### PR TITLE
Fix chat button silently failing on case-insensitive filesystems

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/features/tryit/utils.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/tryit/utils.ts
@@ -19,6 +19,7 @@
 import { exec, execSync } from 'child_process';
 import { debug } from '../../utils';
 import * as os from 'os';
+import * as fs from 'fs';
 import * as vscode from 'vscode';
 
 export const TRYIT_TEMPLATE = `/*
@@ -144,9 +145,19 @@ export interface Process {
 }
 
 export function findRunningBallerinaProcesses(projectPath: string): Promise<Process[]> {
+    // Resolve to the canonical path so the search matches the path the JVM
+    // recorded for -XX:HeapDumpPath, which can differ in case on case-insensitive
+    // filesystems (macOS APFS, Windows NTFS).
+    let resolvedPath = projectPath;
+    try {
+        resolvedPath = fs.realpathSync.native(projectPath);
+    } catch {
+        // Fall back to the original path if it can't be resolved
+    }
+
     // Execute the 'ps' command to retrieve running processes with command
     return new Promise((resolve, reject) => {
-        exec(getPSCommand(platform, `-XX:HeapDumpPath=${projectPath}`), (error, stdout) => {
+        exec(getPSCommand(platform, `-XX:HeapDumpPath=${resolvedPath}`), (error, stdout) => {
             if (error) {
                 debug(`Failed to detect running Ballerina processes: ${error.message}`);
                 return reject(error);

--- a/workspaces/ballerina/ballerina-extension/src/features/tryit/utils.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/tryit/utils.ts
@@ -144,15 +144,15 @@ export interface Process {
     ports: number[];
 }
 
+const canonicalPathCache = new Map<string, string>();
+
 export function findRunningBallerinaProcesses(projectPath: string): Promise<Process[]> {
-    // Resolve to the canonical path so the search matches the path the JVM
-    // recorded for -XX:HeapDumpPath, which can differ in case on case-insensitive
-    // filesystems (macOS APFS, Windows NTFS).
-    let resolvedPath = projectPath;
-    try {
-        resolvedPath = fs.realpathSync.native(projectPath);
-    } catch {
-        // Fall back to the original path if it can't be resolved
+    // Match the canonical path the JVM records for -XX:HeapDumpPath
+    // (case-insensitive filesystems can hand us a differently-cased path).
+    let resolvedPath = canonicalPathCache.get(projectPath);
+    if (!resolvedPath) {
+        try { resolvedPath = fs.realpathSync.native(projectPath); } catch { resolvedPath = projectPath; }
+        canonicalPathCache.set(projectPath, resolvedPath);
     }
 
     // Execute the 'ps' command to retrieve running processes with command


### PR DESCRIPTION
## Purpose

Fixes https://github.com/wso2/product-integrator/issues/1024

This PR adds a fix for resolving the project path with `fs.realpathSync.native` before grepping the process list for `-XX:HeapDumpPath`.

On macOS (case-insensitive APFS), the path VS Code uses for a project can differ in case from the canonical on-disk path (e.g. `/Users/me/WSO2Integrator/agent` vs `/Users/me/wso2integrator/agent`). The JVM records the canonical path in `-XX:HeapDumpPath`, but `findRunningBallerinaProcesses` was doing a case-sensitive `grep`. The match failed, the extension assumed nothing was running, and the **Chat** button on AI Agents silently did nothing.

The fix: Canonicalize the path with `fs.realpathSync.native(projectPath)` before building the grep pattern, so the search uses the same path the JVM uses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process detection in the Ballerina extension by enhancing file system path resolution mechanisms. The system now correctly identifies running Ballerina processes using their canonical file system paths, significantly improving reliability across different project path representations and configurations. Includes robust fallback handling to ensure compatibility when path resolution encounters issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->