### PR TITLE
fix: clear top-level diagnostic banner on form field change

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FlowNodeForm/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FlowNodeForm/index.tsx
@@ -714,6 +714,16 @@ export const FlowNodeForm = forwardRef<FormExpressionEditorRef, FlowNodeFormProp
         }
     };
 
+    const handleFormChange = useCallback(
+        (fieldKey: string, value: any, allValues: FormValues) => {
+            if (formDiagnostics.length > 0) {
+                setFormDiagnostics([]);
+            }
+            onChange?.(fieldKey, value, allValues);
+        },
+        [formDiagnostics, onChange]
+    );
+
     const mergeFormDataWithFlowNode = (data: FormValues, targetLineRange: LineRange, dirtyFields?: any): FlowNode => {
         const clonedNode = cloneDeep(node);
         // Create updated node with new line range
@@ -1918,7 +1928,7 @@ export const FlowNodeForm = forwardRef<FormExpressionEditorRef, FlowNodeFormProp
                         node.codedata.node === ("DATA_MAPPER_CREATION" as NodeKind)
                     }
                     scopeFieldAddon={scopeFieldAddon}
-                    onChange={onChange}
+                    onChange={handleFormChange}
                     injectedComponents={injectedComponents}
                     derivedFields={props.derivedFields}
                     updateImports={handleUpdateImports}

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FlowNodeForm/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FlowNodeForm/index.tsx
@@ -716,12 +716,10 @@ export const FlowNodeForm = forwardRef<FormExpressionEditorRef, FlowNodeFormProp
 
     const handleFormChange = useCallback(
         (fieldKey: string, value: any, allValues: FormValues) => {
-            if (formDiagnostics.length > 0) {
-                setFormDiagnostics([]);
-            }
+            setFormDiagnostics(prev => prev.length > 0 ? [] : prev);
             onChange?.(fieldKey, value, allValues);
         },
-        [formDiagnostics, onChange]
+        [onChange]
     );
 
     const mergeFormDataWithFlowNode = (data: FormValues, targetLineRange: LineRange, dirtyFields?: any): FlowNode => {


### PR DESCRIPTION
## Summary

- When a BI diagram node has diagnostics not tied to any specific property, the `ErrorBanner` at the top of the form now clears as soon as the user edits any field
- Adds an internal `handleFormChange` callback in `FlowNodeForm` that calls `setFormDiagnostics([])` on first field change before forwarding to the external `onChange` prop
- Full form validation on Save/Update is unaffected

Fixes wso2/product-integrator#985

## Test plan

- [ ] Open a Ballerina BI diagram with a node that has a node-level diagnostic (e.g., a misconfigured expression causing a language server error)
- [ ] Click the node to open the form panel — confirm the `ErrorBanner` with "Fix with AI" is visible at the top
- [ ] Edit any form field — confirm the `ErrorBanner` disappears immediately
- [ ] Click Save — confirm normal field-level validation still fires correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Form diagnostic messages now automatically clear when field values are modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->