### PR TITLE
Update identifier error handling in `IdentifierField` component to disable save button in forms

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/IdentifierField.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/IdentifierField.tsx
@@ -39,6 +39,9 @@ export function IdentifierField(props: IdentifierFieldProps) {
     const { errors } = formState;
     const hasSetIdentifierErrorRef = useRef(false);
     const isMountedRef = useRef(true);
+    // form is unstable across parent renders; ref keeps deps clean
+    const formRef = useRef(form);
+    formRef.current = form;
 
     useEffect(() => {
         return () => {
@@ -51,12 +54,12 @@ export function IdentifierField(props: IdentifierFieldProps) {
             setError(field.key, { type: "identifier_diagnostic", message: errorMessage });
             hasSetIdentifierErrorRef.current = true;
         } else if (hasSetIdentifierErrorRef.current) {
-            if (form.formState.errors[field.key]?.type === "identifier_diagnostic") {
+            if (formRef.current.formState.errors[field.key]?.type === "identifier_diagnostic") {
                 clearErrors(field.key);
             }
             hasSetIdentifierErrorRef.current = false;
         }
-    }, [field.key, setError, clearErrors, form]);
+    }, [field.key, setError, clearErrors]);
 
     useEffect(() => {
         setFormDiagnostics(field.diagnostics);
@@ -67,13 +70,13 @@ export function IdentifierField(props: IdentifierFieldProps) {
         const key = field.key;
         return () => {
             if (hasSetIdentifierErrorRef.current) {
-                if (form.formState.errors[key]?.type === "identifier_diagnostic") {
+                if (formRef.current.formState.errors[key]?.type === "identifier_diagnostic") {
                     clearErrors(key);
                 }
                 hasSetIdentifierErrorRef.current = false;
             }
         };
-    }, [field.key, clearErrors, form]);
+    }, [field.key, clearErrors]);
 
     // Sync external field value changes to the form (e.g., when a sibling field's onValueChange updates the value)
     useEffect(() => {

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/IdentifierField.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/IdentifierField.tsx
@@ -38,16 +38,25 @@ export function IdentifierField(props: IdentifierFieldProps) {
     const { watch, formState, register, setValue, setError, clearErrors } = form;
     const { errors } = formState;
     const hasSetIdentifierErrorRef = useRef(false);
+    const isMountedRef = useRef(true);
+
+    useEffect(() => {
+        return () => {
+            isMountedRef.current = false;
+        };
+    }, []);
 
     const setIdentifierErrorState = useCallback((errorMessage: string | null) => {
         if (errorMessage) {
             setError(field.key, { type: "identifier_diagnostic", message: errorMessage });
             hasSetIdentifierErrorRef.current = true;
         } else if (hasSetIdentifierErrorRef.current) {
-            clearErrors(field.key);
+            if (form.formState.errors[field.key]?.type === "identifier_diagnostic") {
+                clearErrors(field.key);
+            }
             hasSetIdentifierErrorRef.current = false;
         }
-    }, [field.key, setError, clearErrors]);
+    }, [field.key, setError, clearErrors, form]);
 
     useEffect(() => {
         setFormDiagnostics(field.diagnostics);
@@ -58,11 +67,13 @@ export function IdentifierField(props: IdentifierFieldProps) {
         const key = field.key;
         return () => {
             if (hasSetIdentifierErrorRef.current) {
-                clearErrors(key);
+                if (form.formState.errors[key]?.type === "identifier_diagnostic") {
+                    clearErrors(key);
+                }
                 hasSetIdentifierErrorRef.current = false;
             }
         };
-    }, [field.key, clearErrors]);
+    }, [field.key, clearErrors, form]);
 
     // Sync external field value changes to the form (e.g., when a sibling field's onValueChange updates the value)
     useEffect(() => {
@@ -82,6 +93,7 @@ export function IdentifierField(props: IdentifierFieldProps) {
                     property: getPropertyFromFormField(field)
                 }
             });
+            if (!isMountedRef.current) return;
             if (response.diagnostics.length > 0) {
                 const rawDiagnostic = response.diagnostics[0];
                 setFormDiagnostics([{ message: rawDiagnostic.message, severity: mapDiagnosticsServerityToFormSeverity(rawDiagnostic.severity) }]);
@@ -93,11 +105,18 @@ export function IdentifierField(props: IdentifierFieldProps) {
             }
         } catch (error) {
             console.error('Failed to fetch expression diagnostics:', error);
+            if (!isMountedRef.current) return;
             // Optionally clear diagnostics or show error state
             setFormDiagnostics([]);
             setIdentifierErrorState(null);
         }
     }, 250), [rpcClient, field, targetLineRange, fileName, setIdentifierErrorState]);
+
+    useEffect(() => {
+        return () => {
+            validateIdentifierName.cancel();
+        };
+    }, [validateIdentifierName]);
 
     const handleOnBlur = (e: React.ChangeEvent<HTMLInputElement>) => {
         validateIdentifierName(e.target.value);

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/IdentifierField.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/IdentifierField.tsx
@@ -115,12 +115,6 @@ export function IdentifierField(props: IdentifierFieldProps) {
         }
     }, 250), [rpcClient, field, targetLineRange, fileName, setIdentifierErrorState]);
 
