### PR TITLE
Fix AI panel code context path for workspace projects

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/prompts.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/prompts.ts
@@ -243,10 +243,13 @@ export function getUserPrompt(params: GenerateAgentCodeRequest, tempProjectPath:
 
     // Add code context if available
     if (params.codeContext) {
-        content.push({
-            type: 'text' as const,
-            text: formatCodeContext(params.codeContext, tempProjectPath)
-        });
+        const codeContextText = formatCodeContext(params.codeContext, tempProjectPath);
+        if (codeContextText) {
+            content.push({
+                type: 'text' as const,
+                text: codeContextText
+            });
+        }
     }
 
     // Add file attachments if available

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/utils.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/utils.ts
@@ -355,6 +355,11 @@ export async function applyTextEdits(filePath: string, textEdits: TextEdit[]): P
 export function formatCodeContext(codeContext: CodeContext, tempProjectPath: string): string {
     const absolutePath = path.join(tempProjectPath, codeContext.filePath);
 
+    if (!fs.existsSync(absolutePath)) {
+        console.warn(`[formatCodeContext] File not found in temp project: ${absolutePath}`);
+        return '';
+    }
+
     const fileContent = normalizeToLf(fs.readFileSync(absolutePath, "utf-8"));
     const lines = fileContent.split("\n");
     const totalLines = lines.length;

--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
@@ -116,11 +116,13 @@ export class AiPanelRpcManager implements AIPanelAPI {
     async getDefaultPrompt(): Promise<AIPanelPrompt> {
         let defaultPrompt: AIPanelPrompt = extension.aiChatDefaultPrompt;
 
-        // Normalize code context to use relative paths
+        // Normalize code context to use workspace-relative paths
         if (defaultPrompt && 'codeContext' in defaultPrompt && defaultPrompt.codeContext) {
+            const smCtx = StateMachine.context();
+            const workspaceRoot = smCtx.workspacePath || smCtx.projectPath;
             defaultPrompt = {
                 ...defaultPrompt,
-                codeContext: normalizeCodeContext(defaultPrompt.codeContext)
+                codeContext: normalizeCodeContext(defaultPrompt.codeContext, workspaceRoot, smCtx.projectPath)
             };
         }
 

--- a/workspaces/ballerina/ballerina-extension/src/views/ai-panel/codeContextUtils.ts
+++ b/workspaces/ballerina/ballerina-extension/src/views/ai-panel/codeContextUtils.ts
@@ -21,27 +21,31 @@ import { workspace } from 'vscode';
 import { CodeContext } from '@wso2/ballerina-core/lib/rpc-types/ai-panel/interfaces';
 
 /**
- * Normalizes codeContext to use relative paths from workspace root
- * @param codeContext The code context with potentially absolute file path
- * @returns CodeContext with relative file path, or undefined if input is undefined
+ * Normalizes codeContext filePath to be relative to the workspace root.
+ * @param codeContext   The code context with a potentially absolute or package-relative filePath.
+ * @param workspaceRoot Ballerina workspace root (workspacePath ?? projectPath).
+ * @param projectPath   Active package path, used to resolve package-relative filePaths correctly.
+ * @returns CodeContext with workspace-relative filePath, or undefined if input is undefined
  */
-export const normalizeCodeContext = (codeContext?: CodeContext): CodeContext | undefined => {
+export const normalizeCodeContext = (codeContext?: CodeContext, workspaceRoot?: string, projectPath?: string): CodeContext | undefined => {
     if (!codeContext) {
         return undefined;
     }
 
     const workspaceFolders = workspace.workspaceFolders;
-    if (!workspaceFolders || workspaceFolders.length === 0) {
+    const root = workspaceRoot || workspaceFolders?.[0]?.uri.fsPath;
+
+    if (!root) {
         return codeContext;
     }
 
-    const workspaceRoot = workspaceFolders[0].uri.fsPath;
+    // Resolve relative paths against the package dir so the workspace prefix is included
+    const resolveBase = projectPath || root;
     const absolutePath = path.isAbsolute(codeContext.filePath)
         ? codeContext.filePath
-        : path.join(workspaceRoot, codeContext.filePath);
+        : path.join(resolveBase, codeContext.filePath);
 
-    // Convert to relative path from workspace root
-    const relativePath = path.relative(workspaceRoot, absolutePath);
+    const relativePath = path.relative(root, absolutePath);
 
     if (codeContext.type === 'addition') {
         return {


### PR DESCRIPTION
Fixes https://github.com/wso2/product-integrator/issues/566

## Problem

When clicking "Fix with AI" in a Ballerina workspace project (a workspace with multiple packages), the AI panel crashed with an `ENOENT` error. The file path passed to the agent was missing the package directory prefix — e.g. `functions.bal` instead of `package1/functions.bal` — so the file couldn't be located in the temp project copy.

## Root Cause

`normalizeCodeContext` was using `workspaceFolders[0]` (the VS Code folder, which points to the package directory) as the root when computing a workspace-relative path. But the agent's temp project is rooted at the Ballerina workspace level. In a multi-package workspace, this caused the package directory prefix to be stripped out.

## Fix

- `normalizeCodeContext` now accepts `workspaceRoot` and `projectPath` parameters. Relative filePaths are first resolved against the package directory, then made relative to the workspace root — producing the correct prefixed path (e.g. `package1/functions.bal`)
- `rpc-manager.ts` passes `workspacePath || projectPath` and `projectPath` from `StateMachine.context()`, matching the base path the agent uses for the temp project
- `formatCodeContext` now returns an empty string instead of throwing when a file doesn't exist, and the caller skips the empty block rather than pushing it into the prompt