### PR TITLE
Warn on FileIntegration handler signature change; preserve advanced params

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/WarningPopup/index.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/WarningPopup/index.tsx
@@ -25,12 +25,15 @@ interface WarningPopupProps {
     isOpen: boolean;
     onContinue: () => void;
     onCancel: () => void;
+    message?: string;
 }
 
-const WarningPopup: React.FC<WarningPopupProps> = ({ isOpen, onContinue, onCancel }) => {
+const DEFAULT_MESSAGE = "If you continue, you will lose all structured information. Do you want to continue?";
+
+const WarningPopup: React.FC<WarningPopupProps> = ({ isOpen, onContinue, onCancel, message }) => {
     return (
         <Modal isOpen={isOpen} onClose={onCancel} maxWidth='90%'>
-            <p>If you continue, you will lose all structured information. Do you want to continue?</p>
+            <p>{message ?? DEFAULT_MESSAGE}</p>
             <ButtonContainer>
                 <Button 
                     appearance='primary'

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/FileIntegrationForm/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/FileIntegrationForm/index.tsx
@@ -16,14 +16,18 @@
  * under the License.
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ActionButtons, Divider, SidePanelBody, ProgressIndicator, Tooltip, CheckBoxGroup, CheckBox, Codicon, LinkButton, Dropdown, Typography, RadioButtonGroup } from '@wso2/ui-toolkit';
 import styled from '@emotion/styled';
 import { Diagnostic, FunctionModel, ParameterModel, GeneralPayloadContext, Type, ServiceModel, Protocol, Imports, PropertyModel } from '@wso2/ballerina-core';
 import { cloneDeep } from 'lodash';
+import WarningPopup from '@wso2/ballerina-side-panel/lib/components/WarningPopup';
 import { EntryPointTypeCreator } from '../../../../../components/EntryPointTypeCreator';
 import { Parameters } from './Parameters/Parameters';
 import { TextExpressionField } from './TextExpressionField';
+
+const SIGNATURE_CHANGE_BODY_WARNING =
+    "This edit will change the file handler signature. Nodes in the function body may be broken due to this change. Continue?";
 
 const FileConfigContainer = styled.div`
     margin-bottom: 0;
@@ -147,6 +151,18 @@ const typeNameToParamName = (typeName: string, pluralize: boolean = false): stri
     return camelCase + 's';
 };
 
+/**
+ * Produces a stable key representing the function's generated signature. Two models that share
+ * this key regenerate to the same signature; any diff here indicates that saving will rewrite
+ * the handler signature on disk and potentially break body code that referenced the previous one.
+ */
+const getFunctionSignatureKey = (fm: FunctionModel): string => {
+    const params = (fm.parameters ?? []).map(p =>
+        [p.kind ?? '', p.name?.value ?? '', p.type?.value ?? '', p.enabled ?? false].join('|')
+    );
+    return [fm.name?.value ?? '', ...params].join(';');
+};
+
 export const EditorContentColumn = styled.div`
     display: flex;
     flex-direction: column;
@@ -183,6 +199,8 @@ export function FileIntegrationForm(props: FileIntegrationFormProps) {
     } as GeneralPayloadContext;
 
     const [isTypeEditorOpen, setIsTypeEditorOpen] = useState<boolean>(false);
+    const [isSignatureWarningOpen, setIsSignatureWarningOpen] = useState<boolean>(false);
+    const initialSignatureKeyRef = useRef<string | null>(null);
 
     // Derive the event-category label from model (e.g. "onCreate", "onError")
     const currentCategory = functionModel?.metadata?.label || selectedHandler;
@@ -224,6 +242,7 @@ export function FileIntegrationForm(props: FileIntegrationFormProps) {
             return;
         }
         setFunctionModel(props.functionModel ? cloneDeep(props.functionModel) : null);
+        initialSignatureKeyRef.current = props.functionModel ? getFunctionSignatureKey(props.functionModel) : null;
     }, [isNew, props.functionModel]);
 
     const handleParamChange = (params: ParameterModel[]) => {
@@ -232,10 +251,35 @@ export function FileIntegrationForm(props: FileIntegrationFormProps) {
         }
     };
 
