### PR TITLE
Fix default model provider config not added automatically when creating inline agents

### DIFF
--- a/workspaces/ballerina/ballerina-extension/CHANGELOG.md
+++ b/workspaces/ballerina/ballerina-extension/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ### Fixed
 
 - **Test Explorer** - Render Ballerina test explorer icons only when a Ballerina project is opened.
+- **Agent Default Model Provider Configuration** - Fixed default model provider configuration not added automatically when creating inline agents.
 
 ## [5.8.2](https://github.com/wso2/vscode-extensions/compare/ballerina-5.8.1...ballerina-5.8.2) - 2026-03-11
 

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
@@ -1372,7 +1372,7 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
             .then(async (response) => {
                 if (response.artifacts.length > 0) {
                     if (updatedNode?.codedata?.symbol === GET_DEFAULT_MODEL_PROVIDER
-                        || (updatedNode?.codedata?.node === "AGENT_CALL" && updatedNode?.properties?.model?.value === "")) {
+                        || (updatedNode?.codedata?.node === "AGENT_CALL" && (updatedNode?.properties?.model?.value === "" || updatedNode?.properties?.model?.value === undefined))) {
                         await rpcClient.getAIAgentRpcClient().configureDefaultModelProvider();
                     }
                     if (noFormSubmitOptions) {


### PR DESCRIPTION
## Purpose

Fixes https://github.com/wso2/product-integrator/issues/708

https://github.com/user-attachments/assets/4c37f791-44a2-4488-9f63-33802be0b2b7