### PR TITLE
Fix package overview not refreshing

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/RPCLayer.ts
+++ b/workspaces/ballerina/ballerina-extension/src/RPCLayer.ts
@@ -190,7 +190,14 @@ function isMigrationPanel(webview: WebviewPanel | WebviewView): boolean {
     return 'reveal' in webview && webview.title === "Migration Assistant";
 }
 
+let _suppressWebviewNotify = false;
+
+export function suppressWebviewNotifications(suppress: boolean) {
+    _suppressWebviewNotify = suppress;
+}
+
 export function notifyCurrentWebview() {
+    if (_suppressWebviewNotify) { return; }
     RPCLayer._messenger.sendNotification(projectContentUpdated, { type: 'webview', webviewType: VisualizerWebview.viewType }, true);
 }
 

--- a/workspaces/ballerina/ballerina-extension/src/RPCLayer.ts
+++ b/workspaces/ballerina/ballerina-extension/src/RPCLayer.ts
@@ -190,14 +190,21 @@ function isMigrationPanel(webview: WebviewPanel | WebviewView): boolean {
     return 'reveal' in webview && webview.title === "Migration Assistant";
 }
 
-let _suppressWebviewNotify = false;
+let _suppressWebviewNotifyCount = 0;
 
-export function suppressWebviewNotifications(suppress: boolean) {
-    _suppressWebviewNotify = suppress;
+// Returns a release function; safe to call multiple times (no-op after first).
+export function suppressWebviewNotifications(): () => void {
+    _suppressWebviewNotifyCount++;
+    let released = false;
+    return () => {
+        if (released) { return; }
+        released = true;
+        _suppressWebviewNotifyCount = Math.max(0, _suppressWebviewNotifyCount - 1);
+    };
 }
 
 export function notifyCurrentWebview() {
-    if (_suppressWebviewNotify) { return; }
+    if (_suppressWebviewNotifyCount > 0) { return; }
     RPCLayer._messenger.sendNotification(projectContentUpdated, { type: 'webview', webviewType: VisualizerWebview.viewType }, true);
 }
 

--- a/workspaces/ballerina/ballerina-extension/src/views/ai-panel/checkpoint/checkpointUtils.ts
+++ b/workspaces/ballerina/ballerina-extension/src/views/ai-panel/checkpoint/checkpointUtils.ts
@@ -171,13 +171,13 @@ export async function restoreWorkspaceSnapshot(checkpoint: Checkpoint, skipArtif
             progress.report({ message: 'Applying workspace changes...' });
 
             // Apply all changes atomically
-            suppressWebviewNotifications(true);
+            const resumeNotifications = suppressWebviewNotifications();
             let success = false;
             try {
                 success = await vscode.workspace.applyEdit(workspaceEdit);
                 await vscode.workspace.saveAll();
             } finally {
-                suppressWebviewNotifications(false);
+                resumeNotifications();
             }
 
             if (!success) {

--- a/workspaces/ballerina/ballerina-extension/src/views/ai-panel/checkpoint/checkpointUtils.ts
+++ b/workspaces/ballerina/ballerina-extension/src/views/ai-panel/checkpoint/checkpointUtils.ts
@@ -135,10 +135,24 @@ export async function restoreWorkspaceSnapshot(checkpoint: Checkpoint, skipArtif
             // Queue all file creations/updates with content
             for (const [filePath, content] of Object.entries(checkpoint.workspaceSnapshot)) {
                 const fileUri = vscode.Uri.file(path.join(workspaceRoot.fsPath, filePath));
-                
+
+                // Skip writes when content already matches on disk.
+                // TODO: Proper fix for Ballerina.toml — rewriting it triggers
+                // an unwanted PackageOverview → WorkspaceOverview redirect.
+                let alreadyMatches = false;
+                try {
+                    const existing = await vscode.workspace.fs.readFile(fileUri);
+                    alreadyMatches = Buffer.from(existing).toString('utf8') === content;
+                } catch {
+                    // File does not exist on disk.
+                }
+                if (alreadyMatches) {
+                    continue;
+                }
+
                 // Create file first (empty or existing)
                 workspaceEdit.createFile(fileUri, { ignoreIfExists: true, overwrite: true });
-                
+
                 // Then replace content to trigger proper LS notifications
                 workspaceEdit.replace(
                     fileUri,

--- a/workspaces/ballerina/ballerina-extension/src/views/ai-panel/checkpoint/checkpointUtils.ts
+++ b/workspaces/ballerina/ballerina-extension/src/views/ai-panel/checkpoint/checkpointUtils.ts
@@ -28,6 +28,10 @@ import { notifyCurrentWebview, suppressWebviewNotifications } from '../../../../
 
 const generateId = () => `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
 
+const SKIP_REWRITE_WHEN_UNCHANGED_FILENAMES: ReadonlySet<string> = new Set([
+    'Ballerina.toml'
+]);
+
 export async function captureWorkspaceSnapshot(messageId: string): Promise<Checkpoint | null> {
     const config = getCheckpointConfig();
 
@@ -136,18 +140,18 @@ export async function restoreWorkspaceSnapshot(checkpoint: Checkpoint, skipArtif
             for (const [filePath, content] of Object.entries(checkpoint.workspaceSnapshot)) {
                 const fileUri = vscode.Uri.file(path.join(workspaceRoot.fsPath, filePath));
 
-                // Skip writes when content already matches on disk.
-                // TODO: Proper fix for Ballerina.toml — rewriting it triggers
-                // an unwanted PackageOverview → WorkspaceOverview redirect.
-                let alreadyMatches = false;
-                try {
-                    const existing = await vscode.workspace.fs.readFile(fileUri);
-                    alreadyMatches = Buffer.from(existing).toString('utf8') === content;
-                } catch {
-                    // File does not exist on disk.
-                }
-                if (alreadyMatches) {
-                    continue;
+                // TODO: workaround — rewriting Ballerina.toml triggers an unwanted PackageOverview → WorkspaceOverview redirect.
+                if (SKIP_REWRITE_WHEN_UNCHANGED_FILENAMES.has(path.basename(filePath))) {
+                    let alreadyMatches = false;
+                    try {
+                        const existing = await vscode.workspace.fs.readFile(fileUri);
+                        alreadyMatches = Buffer.from(existing).toString('utf8') === content;
+                    } catch {
+                        // File does not exist on disk.
+                    }
+                    if (alreadyMatches) {
+                        continue;
+                    }
                 }
 
                 // Create file first (empty or existing)

--- a/workspaces/ballerina/ballerina-extension/src/views/ai-panel/checkpoint/checkpointUtils.ts
+++ b/workspaces/ballerina/ballerina-extension/src/views/ai-panel/checkpoint/checkpointUtils.ts
@@ -24,6 +24,7 @@ import { ArtifactNotificationHandler, ArtifactsUpdated } from '../../../utils/pr
 import { VisualizerRpcManager } from '../../../rpc-managers/visualizer/rpc-manager';
 import { StateMachine, updateView } from '../../../../src/stateMachine';
 import { refreshDataMapper } from '../../../../src/rpc-managers/data-mapper/utils';
+import { notifyCurrentWebview, suppressWebviewNotifications } from '../../../../src/RPCLayer';
 
 const generateId = () => `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
 
@@ -152,14 +153,22 @@ export async function restoreWorkspaceSnapshot(checkpoint: Checkpoint, skipArtif
             progress.report({ message: 'Applying workspace changes...' });
 
             // Apply all changes atomically
-            const success = await vscode.workspace.applyEdit(workspaceEdit);
-            await vscode.workspace.saveAll();
+            suppressWebviewNotifications(true);
+            let success = false;
+            try {
+                success = await vscode.workspace.applyEdit(workspaceEdit);
+                await vscode.workspace.saveAll();
+            } finally {
+                suppressWebviewNotifications(false);
+            }
+
             if (!success) {
                 throw new Error('Failed to apply workspace edit');
             }
 
             progress.report({ message: 'Checkpoint restored successfully!' });
             await renderDatamapper();
+            notifyCurrentWebview();
         });
 
         // Wait for artifact update notification if any .bal files were restored

--- a/workspaces/ballerina/ballerina-rpc-client/src/BallerinaRpcClient.ts
+++ b/workspaces/ballerina/ballerina-rpc-client/src/BallerinaRpcClient.ts
@@ -109,6 +109,7 @@ export class BallerinaRpcClient {
     private _platformExt: PlatformExtRpcClient;
     private _identifierUpdatedCallbacks = new Set<(response: ProjectStructureArtifactResponse[]) => void>();
     private _runningServicesChangedCallbacks = new Set<(services: RunningServiceInfo[]) => void>();
+    private _projectContentUpdatedCallbacks = new Set<(state: boolean) => void>();
 
     constructor() {
         this.messenger = new Messenger(vscode);
@@ -137,6 +138,9 @@ export class BallerinaRpcClient {
         });
         this.messenger.onNotification(runningServicesChanged, (services: RunningServiceInfo[]) => {
             this._runningServicesChangedCallbacks.forEach((callback) => callback(services));
+        });
+        this.messenger.onNotification(projectContentUpdated, (state: boolean) => {
+            this._projectContentUpdatedCallbacks.forEach((callback) => callback(state));
         });
     }
 
@@ -236,8 +240,11 @@ export class BallerinaRpcClient {
         this.messenger.onNotification(promptUpdated, callback);
     }
 
-    onProjectContentUpdated(callback: (state: boolean) => void) {
-        this.messenger.onNotification(projectContentUpdated, callback);
+    onProjectContentUpdated(callback: (state: boolean) => void): () => void {
+        this._projectContentUpdatedCallbacks.add(callback);
+        return () => {
+            this._projectContentUpdatedCallbacks.delete(callback);
+        };
     }
 
     onIdentifierUpdated(callback: (response: ProjectStructureArtifactResponse[]) => void) {

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/WorkspaceOverview/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/WorkspaceOverview/index.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { EditableTitle } from "../../../components/EditableTitle";
 import {
     ProjectStructureResponse,
@@ -699,11 +699,20 @@ export function WorkspaceOverview() {
             });
     };
 
-    rpcClient?.onProjectContentUpdated((state: boolean) => {
-        if (state) {
-            fetchContext();
-        }
-    });
+    // Stable ref so the subscription callback always calls the latest
+    // fetchContext without re-registering on every render.
+    const fetchContextRef = useRef(fetchContext);
+    fetchContextRef.current = fetchContext;
+
+    useEffect(() => {
+        if (!rpcClient) return;
+        const unsubscribe = rpcClient.onProjectContentUpdated((state: boolean) => {
+            if (state) {
+                fetchContextRef.current();
+            }
+        });
+        return unsubscribe;
+    }, [rpcClient]);
 
     useEffect(() => {
         fetchContext();


### PR DESCRIPTION
Fixes https://github.com/wso2/product-integrator/issues/910

In workspace projects, the package overview was not refreshing after Copilot generation finished or after restoring a checkpoint — newly added/changed services and functions did not appear until a manual reload.

- Convert `onProjectContentUpdated` in `BallerinaRpcClient` to a Set-based fan-out so both `PackageOverview` and `TopNavigationBar` receive the notification. `vscode-messenger`'s single-slot registry was letting the child's listener overwrite the parent's, so the overview never re-fetched on any project content update in workspace projects. `WorkspaceOverview` also re-subscribed on every render; switched to a single `useEffect`-scoped subscription.
- Suppress webview notifications during the checkpoint-restore batch write to avoid a storm of per-file notifications while the `WorkspaceEdit` is being applied. Suppression is reentrant (counter-based, returns a release token).
- Fix an unwanted `PackageOverview → WorkspaceOverview` redirect on focus after a checkpoint restore: skip writes whose on-disk `Ballerina.toml` content already matches the snapshot byte-for-byte. The redirect happened because a byte-identical rewrite of the workspace-root `Ballerina.toml` still fired `onDidChangeTextDocument`, which queued a project-info refresh for the next time the webview became active. Scope kept narrow to `Ballerina.toml` on purpose — a broader skip would risk `saveAll()` reviving dirty editor buffers over restored state.