### PR TITLE
Fix navigate between different artifacts in different integrations

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/MainPanel.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/MainPanel.tsx
@@ -391,7 +391,7 @@ const MainPanel = () => {
                             if (isStaleNavigation()) return;
                             setViewComponent(
                                 <DiagramWrapper
-                                    key={value?.identifier}
+                                    key={[value?.documentUri, value?.identifier].filter(Boolean).join('#')}
                                     syntaxTree={st.syntaxTree}
                                     projectPath={value?.projectPath}
                                     filePath={value?.documentUri}
@@ -405,7 +405,7 @@ const MainPanel = () => {
                             // Fallback to render without waiting
                             setViewComponent(
                                 <DiagramWrapper
-                                    key={value?.identifier}
+                                    key={[value?.documentUri, value?.identifier].filter(Boolean).join('#')}
                                     projectPath={value?.projectPath}
                                     filePath={value?.documentUri}
                                     view={value?.focusFlowDiagramView}


### PR DESCRIPTION
## Purpose
$title
Addresses: https://github.com/wso2/product-integrator/issues/1043

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagram rendering consistency by enhancing how the system tracks diagram state during document transitions. Diagrams now load and display reliably when switching between different documents, providing a more stable visualization experience. This improvement applies consistently across both successful loads and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->