### PR TITLE
Fix FileIntegration Move to field blocking save on LS diagnostic errors

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/FileIntegrationForm/TextExpressionField.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/FileIntegrationForm/TextExpressionField.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
 import styled from "@emotion/styled";
 import { debounce } from "lodash";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
@@ -245,7 +245,16 @@ export interface TextExpressionFieldProps {
     onValidationStateChange?: (state: { isValidating: boolean }) => void;
 }
 
-export function TextExpressionField(props: TextExpressionFieldProps) {
+export interface TextExpressionFieldHandle {
+    /**
+     * Synchronously re-runs expression diagnostics against the language server for the current
+     * value, bypassing the typing-time debounce. Returns the resulting diagnostics. If the LS
+     * call itself fails, returns an empty array (same silent fallback as typing-time validation).
+     */
+    revalidate: () => Promise<Diagnostic[]>;
+}
+
+export const TextExpressionField = forwardRef<TextExpressionFieldHandle, TextExpressionFieldProps>((props, ref) => {
     const { id, value, property, filePath, targetLineRange, required, disabled, onChange, onDiagnosticsChange, onValidationStateChange } = props;
     const { rpcClient } = useRpcContext();
 
@@ -337,50 +346,67 @@ export function TextExpressionField(props: TextExpressionFieldProps) {
         return templateContent !== null && templateContent.trim() === "";
     }, [value]);
 
+    const runValidation = useCallback(async (expression: string): Promise<Diagnostic[]> => {
+        if (!rpcClient || !filePath) {
+            resetValidationState();
+            return [];
+        }
+
+        const startLine = targetLineRange?.startLine ?? { line: 0, offset: 0 };
+        const expressionForDiagnostics = inputMode === InputMode.TEXT
+            && !isQuotedStringLiteral(expression)
+            && !isStringTemplateLiteral(expression)
+            ? JSON.stringify(expression)
+            : expression;
+        const prop = toDiagnosticsExpressionProperty(propertyRef.current, expressionForDiagnostics);
+
+        let result: Diagnostic[] = [];
+        try {
+            const response = await rpcClient.getBIDiagramRpcClient().getExpressionDiagnostics({
+                filePath,
+                context: {
+                    expression: expressionForDiagnostics,
+                    startLine,
+                    lineOffset: 0,
+                    offset: 0,
+                    codedata: prop.codedata,
+                    property: prop,
+                } as any,
+            });
+
+            result = removeDuplicateDiagnostics(response.diagnostics || []);
+            setDiagnostics(result);
+            onDiagnosticsChangeRef.current?.(result);
+        } catch (error) {
+            // Silently ignore LS failures during fast textarea validation; the save path
+            // re-runs validation via revalidate() to give the LS one more chance before save.
+            console.error(">>> Error getting expression diagnostics", error);
+            setDiagnostics([]);
+            onDiagnosticsChangeRef.current?.([]);
+        } finally {
+            setIsValidating(false);
+        }
+        return result;
+    }, [rpcClient, filePath, targetLineRange, inputMode, resetValidationState]);
+
     const validateExpression = useMemo(
-        () =>
-            debounce(async (expression: string) => {
-                if (!rpcClient || !filePath) {
-                    resetValidationState();
-                    return;
-                }
-
-                const startLine = targetLineRange?.startLine ?? { line: 0, offset: 0 };
-                const expressionForDiagnostics = inputMode === InputMode.TEXT
-                    && !isQuotedStringLiteral(expression)
-                    && !isStringTemplateLiteral(expression)
-                    ? JSON.stringify(expression)
-                    : expression;
-                const prop = toDiagnosticsExpressionProperty(propertyRef.current, expressionForDiagnostics);
-
-                try {
-                    const response = await rpcClient.getBIDiagramRpcClient().getExpressionDiagnostics({
-                        filePath,
-                        context: {
-                            expression: expressionForDiagnostics,
-                            startLine,
-                            lineOffset: 0,
-                            offset: 0,
-                            codedata: prop.codedata,
-                            property: prop,
-                        } as any,
-                    });
-
-                    const uniqueDiagnostics = removeDuplicateDiagnostics(response.diagnostics || []);
-                    setDiagnostics(uniqueDiagnostics);
-                    onDiagnosticsChangeRef.current?.(uniqueDiagnostics);
-                } catch (error) {
-                    // Silently ignore LS failures during fast textarea validation; the save path
-                    // revalidates the generated source and surfaces any real errors there.
-                    console.error(">>> Error getting expression diagnostics", error);
-                    setDiagnostics([]);
-                    onDiagnosticsChangeRef.current?.([]);
-                } finally {
-                    setIsValidating(false);
-                }
-            }, 250),
-        [rpcClient, filePath, targetLineRange, inputMode, resetValidationState]
+        () => debounce((expression: string) => { void runValidation(expression); }, 250),
+        [runValidation]
     );
+
+    useImperativeHandle(ref, () => ({
+        revalidate: async () => {
+            validateExpression.cancel();
+            const trimmed = getTrimmed(value);
+            if (!trimmed) {
+                setDiagnostics([]);
+                onDiagnosticsChangeRef.current?.([]);
+                setIsValidating(false);
+                return [];
+            }
+            return runValidation(value);
+        }
+    }), [validateExpression, runValidation, value]);
 
     const retrieveCompletions = useMemo(
         () =>
@@ -667,4 +693,6 @@ export function TextExpressionField(props: TextExpressionFieldProps) {
             />
         </div>
     );
-}
+});
+
+TextExpressionField.displayName = "TextExpressionField";

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/FileIntegrationForm/TextExpressionField.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/FileIntegrationForm/TextExpressionField.tsx
@@ -192,39 +192,6 @@ const removeLiteralWrapping = (value: string): string => {
     return unquoteStringLiteral(trimmed);
 };
 
