### PR TITLE
Remove record item from type editor completions

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/bi-diagram/rpc-manager.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/bi-diagram/rpc-manager.ts
@@ -1588,7 +1588,7 @@ export class BiDiagramRpcManager implements BIDiagramAPI {
             StateMachine.langClient()
                 .getVisibleTypes(params)
                 .then((visibleTypes) => {
-                    resolve(visibleTypes);
+                    resolve(visibleTypes?.filter((item) => item.label !== "record"));
                 })
                 .catch((error) => {
                     reject("Error fetching visible types from ls");


### PR DESCRIPTION
## Purpose
> Remove `record` item from the type editor completions
Resolves: https://github.com/wso2/product-integrator/issues/1122

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of type items in diagram visualization to enhance accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->