### PR TITLE
Fix tools not getting auto selected when opening MCP tool form in edit mode

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/components/ConnectionSelector/ConnectionCreator.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/components/ConnectionSelector/ConnectionCreator.tsx
@@ -135,6 +135,7 @@ export function ConnectionCreator(props: ConnectionCreatorProps): JSX.Element {
                     <ArtifactForm
                         fileName={connectionsFilePath.current || projectPath.current}
                         fields={connectionFields}
+                        description={nodeFormTemplate?.metadata?.description}
                         onSubmit={handleOnSave}
                         submitText={savingForm ? "Saving..." : "Save"}
                         disableSaveButton={savingForm}

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/AIChatAgent/AddMcpServer.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/AIChatAgent/AddMcpServer.tsx
@@ -420,6 +420,10 @@ export function AddMcpServer(props: AddMcpServerProps): JSX.Element {
                 updatedNode: node,
                 toolScopes: showScopes && Object.keys(toolScopes).length > 0 ? toolScopes : undefined,
             });
+
+            // Safety net: fix any missing imports after all edits are applied
+            await rpcClient.getAIAgentRpcClient().fixMissingImports();
+
             onSave?.();
         } catch (error) {
             console.error("Error saving MCP server:", error);

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/AIChatAgent/AddMcpServer.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/AIChatAgent/AddMcpServer.tsx
@@ -67,7 +67,7 @@ export function AddMcpServer(props: AddMcpServerProps): JSX.Element {
     const [resolutionError, setResolutionError] = useState<string>("");
     const [toolSource, setToolSource] = useState<'auto-fetched' | 'manual-discovery' | 'saved-mock' | null>(null);
     const isInitializingEditModeRef = useRef<boolean>(false);
-    const savedFormValuesRef = useRef<{ serverUrl: string; auth: string } | null>(null);
+    const lastProcessedValuesRef = useRef<{ serverUrl: string; auth: string } | null>(null);
 
     const mcpToolKitNodeTemplateRef = useRef<FlowNode>(null);
     const mcpToolKitNodeRef = useRef<FlowNode>(null);
@@ -293,7 +293,7 @@ export function AddMcpServer(props: AddMcpServerProps): JSX.Element {
 
             const { serverUrl: savedUrl, auth: savedAuth, permittedTools, requiresAuth: savedRequiresAuth, toolScopes: savedToolScopes } = extractOriginalValues(node);
 
-            savedFormValuesRef.current = { serverUrl: savedUrl, auth: savedAuth };
+            lastProcessedValuesRef.current = { serverUrl: savedUrl, auth: savedAuth };
 
             // Update form state so FlowNodeForm displays values
             setRequiresAuth(savedRequiresAuth);
@@ -420,9 +420,12 @@ export function AddMcpServer(props: AddMcpServerProps): JSX.Element {
                 updatedNode: node,
                 toolScopes: showScopes && Object.keys(toolScopes).length > 0 ? toolScopes : undefined,
             });
-
-            // Safety net: fix any missing imports after all edits are applied
-            await rpcClient.getAIAgentRpcClient().fixMissingImports();
+            
+            try {
+                await rpcClient.getAIAgentRpcClient().fixMissingImports();
+            } catch (importFixError) {
+                console.warn("fixMissingImports failed after MCP save", importFixError);
+            }
 
             onSave?.();
         } catch (error) {
@@ -508,23 +511,21 @@ export function AddMcpServer(props: AddMcpServerProps): JSX.Element {
                     node={mcpToolKitNodeRef.current}
                     onSubmit={handleSave}
                     onChange={(fieldKey, value) => {
+                        const processed = lastProcessedValuesRef.current;
                         if (fieldKey === SERVER_URL_FIELD_KEY) {
-                            const savedServerUrl = savedFormValuesRef.current?.serverUrl;
-                            // Skip form replays of the saved value (normalized to ignore syntactic re-wrapping).
-                            const isReplayOfSavedValue =
-                                savedServerUrl !== undefined &&
-                                normalizeExpressionValue(value) === normalizeExpressionValue(savedServerUrl);
+                            const isReplay = processed !== null &&
+                                normalizeExpressionValue(value) === normalizeExpressionValue(processed.serverUrl);
                             setServerUrl(value);
-                            if (editMode && !isInitializingEditModeRef.current && toolSource !== null && !isReplayOfSavedValue) {
+                            if (processed) processed.serverUrl = value;
+                            if (editMode && !isInitializingEditModeRef.current && toolSource !== null && !isReplay) {
                                 setToolSource(null);
                             }
                         } else if (fieldKey === AUTH_FIELD_KEY) {
-                            const savedAuth = savedFormValuesRef.current?.auth;
-                            const isReplayOfSavedValue =
-                                savedAuth !== undefined &&
-                                normalizeExpressionValue(value) === normalizeExpressionValue(savedAuth);
+                            const isReplay = processed !== null &&
+                                normalizeExpressionValue(value) === normalizeExpressionValue(processed.auth);
                             setAuth(value);
-                            if (editMode && !isInitializingEditModeRef.current && toolSource !== null && !isReplayOfSavedValue) {
+                            if (processed) processed.auth = value;
+                            if (editMode && !isInitializingEditModeRef.current && toolSource !== null && !isReplay) {
                                 setToolSource(null);
                             }
                         }

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/AIChatAgent/AddMcpServer.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/AIChatAgent/AddMcpServer.tsx
@@ -39,6 +39,22 @@ const AUTH_FIELD_KEY = "auth";
 const RESULT_FIELD_KEY = "variable";
 const TOOLKIT_NAME_FIELD_KEY = "toolKitName";
 
+// Strip Ballerina wrappers so `"url"` and string `url` compare equal.
+const normalizeExpressionValue = (value: string | undefined | null): string => {
+    if (value === undefined || value === null) return "";
+    let normalized = String(value).trim();
+    if (normalized.startsWith("string ")) {
+        normalized = normalized.slice("string ".length).trim();
+    }
+    if (normalized.length >= 2 && normalized.startsWith("`") && normalized.endsWith("`")) {
+        normalized = normalized.slice(1, -1);
+    }
+    if (normalized.length >= 2 && normalized.startsWith('"') && normalized.endsWith('"')) {
+        normalized = normalized.slice(1, -1);
+    }
+    return normalized;
+};
+
 export function AddMcpServer(props: AddMcpServerProps): JSX.Element {
     const { agentCallNode, onSave, editMode = false } = props;
     const { rpcClient } = useRpcContext();
@@ -63,6 +79,7 @@ export function AddMcpServer(props: AddMcpServerProps): JSX.Element {
     const [resolutionError, setResolutionError] = useState<string>("");
     const [toolSource, setToolSource] = useState<'auto-fetched' | 'manual-discovery' | 'saved-mock' | null>(null);
     const isInitializingEditModeRef = useRef<boolean>(false);
+    const savedFormValuesRef = useRef<{ serverUrl: string; auth: string } | null>(null);
 
     const mcpToolKitNodeTemplateRef = useRef<FlowNode>(null);
     const mcpToolKitNodeRef = useRef<FlowNode>(null);
@@ -288,6 +305,8 @@ export function AddMcpServer(props: AddMcpServerProps): JSX.Element {
 
             const { serverUrl: savedUrl, auth: savedAuth, permittedTools, requiresAuth: savedRequiresAuth, toolScopes: savedToolScopes } = extractOriginalValues(node);
 
+            savedFormValuesRef.current = { serverUrl: savedUrl, auth: savedAuth };
+
             // Update form state so FlowNodeForm displays values
             setRequiresAuth(savedRequiresAuth);
 
@@ -498,13 +517,22 @@ export function AddMcpServer(props: AddMcpServerProps): JSX.Element {
                     onSubmit={handleSave}
                     onChange={(fieldKey, value) => {
                         if (fieldKey === SERVER_URL_FIELD_KEY) {
+                            const savedServerUrl = savedFormValuesRef.current?.serverUrl;
+                            // Skip form replays of the saved value (normalized to ignore syntactic re-wrapping).
+                            const isReplayOfSavedValue =
+                                savedServerUrl !== undefined &&
+                                normalizeExpressionValue(value) === normalizeExpressionValue(savedServerUrl);
                             setServerUrl(value);
-                            if (editMode && !isInitializingEditModeRef.current && toolSource !== null) {
+                            if (editMode && !isInitializingEditModeRef.current && toolSource !== null && !isReplayOfSavedValue) {
                                 setToolSource(null);
                             }
                         } else if (fieldKey === AUTH_FIELD_KEY) {
+                            const savedAuth = savedFormValuesRef.current?.auth;
+                            const isReplayOfSavedValue =
+                                savedAuth !== undefined &&
+                                normalizeExpressionValue(value) === normalizeExpressionValue(savedAuth);
                             setAuth(value);
-                            if (editMode && !isInitializingEditModeRef.current && toolSource !== null) {
+                            if (editMode && !isInitializingEditModeRef.current && toolSource !== null && !isReplayOfSavedValue) {
                                 setToolSource(null);
                             }
                         }

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/AIChatAgent/AddMcpServer.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/AIChatAgent/AddMcpServer.tsx
@@ -19,7 +19,7 @@ import { RequiresAuthCheckbox } from "./Mcp/RequiresAuthCheckbox";
 import { attemptValueResolution, createMockTools, extractOriginalValues, generateToolKitName } from "./Mcp/utils";
 import { cleanServerUrl } from "./formUtils";
 import { Container, LoaderContainer } from "./styles";
-import { extractAccessToken, findAgentNodeFromAgentCallNode, getEndOfFileLineRange, resolveVariableValue, resolveAuthConfig, checkAiPackageVersionSupport } from "./utils";
+import { extractAccessToken, findAgentNodeFromAgentCallNode, getEndOfFileLineRange, removeQuotes, resolveVariableValue, resolveAuthConfig, checkAiPackageVersionSupport } from "./utils";
 
 interface Tool {
     name: string;
@@ -39,21 +39,9 @@ const AUTH_FIELD_KEY = "auth";
 const RESULT_FIELD_KEY = "variable";
 const TOOLKIT_NAME_FIELD_KEY = "toolKitName";
 
-// Strip Ballerina wrappers so `"url"` and string `url` compare equal.
-const normalizeExpressionValue = (value: string | undefined | null): string => {
-    if (value === undefined || value === null) return "";
-    let normalized = String(value).trim();
-    if (normalized.startsWith("string ")) {
-        normalized = normalized.slice("string ".length).trim();
-    }
-    if (normalized.length >= 2 && normalized.startsWith("`") && normalized.endsWith("`")) {
-        normalized = normalized.slice(1, -1);
-    }
-    if (normalized.length >= 2 && normalized.startsWith('"') && normalized.endsWith('"')) {
-        normalized = normalized.slice(1, -1);
-    }
-    return normalized;
-};
+// Delegates to the shared removeQuotes so `"url"` and string `url` compare equal.
+const normalizeExpressionValue = (value: unknown): string =>
+    typeof value === "string" ? removeQuotes(value) : "";
 
 export function AddMcpServer(props: AddMcpServerProps): JSX.Element {
     const { agentCallNode, onSave, editMode = false } = props;

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/AIChatAgent/Mcp/utils.ts
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/AIChatAgent/Mcp/utils.ts
@@ -62,8 +62,8 @@ export async function attemptValueResolution(
         error = `Failed to resolve server URL: ${e instanceof Error ? e.message : String(e)}`;
     }
 
-    // Try to resolve auth
-    let resolvedAuthValue = null;
+    // Default to "" so no-auth servers count as resolved; null signals a real failure.
+    let resolvedAuthValue: string | null = "";
     if (auth && auth.trim()) {
         try {
             resolvedAuthValue = await resolveAuthConfig(

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/AIChatAgent/Mcp/utils.ts
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/AIChatAgent/Mcp/utils.ts
@@ -28,8 +28,8 @@ export interface Tool {
 
 export interface ResolutionResult {
     canResolve: boolean;
-    resolvedUrl: string;
-    resolvedAuth: string;
+    resolvedUrl: string | null;
+    resolvedAuth: string | null;
     error: string;
 }
 

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/FlowDiagram/utils.ts
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/FlowDiagram/utils.ts
@@ -104,7 +104,10 @@ export const getNodeTemplateForConnection = async (
         });
 
     const flowNode = response.flowNode;
-    flowNode.metadata = node.metadata;
+    flowNode.metadata = {
+        ...node.metadata,
+        description: flowNode?.metadata?.description || node?.metadata?.description,
+    };
 
     let connectionKind: string;
     switch (nodeId) {


### PR DESCRIPTION
## Purpose

$subject

Fixes https://github.com/wso2/product-integrator/issues/1034

https://github.com/user-attachments/assets/410bc5f6-d383-462c-918f-32e5271c8b2c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unexpected reset of MCP server form when editing server details.
  * Better handling for MCP servers with empty or missing authentication; resolution no longer fails for blank auth.
  * Trigger post-save import-fix step for MCP server saves and log a warning if it fails.

* **Improvements**
  * Artifact creation form now surfaces connection description from templates.
  * Flow diagram nodes preserve existing description metadata when merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->