-const getValidationErrorMessage = (error: unknown): string => {
-    if (error instanceof Error && error.message) {
-        return error.message;
-    }
-
-    if (typeof error === "string" && error.trim()) {
-        return error;
-    }
-
-    if (error && typeof error === "object") {
-        const err = error as Record<string, any>;
-        const message =
-            err?.message ||
-            err?.error?.message ||
-            err?.data?.message ||
-            err?.response?.message ||
-            err?.response?.data?.message;
-        if (typeof message === "string" && message.trim()) {
-            return message;
-        }
-        try {
-            const serialized = JSON.stringify(error);
-            if (serialized && serialized !== "{}") {
-                return serialized;
-            }
-        } catch {
-            // Ignore stringify failures and return fallback.
-        }
-    }
-
-    return "Unable to validate expression.";
-};
-
 const toExpressionProperty = (propertyModel: PropertyModel | undefined, value: string): ExpressionProperty => ({
     metadata: {
         label: propertyModel?.metadata?.label || "",
@@ -275,7 +242,7 @@ export interface TextExpressionFieldProps {
     disabled?: boolean;
     onChange: (value: string) => void;
     onDiagnosticsChange?: (diagnostics: Diagnostic[]) => void;
-    onValidationStateChange?: (state: { isValidating: boolean; hasValidationFailure: boolean }) => void;
+    onValidationStateChange?: (state: { isValidating: boolean }) => void;
 }
 
 export function TextExpressionField(props: TextExpressionFieldProps) {
@@ -326,8 +293,6 @@ export function TextExpressionField(props: TextExpressionFieldProps) {
     });
     const [diagnostics, setDiagnostics] = useState<Diagnostic[]>([]);
     const [isValidating, setIsValidating] = useState(false);
-    const [hasValidationFailure, setHasValidationFailure] = useState(false);
-    const [validationFailureMessage, setValidationFailureMessage] = useState("");
     const [showWarning, setShowWarning] = useState(false);
     const [completions, setCompletions] = useState<CompletionItem[]>([]);
     const [filteredCompletions, setFilteredCompletions] = useState<CompletionItem[]>([]);
@@ -347,22 +312,16 @@ export function TextExpressionField(props: TextExpressionFieldProps) {
     }, [onValidationStateChange]);
 
     useEffect(() => {
-        onValidationStateChangeRef.current?.({ isValidating, hasValidationFailure });
-    }, [isValidating, hasValidationFailure]);
+        onValidationStateChangeRef.current?.({ isValidating });
+    }, [isValidating]);
 
     useEffect(() => {
         propertyRef.current = property;
     }, [property]);
 
