### PR TITLE
Update @codemirror/state to 6.6.0 and clean up dependencies in package.json

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -999,10 +999,10 @@ importers:
         specifier: ~6.8.1
         version: 6.8.5
       '@codemirror/state':
-        specifier: ~6.5.2
-        version: 6.5.4
+        specifier: ~6.6.0
+        version: 6.6.0
       '@codemirror/view':
-        specifier: ~6.38.6
+        specifier: ~6.38.8
         version: 6.38.8
       '@emotion/react':
         specifier: ^11.14.0
@@ -24841,7 +24841,7 @@ snapshots:
   '@codemirror/autocomplete@6.19.1':
     dependencies:
       '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.4
+      '@codemirror/state': 6.6.0
       '@codemirror/view': 6.38.8
       '@lezer/common': 1.5.2
 
@@ -24870,7 +24870,7 @@ snapshots:
     dependencies:
       '@codemirror/autocomplete': 6.19.1
       '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.4
+      '@codemirror/state': 6.6.0
       '@lezer/common': 1.5.2
       '@lezer/css': 1.3.3
 
@@ -24878,7 +24878,7 @@ snapshots:
     dependencies:
       '@codemirror/autocomplete': 6.19.1
       '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.4
+      '@codemirror/state': 6.6.0
       '@lezer/common': 1.5.2
       '@lezer/go': 1.0.1
 
@@ -24888,7 +24888,7 @@ snapshots:
       '@codemirror/lang-css': 6.3.1
       '@codemirror/lang-javascript': 6.2.5
       '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.4
+      '@codemirror/state': 6.6.0
       '@codemirror/view': 6.38.8
       '@lezer/common': 1.5.2
       '@lezer/css': 1.3.3
@@ -24904,7 +24904,7 @@ snapshots:
       '@codemirror/autocomplete': 6.19.1
       '@codemirror/language': 6.11.3
       '@codemirror/lint': 6.8.5
-      '@codemirror/state': 6.5.4
+      '@codemirror/state': 6.6.0
       '@codemirror/view': 6.38.8
       '@lezer/common': 1.5.2
       '@lezer/javascript': 1.5.4
@@ -24914,7 +24914,7 @@ snapshots:
       '@codemirror/autocomplete': 6.19.1
       '@codemirror/lang-html': 6.4.11
       '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.4
+      '@codemirror/state': 6.6.0
       '@codemirror/view': 6.38.8
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
@@ -24938,7 +24938,7 @@ snapshots:
       '@codemirror/autocomplete': 6.19.1
       '@codemirror/lang-html': 6.4.11
       '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.4
+      '@codemirror/state': 6.6.0
       '@codemirror/view': 6.38.8
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
@@ -24949,7 +24949,7 @@ snapshots:
       '@codemirror/autocomplete': 6.19.1
       '@codemirror/lang-html': 6.4.11
       '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.4
+      '@codemirror/state': 6.6.0
       '@codemirror/view': 6.38.8
       '@lezer/common': 1.5.2
       '@lezer/markdown': 1.6.3
@@ -24958,7 +24958,7 @@ snapshots:
     dependencies:
       '@codemirror/lang-html': 6.4.11
       '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.4
+      '@codemirror/state': 6.6.0
       '@lezer/common': 1.5.2
       '@lezer/php': 1.0.5
 
@@ -24966,7 +24966,7 @@ snapshots:
     dependencies:
       '@codemirror/autocomplete': 6.19.1
       '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.4
+      '@codemirror/state': 6.6.0
       '@lezer/common': 1.5.2
       '@lezer/python': 1.1.18
 
@@ -24979,7 +24979,7 @@ snapshots:
     dependencies:
       '@codemirror/lang-css': 6.3.1
       '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.4
+      '@codemirror/state': 6.6.0
       '@lezer/common': 1.5.2
       '@lezer/sass': 1.1.0
 
@@ -24987,7 +24987,7 @@ snapshots:
     dependencies:
       '@codemirror/autocomplete': 6.19.1
       '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.4
+      '@codemirror/state': 6.6.0
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.10
@@ -25012,7 +25012,7 @@ snapshots:
     dependencies:
       '@codemirror/autocomplete': 6.19.1
       '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.4
+      '@codemirror/state': 6.6.0
       '@codemirror/view': 6.38.8
       '@lezer/common': 1.5.2
       '@lezer/xml': 1.0.6
@@ -25021,7 +25021,7 @@ snapshots:
     dependencies:
       '@codemirror/autocomplete': 6.19.1
       '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.4
+      '@codemirror/state': 6.6.0
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.10
@@ -25055,7 +25055,7 @@ snapshots:
 
   '@codemirror/language@6.11.3':
     dependencies:
