### PR TITLE
Fix Missing Type when Adding GraphQL Input

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/GraphQLDiagram/OperationForm.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/GraphQLDiagram/OperationForm.tsx
@@ -64,7 +64,10 @@ export function OperationForm(props: OperationFormProps) {
 
         params.forEach(param => {
             // Find matching field configurations from schema
-            const typeField = paramFields.find(field => getPrimaryInputType(field.types)?.fieldType === 'TYPE');
+            const typeField = paramFields.find(field => {
+                const fieldType = getPrimaryInputType(field.types)?.fieldType;
+                return fieldType === 'TYPE' || fieldType === 'ACTION_TYPE';
+            });
             const nameField = paramFields.find(field => field.key === 'variable');
             const defaultField = paramFields.find(field => field.key === 'defaultable');
             const documentationField = paramFields.find(field => field.key === 'documentation');


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-integrator/issues/888

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed parameter field configuration in GraphQL operation forms. The parameter lookup logic now properly recognizes and processes additional field type categories, ensuring all parameters are correctly configured with appropriate enabled, editable, advanced, and optional properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->