-    useEffect(() => {
-        return () => {
-            validateIdentifierName.cancel();
-        };
-    }, [validateIdentifierName]);
-
     const handleOnBlur = (e: React.ChangeEvent<HTMLInputElement>) => {
         validateIdentifierName(e.target.value);
         onBlur?.();

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/IdentifierField.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/IdentifierField.tsx
@@ -17,7 +17,7 @@
  */
 
 import { ErrorBanner, TextField } from "@wso2/ui-toolkit";
-import React, { useState, useCallback, useEffect } from "react";
+import React, { useState, useCallback, useEffect, useRef } from "react";
 import { debounce } from "lodash";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { useFormContext } from "../../context";
@@ -35,12 +35,34 @@ export function IdentifierField(props: IdentifierFieldProps) {
     const { rpcClient } = useRpcContext();
     const { form, targetLineRange, fileName } = useFormContext();
     const [formDiagnostics, setFormDiagnostics] = useState(field.diagnostics);
-    const { watch, formState, register, setValue } = form;
+    const { watch, formState, register, setValue, setError, clearErrors } = form;
     const { errors } = formState;
+    const hasSetIdentifierErrorRef = useRef(false);
+
+    const setIdentifierErrorState = useCallback((errorMessage: string | null) => {
+        if (errorMessage) {
+            setError(field.key, { type: "identifier_diagnostic", message: errorMessage });
+            hasSetIdentifierErrorRef.current = true;
+        } else if (hasSetIdentifierErrorRef.current) {
+            clearErrors(field.key);
+            hasSetIdentifierErrorRef.current = false;
+        }
+    }, [field.key, setError, clearErrors]);
 
     useEffect(() => {
         setFormDiagnostics(field.diagnostics);
     }, [field.diagnostics]);
+
+    // Clear our identifier diagnostic error on unmount so it doesn't persist and block save after the field is gone
+    useEffect(() => {
+        const key = field.key;
+        return () => {
+            if (hasSetIdentifierErrorRef.current) {
+                clearErrors(key);
+                hasSetIdentifierErrorRef.current = false;
+            }
+        };
+    }, [field.key, clearErrors]);
 
     // Sync external field value changes to the form (e.g., when a sibling field's onValueChange updates the value)
     useEffect(() => {
@@ -61,16 +83,21 @@ export function IdentifierField(props: IdentifierFieldProps) {
                 }
             });
             if (response.diagnostics.length > 0) {
-                setFormDiagnostics([{message: response.diagnostics[0].message, severity: mapDiagnosticsServerityToFormSeverity(response.diagnostics[0].severity)}]);
+                const rawDiagnostic = response.diagnostics[0];
+                setFormDiagnostics([{ message: rawDiagnostic.message, severity: mapDiagnosticsServerityToFormSeverity(rawDiagnostic.severity) }]);
+                const errorDiagnostic = response.diagnostics.find((d) => d.severity === 1);
+                setIdentifierErrorState(errorDiagnostic?.message ?? null);
             } else {
                 setFormDiagnostics([]);
+                setIdentifierErrorState(null);
             }
         } catch (error) {
             console.error('Failed to fetch expression diagnostics:', error);
             // Optionally clear diagnostics or show error state
             setFormDiagnostics([]);
+            setIdentifierErrorState(null);
         }
-    }, 250), [rpcClient, field, targetLineRange, fileName]);
+    }, 250), [rpcClient, field, targetLineRange, fileName, setIdentifierErrorState]);
 
     const handleOnBlur = (e: React.ChangeEvent<HTMLInputElement>) => {
         validateIdentifierName(e.target.value);

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/IdentifierField.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/IdentifierField.tsx
@@ -17,7 +17,7 @@
  */
 
 import { ErrorBanner, TextField } from "@wso2/ui-toolkit";
-import React, { useState, useCallback, useEffect, useRef } from "react";
+import React, { useState, useCallback, useEffect } from "react";
 import { debounce } from "lodash";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { useFormContext } from "../../context";
@@ -34,49 +34,13 @@ export function IdentifierField(props: IdentifierFieldProps) {
     const { field, handleOnFieldFocus, autoFocus, onBlur } = props;
     const { rpcClient } = useRpcContext();
     const { form, targetLineRange, fileName } = useFormContext();
-    const [formDiagnostics, setFormDiagnostics] = useState(field.diagnostics);
     const { watch, formState, register, setValue, setError, clearErrors } = form;
     const { errors } = formState;
-    const hasSetIdentifierErrorRef = useRef(false);
-    const isMountedRef = useRef(true);
-    // form is unstable across parent renders; ref keeps deps clean
-    const formRef = useRef(form);
-    formRef.current = form;
-
-    useEffect(() => {
-        return () => {
-            isMountedRef.current = false;
-        };
-    }, []);
-
-    const setIdentifierErrorState = useCallback((errorMessage: string | null) => {
-        if (errorMessage) {
-            setError(field.key, { type: "identifier_diagnostic", message: errorMessage });
-            hasSetIdentifierErrorRef.current = true;
-        } else if (hasSetIdentifierErrorRef.current) {
-            if (formRef.current.formState.errors[field.key]?.type === "identifier_diagnostic") {
-                clearErrors(field.key);
-            }
-            hasSetIdentifierErrorRef.current = false;
-        }
-    }, [field.key, setError, clearErrors]);
+    const [formDiagnostics, setFormDiagnostics] = useState(field.diagnostics);
 
     useEffect(() => {
         setFormDiagnostics(field.diagnostics);
     }, [field.diagnostics]);
-
-    // Clear our identifier diagnostic error on unmount so it doesn't persist and block save after the field is gone
-    useEffect(() => {
-        const key = field.key;
-        return () => {
-            if (hasSetIdentifierErrorRef.current) {
-                if (formRef.current.formState.errors[key]?.type === "identifier_diagnostic") {
-                    clearErrors(key);
-                }
-                hasSetIdentifierErrorRef.current = false;
-            }
-        };
-    }, [field.key, clearErrors]);
 
     // Sync external field value changes to the form (e.g., when a sibling field's onValueChange updates the value)
     useEffect(() => {
@@ -96,34 +60,40 @@ export function IdentifierField(props: IdentifierFieldProps) {
                     property: getPropertyFromFormField(field)
                 }
             });
-            if (!isMountedRef.current) return;
             if (response.diagnostics.length > 0) {
                 const rawDiagnostic = response.diagnostics[0];
                 setFormDiagnostics([{ message: rawDiagnostic.message, severity: mapDiagnosticsServerityToFormSeverity(rawDiagnostic.severity) }]);
                 const errorDiagnostic = response.diagnostics.find((d) => d.severity === 1);
-                setIdentifierErrorState(errorDiagnostic?.message ?? null);
+                if (errorDiagnostic) {
+                    setError(field.key, { type: "identifier_diagnostic", message: errorDiagnostic.message });
+                } else {
+                    clearErrors(field.key);
+                }
             } else {
                 setFormDiagnostics([]);
-                setIdentifierErrorState(null);
+                clearErrors(field.key);
             }
         } catch (error) {
             console.error('Failed to fetch expression diagnostics:', error);
-            if (!isMountedRef.current) return;
-            // Optionally clear diagnostics or show error state
             setFormDiagnostics([]);
-            setIdentifierErrorState(null);
+            clearErrors(field.key);
         }
-    }, 250), [rpcClient, field, targetLineRange, fileName, setIdentifierErrorState]);
+    }, 250), [rpcClient, field.key, field.codedata, targetLineRange, fileName, setError, clearErrors]);
 