-    const clearValidationFailure = useCallback(() => {
-        setHasValidationFailure(false);
-        setValidationFailureMessage("");
-    }, []);
-
     const resetValidationState = useCallback(() => {
         setIsValidating(false);
-        clearValidationFailure();
-    }, [clearValidationFailure]);
+    }, []);
 
     const canSwitchToText = useMemo(() => {
         const trimmed = getTrimmed(value);
@@ -410,19 +369,17 @@ export function TextExpressionField(props: TextExpressionFieldProps) {
                     const uniqueDiagnostics = removeDuplicateDiagnostics(response.diagnostics || []);
                     setDiagnostics(uniqueDiagnostics);
                     onDiagnosticsChangeRef.current?.(uniqueDiagnostics);
-                    clearValidationFailure();
-                } catch (e) {
-                    // Treat LS diagnostics failures as blocking save until recovered.
+                } catch (error) {
+                    // Silently ignore LS failures during fast textarea validation; the save path
+                    // revalidates the generated source and surfaces any real errors there.
+                    console.error(">>> Error getting expression diagnostics", error);
                     setDiagnostics([]);
                     onDiagnosticsChangeRef.current?.([]);
-                    setHasValidationFailure(true);
-                    const errorMessage = getValidationErrorMessage(e);
-                    setValidationFailureMessage(errorMessage);
                 } finally {
                     setIsValidating(false);
                 }
             }, 250),