-      '@codemirror/state': 6.5.4
+      '@codemirror/state': 6.6.0
       '@codemirror/view': 6.38.8
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
@@ -25068,21 +25068,21 @@ snapshots:
 
   '@codemirror/lint@6.8.5':
     dependencies:
-      '@codemirror/state': 6.5.4
+      '@codemirror/state': 6.6.0
       '@codemirror/view': 6.38.8
       crelt: 1.0.6
 
   '@codemirror/merge@6.12.1':
     dependencies:
       '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.4
+      '@codemirror/state': 6.6.0
       '@codemirror/view': 6.38.8
       '@lezer/highlight': 1.2.3
       style-mod: 4.1.3
 
   '@codemirror/search@6.7.0':
     dependencies:
-      '@codemirror/state': 6.5.4
+      '@codemirror/state': 6.6.0
       '@codemirror/view': 6.38.8
       crelt: 1.0.6
 
@@ -25097,13 +25097,13 @@ snapshots:
   '@codemirror/theme-one-dark@6.1.3':
     dependencies:
       '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.4
+      '@codemirror/state': 6.6.0
       '@codemirror/view': 6.38.8
       '@lezer/highlight': 1.2.3
 
   '@codemirror/view@6.38.8':
     dependencies:
-      '@codemirror/state': 6.5.4
+      '@codemirror/state': 6.6.0
       crelt: 1.0.6
       style-mod: 4.1.3
       w3c-keyname: 2.2.8
@@ -25130,7 +25130,7 @@ snapshots:
       '@codemirror/lang-html': 6.4.11
       '@codemirror/lang-javascript': 6.2.5
       '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.4
+      '@codemirror/state': 6.6.0
       '@codemirror/view': 6.38.8
       '@codesandbox/sandpack-client': 2.19.8
       '@lezer/highlight': 1.2.3
@@ -35960,14 +35960,14 @@ snapshots:
       '@codemirror/language': 6.11.3
       '@codemirror/lint': 6.8.5
       '@codemirror/search': 6.7.0
-      '@codemirror/state': 6.5.4
+      '@codemirror/state': 6.6.0
       '@codemirror/view': 6.38.8
 
   '@uiw/react-codemirror@4.23.14(@codemirror/lint@6.8.5)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.38.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@codemirror/commands': 6.10.3
-      '@codemirror/state': 6.5.4
+      '@codemirror/state': 6.6.0
       '@codemirror/theme-one-dark': 6.1.3
       '@codemirror/view': 6.38.8
       '@uiw/codemirror-extensions-basic-setup': 4.23.14(@codemirror/lint@6.8.5)
@@ -38567,7 +38567,7 @@ snapshots:
       '@codemirror/language': 6.11.3
       '@codemirror/lint': 6.8.5
       '@codemirror/search': 6.7.0
-      '@codemirror/state': 6.5.4
+      '@codemirror/state': 6.6.0
       '@codemirror/view': 6.38.8
 
   collapse-white-space@1.0.6: {}

--- a/workspaces/ballerina/ballerina-side-panel/package.json
+++ b/workspaces/ballerina/ballerina-side-panel/package.json
@@ -20,10 +20,13 @@
     "dependencies": {
         "@codemirror/autocomplete": "~6.19.1",
         "@codemirror/commands": "~6.10.0",
+        "@codemirror/lang-sql": "~6.10.0",
+        "@codemirror/language": "~6.11.3",
         "@codemirror/language-data": "~6.5.2",
         "@codemirror/lint": "~6.8.1",
-        "@codemirror/state": "~6.5.2",
+        "@codemirror/state": "~6.6.0",
         "@codemirror/view": "~6.38.8",
+        "@lezer/highlight": "~1.2.3",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
         "@wso2/ballerina-core": "workspace:*",
@@ -48,14 +51,7 @@
         "react-markdown": "~10.1.0",
         "rehype-raw": "^7.0.0",
         "remark-gfm": "^4.0.1",
-        "@github/markdown-toolbar-element": "^2.2.3",
-        "@codemirror/commands": "~6.10.0",
-        "@codemirror/state": "~6.5.2",
-        "@codemirror/view": "~6.38.6",
-        "@codemirror/autocomplete": "~6.19.1",
-        "@codemirror/lang-sql": "~6.10.0",
-        "@codemirror/language": "~6.11.3",
-        "@lezer/highlight": "~1.2.3"
+        "@github/markdown-toolbar-element": "^2.2.3"
     },
     "devDependencies": {
         "@storybook/react": "^6.5.16",


### PR DESCRIPTION
## Purpose

$subject

Fixes the following error when opening forms that use codemirror:
```
react-dom.development.js:12056 Uncaught Error: Unrecognized extension value in extension set ([object Object]). This sometimes happens because multiple instances of @codemirror/state are loaded, breaking instanceof checks.
```