-    const handleOnBlur = (e: React.ChangeEvent<HTMLInputElement>) => {
-        validateIdentifierName(e.target.value);
-        onBlur?.();
-    }
+    // Validate on value change (covers initial load, paste, programmatic updates, typing)
+    const fieldValue = watch(field.key);
+    useEffect(() => {
+        if (fieldValue !== undefined && fieldValue !== null) {
+            validateIdentifierName(String(fieldValue));
+        }
+        return () => validateIdentifierName.cancel();
+    }, [fieldValue, validateIdentifierName]);
 
-    const handleOnFocus = (e: React.ChangeEvent<HTMLInputElement>) => {
-        validateIdentifierName(e.target.value);
-        handleOnFieldFocus?.(field.key);
-    }
+    // Clear error on unmount so it doesn't persist and block save after the field is gone
+    useEffect(() => {
+        const key = field.key;
+        return () => clearErrors(key);
+    }, [field.key, clearErrors]);
 
     const registerField = register(field.key, {
         required: buildRequiredRule({ isRequired: !field.optional, label: field.label }),
@@ -135,7 +105,6 @@ export function IdentifierField(props: IdentifierFieldProps) {
     const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         setFormDiagnostics([]);
         onChange(e);
-        validateIdentifierName(e.target.value);
         field.onValueChange?.(e.target.value as string);
     }
 
@@ -151,8 +120,8 @@ export function IdentifierField(props: IdentifierFieldProps) {
                 placeholder={field.placeholder}
                 readOnly={!field.editable}
                 errorMsg={errors[field.key]?.message.toString()}
-                onBlur={(e) => handleOnBlur(e)}
-                onFocus={(e) => handleOnFocus(e)}
+                onBlur={() => onBlur?.()}
+                onFocus={() => handleOnFieldFocus?.(field.key)}
                 autoFocus={autoFocus}
                 sx={{ width: "100%" }}
             />


### PR DESCRIPTION
## Purpose

Fixes https://github.com/wso2/product-integrator/issues/1116

This PR updates the IdentifierField component, to allow the error diagnostics shown in the field, to disable the save button in forms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Identifier field now surfaces diagnostic messages as field-level validation errors when appropriate, preventing stale errors from blocking saves
  * Validation errors are cleared when diagnostic checks fail or when leaving the field
  * Cleanup on unmount/cancelled validation prevents lingering or late-applied identifier errors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->