-    const handleSave = () => {
+    const hasSignatureChanged = (): boolean => {
+        if (isNew || !functionModel || !initialSignatureKeyRef.current) {
+            return false;
+        }
+        return getFunctionSignatureKey(functionModel) !== initialSignatureKeyRef.current;
+    };
+
+    const performSave = () => {
         if (functionModel) {
             onSave(functionModel, isNew);
         }
+    };
+
+    const handleSave = () => {
+        if (!functionModel) return;
+        if (hasSignatureChanged()) {
+            setIsSignatureWarningOpen(true);
+            return;
+        }
+        performSave();
+    };
+
+    const confirmSignatureChangeSave = () => {
+        setIsSignatureWarningOpen(false);
+        performSave();
+    };
+
+    const cancelSignatureChangeSave = () => {
+        setIsSignatureWarningOpen(false);
     };
 
     const handleCancel = () => {
@@ -766,12 +810,18 @@ export function FileIntegrationForm(props: FileIntegrationFormProps) {
                                                 </Typography>
                                                 <Parameters
                                                     parameters={[contentParameter]}
-                                                    onChange={(params) => {
-                                                        if (params.length === 0) {
+                                                    onChange={(editedContentParams) => {
+                                                        if (editedContentParams.length === 0) {
                                                             handleDeleteContentSchema();
-                                                        } else {
-                                                            handleParamChange(params);
+                                                            return;
                                                         }
+                                                        // Parameters is rendered with only the content param, so preserve
+                                                        // the rest of the function's parameters (advanced params, etc.).
+                                                        const [editedContent] = editedContentParams;
+                                                        const merged = (functionModel.parameters ?? []).map(p =>
+                                                            p.kind === 'DATA_BINDING' ? editedContent : p
+                                                        );
+                                                        handleParamChange(merged);
                                                     }}
                                                     showPayload={true}
                                                     typeLabel={contentSchemaLabel}
@@ -849,6 +899,13 @@ export function FileIntegrationForm(props: FileIntegrationFormProps) {
                     sx={{ justifyContent: "flex-end" }}
                 />
             </SidePanelBody>
+
+            <WarningPopup
+                isOpen={isSignatureWarningOpen}
+                onContinue={confirmSignatureChangeSave}
+                onCancel={cancelSignatureChangeSave}
+                message={SIGNATURE_CHANGE_BODY_WARNING}
+            />
 
             {/* EntryPointTypeCreator Modal for Define Content Schema */}
             <EntryPointTypeCreator


### PR DESCRIPTION


https://github.com/user-attachments/assets/93d9b906-cc61-4da7-a31c-2b55ca6df612




## Summary
- Show a confirmation dialog when saving a FileIntegration handler edit that would rewrite the function signature (content schema bind/unbind, stream toggle, advanced parameter toggle, parameter rename, file format change)
- Fix an adjacent bug where editing an existing content schema wiped the Advanced Configurations section — the content-schema Parameters onChange replaced the full parameter list with just the content param; now it merges the edited param back into the full list
- Parameterize \`WarningPopup\` with an optional \`message\` prop (default text preserved for existing callers)

Fixes wso2/product-integrator#1179

## Test plan
- [ ] Edit an existing handler, define a content schema, click Save → warning dialog appears; Continue saves, Cancel stays on the form
- [ ] Edit an existing handler, toggle the stream checkbox, Save → warning appears
- [ ] Edit an existing handler, toggle an advanced parameter, Save → warning appears
- [ ] Edit an existing handler, rename a parameter via the Parameters edit UI, Save → warning appears
- [ ] Edit only the \`Move to\` path in After Processing (no signature change), Save → no warning
- [ ] Create a new handler, Save → no warning
- [ ] With a handler that has advanced parameters visible, edit the content schema → advanced parameters remain visible after the edit (regression fix)
- [ ] Existing \`WarningPopup\` callers (ModeSwitcher, TextExpressionField text/expression switch) still show the original "lose structured information" message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added warning notification when function signatures change during save operations
  * Warning messages can now be customized

* **Bug Fixes**
  * Parameters editor now preserves advanced settings when editing content

<!-- end of auto-generated comment: release notes by coderabbit.ai -->