### PR TITLE
Fix markdown code block detection and error icon cursor in AI chat

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/ErrorBox.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/ErrorBox.tsx
@@ -17,7 +17,6 @@
  */
 
 import styled from "@emotion/styled";
-import { Codicon } from "@wso2/ui-toolkit";
 import React from "react";
 
 const Container = styled.div`
@@ -59,7 +58,7 @@ interface ErrorBoxProps {
 const ErrorBox: React.FC<ErrorBoxProps> = ({ children }) => {
     return (
         <Container>
-            <Codicon name="error" />
+            <span className="codicon codicon-error" />
             <ErrorText>{children}</ErrorText>
         </Container>
     );

--- a/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/MarkdownRenderer.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/MarkdownRenderer.tsx
@@ -179,12 +179,14 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ markdownContent }) 
         code({ inline, className, children }: { inline?: boolean; className?: string; children: React.ReactNode }) {
             const codeContent = (Array.isArray(children) ? children.join("") : children) ?? "";
             const match = /language-(\w+)/.exec(className || "");
+            // react-markdown v10+ omits `inline`; infer block by language class or newline.
+            const isBlock = !inline && (!!match || String(codeContent).includes("\n"));
 
-            if (!inline && match) {
-                const language = match[1];
+            if (isBlock) {
+                const language = match?.[1];
 
                 // Apply syntax highlighting if language is registered
-                if (hljs.getLanguage(language)) {
+                if (language && hljs.getLanguage(language)) {
                     return (
                         <pre>
                             <code


### PR DESCRIPTION
Fixes https://github.com/wso2/product-integrator/issues/1169
Fixes https://github.com/wso2/product-integrator/issues/1086

- Fix code block detection in `MarkdownRenderer` for react-markdown v10, which dropped the `inline` prop — now infers block vs inline from the presence of a language class or a newline in the content
- Fix pointer cursor showing on the error icon in `ErrorBox` — replaced `<Codicon>` (which has `cursor: pointer` hardcoded) with a plain `<span className="codicon codicon-error" />` since the icon is purely decorative

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced code block rendering to better detect languages and infer layout behavior for improved syntax highlighting support.

* **Refactor**
  * Streamlined error icon rendering in internal components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->