-        [rpcClient, filePath, targetLineRange, inputMode, clearValidationFailure, resetValidationState]
+        [rpcClient, filePath, targetLineRange, inputMode, resetValidationState]
     );
 
     const retrieveCompletions = useMemo(
@@ -521,7 +478,7 @@ export function TextExpressionField(props: TextExpressionFieldProps) {
     useEffect(() => {
         return () => {
             onDiagnosticsChange?.([]);
-            onValidationStateChange?.({ isValidating: false, hasValidationFailure: false });
+            onValidationStateChange?.({ isValidating: false });
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
@@ -695,10 +652,6 @@ export function TextExpressionField(props: TextExpressionFieldProps) {
 
             {errorDiagnostics.length > 0 && (
                 <ErrorBanner errorMsg={errorMessage} />
-            )}
-
-            {hasValidationFailure && (
-                <ErrorBanner errorMsg={validationFailureMessage || `Unable to validate ${fieldLabel} expression from language server diagnostics.`} />
             )}
 
             <WarningPopup

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/FileIntegrationForm/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/FileIntegrationForm/index.tsx
@@ -16,14 +16,14 @@
  * under the License.
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ActionButtons, Divider, SidePanelBody, ProgressIndicator, Tooltip, CheckBoxGroup, CheckBox, Codicon, LinkButton, Dropdown, Typography, RadioButtonGroup } from '@wso2/ui-toolkit';
 import styled from '@emotion/styled';
 import { Diagnostic, FunctionModel, ParameterModel, GeneralPayloadContext, Type, ServiceModel, Protocol, Imports, PropertyModel } from '@wso2/ballerina-core';
 import { cloneDeep } from 'lodash';
 import { EntryPointTypeCreator } from '../../../../../components/EntryPointTypeCreator';
 import { Parameters } from './Parameters/Parameters';
-import { TextExpressionField } from './TextExpressionField';
+import { TextExpressionField, TextExpressionFieldHandle } from './TextExpressionField';
 
 const FileConfigContainer = styled.div`
     margin-bottom: 0;
@@ -231,10 +231,25 @@ export function FileIntegrationForm(props: FileIntegrationFormProps) {
         }
     };
 
-    const handleSave = () => {
-        if (functionModel) {
-            onSave(functionModel, isNew);
+    const moveToFieldRefs = useRef<Record<string, TextExpressionFieldHandle | null>>({});
+
+    const handleSave = async () => {
+        if (!functionModel) return;
+
+        // Save-time revalidation: matches the DeclareVariable / FlowNodeForm pattern of running a
+        // final LS check before save. Typing-time diagnostics are debounced and swallow LS errors
+        // silently, so this is the authoritative gate. Severity-1 diagnostics block save; LS
+        // failures here fall through silently and the save proceeds (same contract as typing-time).
+        const liveRefs = Object.values(moveToFieldRefs.current).filter(
+            (handle): handle is TextExpressionFieldHandle => handle !== null && handle !== undefined
+        );
+        if (liveRefs.length > 0) {
+            const allDiagnostics = await Promise.all(liveRefs.map(h => h.revalidate()));
+            const hasErrorDiagnostics = allDiagnostics.some(diags => diags.some(d => d.severity === 1));
+            if (hasErrorDiagnostics) return;
         }
+
+        onSave(functionModel, isNew);
     };
 
     const handleCancel = () => {
@@ -660,6 +675,13 @@ export function FileIntegrationForm(props: FileIntegrationFormProps) {
                                 return (
                                     <TextExpressionField
                                         key={stateKey}
+                                        ref={(handle) => {
+                                            if (handle) {
+                                                moveToFieldRefs.current[stateKey] = handle;
+                                            } else {
+                                                delete moveToFieldRefs.current[stateKey];
+                                            }
+                                        }}
                                         id={`ftp-${functionModel?.name?.value ?? 'handler'}-${stateKey}`}
                                         value={prop.value || ''}
                                         property={prop}

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/FileIntegrationForm/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/FileIntegrationForm/index.tsx
@@ -168,7 +168,6 @@ export interface FileIntegrationFormProps {
 
 type MoveToValidationState = {
     isValidating: boolean;
-    hasValidationFailure: boolean;
 };
 
 export function FileIntegrationForm(props: FileIntegrationFormProps) {
@@ -447,10 +446,6 @@ export function FileIntegrationForm(props: FileIntegrationFormProps) {
         return Object.values(moveToValidationStateByAction).some(s => s?.isValidating);
     }, [moveToValidationStateByAction]);
 
-    const hasMoveToValidationFailure = useMemo(() => {
-        return Object.values(moveToValidationStateByAction).some(s => s?.hasValidationFailure);
-    }, [moveToValidationStateByAction]);
-
     // ----- Choice helpers — model-driven, no 'MOVE' string hardcoding -----
 
     const getSelectedActionValue = (action: PropertyModel | undefined): string => {
@@ -486,7 +481,7 @@ export function FileIntegrationForm(props: FileIntegrationFormProps) {
         return postProcessSubActions.some(([, action]) => isRequiredNestedPropertyEmpty(action));
     }, [postProcessSubActions]);
 
-    const isSaveDisabled = hasInvalidMoveTo || hasMoveToErrorDiagnostics || hasPendingMoveToValidation || hasMoveToValidationFailure;
+    const isSaveDisabled = hasInvalidMoveTo || hasMoveToErrorDiagnostics || hasPendingMoveToValidation;
 
     const saveTooltip = useMemo(() => {
         if (isSaving) return "Saving...";


### PR DESCRIPTION
## Summary
- Stop treating language server exceptions during fast expression diagnostics as blocking validation failures in the File Integration form's Move to field
- Transient LS errors now clear silently (matching the DeclareVariable / FlowNodeForm pattern); real errors are still surfaced by the save-path compile diagnostics

Fixes wso2/product-integrator#1152

## Test plan
- [ ] Open an FTP file integration and edit an existing handler that uses After Processing > Move to
- [ ] Verify the field no longer shows "Error fetching expression diagnostics from ls" on open
- [ ] Verify save is enabled without needing to make the field dirty first
- [ ] Verify legitimate expression errors (e.g. undefined variable) still render as inline diagnostics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified validation state reporting in form fields—text expression validation now reports only whether validation is actively running, removing redundant failure state tracking.
  * Removed the error banner UI element that previously displayed validation failures.
  * Updated the form save button's disable logic to evaluate validation status based on current process state and error diagnostics severity rather than cached validation failure flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->