### PR TITLE
Prompt user before stopping a running BI integration on running another BI integration

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/features/debugger/config-provider.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/debugger/config-provider.ts
@@ -660,6 +660,7 @@ class BIRunAdapter extends LoggingDebugSession {
     taskTerminationListener: Disposable | null = null;
 
     private session: DebugSession;
+    private disconnected = false;
     private static activeAdapter: BIRunAdapter | null = null;
 
     constructor(session: DebugSession) {
@@ -695,14 +696,15 @@ class BIRunAdapter extends LoggingDebugSession {
                     const timeout = setTimeout(async () => {
                         listener.dispose();
                         const forceChoice = await window.showWarningMessage(
-                            'The previous integration is taking too long to stop. Force start the new integration anyway?',
-                            'Force Start', 'Cancel'
+                            'The previous integration has not stopped yet (terminate was already sent). Force start the new integration anyway?',
+                            'Force Start', 'Cancel new launch'
                         );
                         if (forceChoice === 'Force Start') {
                             BIRunAdapter.activeAdapter = null;
                             resolve(true);
                         } else {
-                            // Leave activeAdapter set — the old process is still running.
+                            // terminate() was already issued; the old process is still shutting down.
+                            // Abort the new launch — the old process will finish stopping on its own.
                             resolve(false);
                         }
                     }, 10000);
@@ -786,10 +788,16 @@ class BIRunAdapter extends LoggingDebugSession {
                     // Add task termination listener
                     this.taskTerminationListener = tasks.onDidEndTaskProcess(e => {
                         if (e.execution === this.task) {
+                            this.taskTerminationListener?.dispose();
+                            this.taskTerminationListener = null;
                             if (BIRunAdapter.activeAdapter === this) {
                                 BIRunAdapter.activeAdapter = null;
                             }
-                            this.sendEvent(new TerminatedEvent());
+                            // Skip TerminatedEvent if disconnectRequest already fired —
+                            // the session is already being torn down by VS Code.
+                            if (!this.disconnected) {
+                                this.sendEvent(new TerminatedEvent());
+                            }
                         }
                     });
 
@@ -807,13 +815,18 @@ class BIRunAdapter extends LoggingDebugSession {
     }
 
     protected disconnectRequest(response: DebugProtocol.DisconnectResponse, args: DebugProtocol.DisconnectArguments, request?: DebugProtocol.Request): void {
+        this.disconnected = true;
         if (this.task) {
             this.task.terminate();
-        }
-        if (BIRunAdapter.activeAdapter === this) {
+            // Don't clear activeAdapter here — the process is still shutting down.
+            // taskTerminationListener will clear it once onDidEndTaskProcess fires.
+        } else if (BIRunAdapter.activeAdapter === this) {
             BIRunAdapter.activeAdapter = null;
         }
-        this.cleanupListeners();
+        if (this.notificationHandler) {
+            this.notificationHandler.dispose();
+            this.notificationHandler = null;
+        }
         response.success = true;
         this.sendResponse(response);
     }

--- a/workspaces/ballerina/ballerina-extension/src/features/debugger/config-provider.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/debugger/config-provider.ts
@@ -685,15 +685,22 @@ class BIRunAdapter extends LoggingDebugSession {
                     this.sendEvent(new TerminatedEvent());
                     return;
                 }
-                BIRunAdapter.activeAdapter = null;
                 // Await full termination before starting the new task to avoid port
                 // conflicts from the still-shutting-down previous process.
+                // activeAdapter is cleared inside the promise so concurrent launches
+                // still see a running integration until the process actually stops.
                 await new Promise<void>((resolve) => {
-                    const timeout = setTimeout(resolve, 3000);
-                    const listener = tasks.onDidEndTaskProcess(e => {
+                    let listener: { dispose(): void };
+                    const timeout = setTimeout(() => {
+                        listener.dispose();
+                        BIRunAdapter.activeAdapter = null;
+                        resolve();
+                    }, 10000);
+                    listener = tasks.onDidEndTaskProcess(e => {
                         if (e.execution === existingTask) {
                             clearTimeout(timeout);
                             listener.dispose();
+                            BIRunAdapter.activeAdapter = null;
                             resolve();
                         }
                     });
@@ -701,6 +708,7 @@ class BIRunAdapter extends LoggingDebugSession {
                     if (!tasks.taskExecutions.some(e => e === existingTask)) {
                         clearTimeout(timeout);
                         listener.dispose();
+                        BIRunAdapter.activeAdapter = null;
                         resolve();
                         return;
                     }

--- a/workspaces/ballerina/ballerina-extension/src/features/debugger/config-provider.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/debugger/config-provider.ts
@@ -687,21 +687,31 @@ class BIRunAdapter extends LoggingDebugSession {
                 }
                 // Await full termination before starting the new task to avoid port
                 // conflicts from the still-shutting-down previous process.
-                // activeAdapter is cleared inside the promise so concurrent launches
-                // still see a running integration until the process actually stops.
-                await new Promise<void>((resolve) => {
+                // activeAdapter is cleared only when the task is confirmed stopped (or
+                // the user explicitly forces a start), so concurrent launches always
+                // see a live reference while the previous process is still alive.
+                const shouldProceed = await new Promise<boolean>((resolve) => {
                     let listener: { dispose(): void };
-                    const timeout = setTimeout(() => {
+                    const timeout = setTimeout(async () => {
                         listener.dispose();
-                        BIRunAdapter.activeAdapter = null;
-                        resolve();
+                        const forceChoice = await window.showWarningMessage(
+                            'The previous integration is taking too long to stop. Force start the new integration anyway?',
+                            'Force Start', 'Cancel'
+                        );
+                        if (forceChoice === 'Force Start') {
+                            BIRunAdapter.activeAdapter = null;
+                            resolve(true);
+                        } else {
+                            // Leave activeAdapter set — the old process is still running.
+                            resolve(false);
+                        }
                     }, 10000);
                     listener = tasks.onDidEndTaskProcess(e => {
                         if (e.execution === existingTask) {
                             clearTimeout(timeout);
                             listener.dispose();
                             BIRunAdapter.activeAdapter = null;
-                            resolve();
+                            resolve(true);
                         }
                     });
                     // Task may have already ended while the dialog was open.
@@ -709,11 +719,19 @@ class BIRunAdapter extends LoggingDebugSession {
                         clearTimeout(timeout);
                         listener.dispose();
                         BIRunAdapter.activeAdapter = null;
-                        resolve();
+                        resolve(true);
                         return;
                     }
                     existingTask.terminate();
                 });
+
+                if (!shouldProceed) {
+                    (this.session.configuration as any).suggestTryit = false;
+                    response.success = true;
+                    this.sendResponse(response);
+                    this.sendEvent(new TerminatedEvent());
+                    return;
+                }
             }
 
             const taskDefinition: TaskDefinition = {

--- a/workspaces/ballerina/ballerina-extension/src/features/debugger/config-provider.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/debugger/config-provider.ts
@@ -713,9 +713,10 @@ class BIRunAdapter extends LoggingDebugSession {
                             if (forceChoice === 'Force Start') {
                                 resolve(true);
                             } else {
-                                // Old process is shutting down — no valid reference to restore.
+                                // Process is still running — restore the previous adapter so
+                                // subsequent launches still detect it as a conflict.
                                 if (BIRunAdapter.activeAdapter === this) {
-                                    BIRunAdapter.activeAdapter = null;
+                                    BIRunAdapter.activeAdapter = existingAdapter;
                                 }
                                 resolve(false);
                             }
@@ -795,10 +796,19 @@ class BIRunAdapter extends LoggingDebugSession {
                 execution
             );
 
+            // Guard against being superseded while awaiting getCurrentProjectRoot() or the
+            // termination wait above — the other adapter already owns the slot.
+            if (BIRunAdapter.activeAdapter !== this) {
+                (this.session.configuration as any).suggestTryit = false;
+                response.success = true;
+                this.sendResponse(response);
+                this.sendEvent(new TerminatedEvent());
+                return;
+            }
+
             try {
                 const taskExecution = await tasks.executeTask(task);
                 this.task = taskExecution;
-                // activeAdapter is already set to this — assigned before any await above.
 
                 this.taskTerminationListener = tasks.onDidEndTaskProcess(e => {
                     if (e.execution === this.task) {

--- a/workspaces/ballerina/ballerina-extension/src/features/debugger/config-provider.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/debugger/config-provider.ts
@@ -278,6 +278,8 @@ async function getModifiedConfigs(workspaceFolder: WorkspaceFolder, config: Debu
         }
     }
 
+    config.name = path.basename(config.script);
+
     // To make compatible with 1.2.x which supports scriptArguments
     if (config.programArgs) {
         config.scriptArguments = config.programArgs;
@@ -657,8 +659,26 @@ class BIRunAdapter extends LoggingDebugSession {
     task: TaskExecution | null = null;
     taskTerminationListener: Disposable | null = null;
 
+    private static activeAdapter: BIRunAdapter | null = null;
+
     protected launchRequest(response: DebugProtocol.LaunchResponse, args: DebugProtocol.LaunchRequestArguments, request?: DebugProtocol.Request): void {
-        getCurrentProjectRoot().then((projectRoot) => {
+        getCurrentProjectRoot().then(async (projectRoot) => {
+            if (BIRunAdapter.activeAdapter?.task) {
+                const choice = await window.showInformationMessage(
+                    'There is already a running integration. Do you want to stop it and start this integration?',
+                    'Yes', 'No'
+                );
+                if (choice !== 'Yes') {
+                    response.success = true;
+                    this.sendResponse(response);
+                    this.sendEvent(new TerminatedEvent());
+                    return;
+                }
+                const previousAdapter = BIRunAdapter.activeAdapter;
+                BIRunAdapter.activeAdapter = null;
+                previousAdapter.task.terminate();
+            }
+
             const taskDefinition: TaskDefinition = {
                 type: 'shell',
                 task: 'run'
@@ -706,10 +726,14 @@ class BIRunAdapter extends LoggingDebugSession {
             try {
                 tasks.executeTask(task).then((taskExecution) => {
                     this.task = taskExecution;
+                    BIRunAdapter.activeAdapter = this;
 
                     // Add task termination listener
                     this.taskTerminationListener = tasks.onDidEndTaskProcess(e => {
                         if (e.execution === this.task) {
+                            if (BIRunAdapter.activeAdapter === this) {
+                                BIRunAdapter.activeAdapter = null;
+                            }
                             this.sendEvent(new TerminatedEvent());
                         }
                     });
@@ -730,6 +754,9 @@ class BIRunAdapter extends LoggingDebugSession {
     protected disconnectRequest(response: DebugProtocol.DisconnectResponse, args: DebugProtocol.DisconnectArguments, request?: DebugProtocol.Request): void {
         if (this.task) {
             this.task.terminate();
+        }
+        if (BIRunAdapter.activeAdapter === this) {
+            BIRunAdapter.activeAdapter = null;
         }
         this.cleanupListeners();
         response.success = true;

--- a/workspaces/ballerina/ballerina-extension/src/features/debugger/config-provider.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/debugger/config-provider.ts
@@ -551,7 +551,7 @@ class BallerinaDebugAdapterDescriptorFactory implements DebugAdapterDescriptorFa
 
         if (session.configuration.noDebug) {
             return new Promise((resolve) => {
-                resolve(new DebugAdapterInlineImplementation(new BIRunAdapter()));
+                resolve(new DebugAdapterInlineImplementation(new BIRunAdapter(session)));
             });
         }
 
@@ -659,24 +659,53 @@ class BIRunAdapter extends LoggingDebugSession {
     task: TaskExecution | null = null;
     taskTerminationListener: Disposable | null = null;
 
+    private session: DebugSession;
     private static activeAdapter: BIRunAdapter | null = null;
+
+    constructor(session: DebugSession) {
+        super();
+        this.session = session;
+    }
 
     protected launchRequest(response: DebugProtocol.LaunchResponse, args: DebugProtocol.LaunchRequestArguments, request?: DebugProtocol.Request): void {
         getCurrentProjectRoot().then(async (projectRoot) => {
-            if (BIRunAdapter.activeAdapter?.task) {
+            const existingAdapter = BIRunAdapter.activeAdapter;
+            const existingTask = existingAdapter?.task ?? null;
+
+            if (existingTask) {
                 const choice = await window.showInformationMessage(
                     'There is already a running integration. Do you want to stop it and start this integration?',
                     'Yes', 'No'
                 );
                 if (choice !== 'Yes') {
+                    // Prevent the debug tracker from triggering the Try It view for this cancelled session.
+                    (this.session.configuration as any).suggestTryit = false;
                     response.success = true;
                     this.sendResponse(response);
                     this.sendEvent(new TerminatedEvent());
                     return;
                 }
-                const previousAdapter = BIRunAdapter.activeAdapter;
                 BIRunAdapter.activeAdapter = null;
-                previousAdapter.task.terminate();
+                // Await full termination before starting the new task to avoid port
+                // conflicts from the still-shutting-down previous process.
+                await new Promise<void>((resolve) => {
+                    const timeout = setTimeout(resolve, 3000);
+                    const listener = tasks.onDidEndTaskProcess(e => {
+                        if (e.execution === existingTask) {
+                            clearTimeout(timeout);
+                            listener.dispose();
+                            resolve();
+                        }
+                    });
+                    // Task may have already ended while the dialog was open.
+                    if (!tasks.taskExecutions.some(e => e === existingTask)) {
+                        clearTimeout(timeout);
+                        listener.dispose();
+                        resolve();
+                        return;
+                    }
+                    existingTask.terminate();
+                });
             }
 
             const taskDefinition: TaskDefinition = {

--- a/workspaces/ballerina/ballerina-extension/src/features/debugger/config-provider.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/debugger/config-provider.ts
@@ -686,25 +686,30 @@ class BIRunAdapter extends LoggingDebugSession {
                     this.sendEvent(new TerminatedEvent());
                     return;
                 }
-                // Await full termination before starting the new task to avoid port
-                // conflicts from the still-shutting-down previous process.
-                // activeAdapter is cleared only when the task is confirmed stopped (or
-                // the user explicitly forces a start), so concurrent launches always
-                // see a live reference while the previous process is still alive.
+                // Claim the slot immediately after user confirms — blocks any concurrent
+                // launchRequest from also reading null and racing past the conflict check.
+                BIRunAdapter.activeAdapter = this;
+
+                // Await full termination before starting the new task to avoid port conflicts.
+                // The slot is already ours; the old adapter's taskTerminationListener will
+                // perform its own identity-guarded clear and will not clobber our reference.
                 const shouldProceed = await new Promise<boolean>((resolve) => {
                     let listener: { dispose(): void };
                     const timeout = setTimeout(async () => {
                         listener.dispose();
                         const forceChoice = await window.showWarningMessage(
-                            'The previous integration has not stopped yet (terminate was already sent). Force start the new integration anyway?',
+                            'The previous run has not stopped yet (terminate was already sent). Force start anyway?',
                             'Force Start', 'Cancel new launch'
                         );
                         if (forceChoice === 'Force Start') {
-                            BIRunAdapter.activeAdapter = null;
+                            // Slot is already ours — no activeAdapter change needed.
                             resolve(true);
                         } else {
-                            // terminate() was already issued; the old process is still shutting down.
-                            // Abort the new launch — the old process will finish stopping on its own.
+                            // Abort the new launch; release the slot we claimed.
+                            // The old process will finish shutting down on its own.
+                            if (BIRunAdapter.activeAdapter === this) {
+                                BIRunAdapter.activeAdapter = null;
+                            }
                             resolve(false);
                         }
                     }, 10000);
@@ -712,15 +717,13 @@ class BIRunAdapter extends LoggingDebugSession {
                         if (e.execution === existingTask) {
                             clearTimeout(timeout);
                             listener.dispose();
-                            BIRunAdapter.activeAdapter = null;
                             resolve(true);
                         }
                     });
-                    // Task may have already ended while the dialog was open.
+                    // Task may have already ended while the confirmation dialog was open.
                     if (!tasks.taskExecutions.some(e => e === existingTask)) {
                         clearTimeout(timeout);
                         listener.dispose();
-                        BIRunAdapter.activeAdapter = null;
                         resolve(true);
                         return;
                     }
@@ -734,6 +737,10 @@ class BIRunAdapter extends LoggingDebugSession {
                     this.sendEvent(new TerminatedEvent());
                     return;
                 }
+            } else {
+                // No active run — claim the slot before any await to prevent a concurrent
+                // launchRequest from also reading null and bypassing the conflict check.
+                BIRunAdapter.activeAdapter = this;
             }
 
             const taskDefinition: TaskDefinition = {
@@ -763,9 +770,13 @@ class BIRunAdapter extends LoggingDebugSession {
                 debugLog(`[BIRunAdapter] Setting cwd to project root: ${cwd}`);
             } catch (error) {
                 window.showErrorMessage(`Failed to determine working directory`);
+                if (BIRunAdapter.activeAdapter === this) {
+                    BIRunAdapter.activeAdapter = null;
+                }
                 response.success = false;
                 this.sendResponse(response);
-                throw error;
+                this.sendEvent(new TerminatedEvent());
+                return;
             }
 
             const execution = new ShellExecution(runCommand, {
@@ -781,34 +792,41 @@ class BIRunAdapter extends LoggingDebugSession {
             );
 
             try {
-                tasks.executeTask(task).then((taskExecution) => {
-                    this.task = taskExecution;
-                    BIRunAdapter.activeAdapter = this;
+                const taskExecution = await tasks.executeTask(task);
+                this.task = taskExecution;
+                // activeAdapter is already set to this — assigned before any await above.
 
-                    // Add task termination listener
-                    this.taskTerminationListener = tasks.onDidEndTaskProcess(e => {
-                        if (e.execution === this.task) {
-                            this.taskTerminationListener?.dispose();
-                            this.taskTerminationListener = null;
-                            if (BIRunAdapter.activeAdapter === this) {
-                                BIRunAdapter.activeAdapter = null;
-                            }
-                            // Skip TerminatedEvent if disconnectRequest already fired —
-                            // the session is already being torn down by VS Code.
-                            if (!this.disconnected) {
-                                this.sendEvent(new TerminatedEvent());
-                            }
+                this.taskTerminationListener = tasks.onDidEndTaskProcess(e => {
+                    if (e.execution === this.task) {
+                        this.taskTerminationListener?.dispose();
+                        this.taskTerminationListener = null;
+                        if (BIRunAdapter.activeAdapter === this) {
+                            BIRunAdapter.activeAdapter = null;
                         }
-                    });
-
-                    response.success = true;
-                    this.sendResponse(response);
+                        // Skip TerminatedEvent if disconnectRequest already fired —
+                        // the session is already being torn down by VS Code.
+                        if (!this.disconnected) {
+                            this.sendEvent(new TerminatedEvent());
+                        }
+                    }
                 });
+
+                response.success = true;
+                this.sendResponse(response);
             } catch (error) {
                 window.showErrorMessage(`Failed to run Ballerina package: ${error}`);
+                if (BIRunAdapter.activeAdapter === this) {
+                    BIRunAdapter.activeAdapter = null;
+                }
+                response.success = false;
+                this.sendResponse(response);
+                this.sendEvent(new TerminatedEvent());
             }
         }).catch((error) => {
             window.showErrorMessage(`Failed to determine project root: ${error}`);
+            if (BIRunAdapter.activeAdapter === this) {
+                BIRunAdapter.activeAdapter = null;
+            }
             response.success = false;
             this.sendResponse(response);
         });
@@ -831,16 +849,6 @@ class BIRunAdapter extends LoggingDebugSession {
         this.sendResponse(response);
     }
 
-    private cleanupListeners(): void {
-        if (this.taskTerminationListener) {
-            this.taskTerminationListener.dispose();
-            this.taskTerminationListener = null;
-        }
-        if (this.notificationHandler) {
-            this.notificationHandler.dispose();
-            this.notificationHandler = null;
-        }
-    }
 }
 
 async function runFast(root: string, options: { debugPort?: number; env?: Map<string, string>; programArgs?: string[]; } = {}): Promise<boolean> {

--- a/workspaces/ballerina/ballerina-extension/src/features/debugger/config-provider.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/debugger/config-provider.ts
@@ -669,11 +669,16 @@ class BIRunAdapter extends LoggingDebugSession {
     }
 
     protected launchRequest(response: DebugProtocol.LaunchResponse, args: DebugProtocol.LaunchRequestArguments, request?: DebugProtocol.Request): void {
-        getCurrentProjectRoot().then(async (projectRoot) => {
-            const existingAdapter = BIRunAdapter.activeAdapter;
-            const existingTask = existingAdapter?.task ?? null;
+        // Capture and claim the slot synchronously before any await — serializes concurrent
+        // launchRequests so neither can read null and race past the conflict check.
+        const existingAdapter = BIRunAdapter.activeAdapter;
+        BIRunAdapter.activeAdapter = this;
 
-            if (existingTask) {
+        getCurrentProjectRoot().then(async (projectRoot) => {
+            // Treat any non-null existingAdapter as a conflict, even if its task hasn't
+            // started yet (adapter claimed slot but still launching).
+            if (existingAdapter) {
+                const existingTask = existingAdapter.task;
                 const choice = await window.showInformationMessage(
                     'There is already a running integration. Do you want to stop it and start this integration?',
                     'Yes', 'No'
@@ -681,66 +686,65 @@ class BIRunAdapter extends LoggingDebugSession {
                 if (choice !== 'Yes') {
                     // Prevent the debug tracker from triggering the Try It view for this cancelled session.
                     (this.session.configuration as any).suggestTryit = false;
+                    // Restore the previous adapter so the next launch still detects it.
+                    if (BIRunAdapter.activeAdapter === this) {
+                        BIRunAdapter.activeAdapter = existingAdapter;
+                    }
                     response.success = true;
                     this.sendResponse(response);
                     this.sendEvent(new TerminatedEvent());
                     return;
                 }
-                // Claim the slot immediately after user confirms — blocks any concurrent
-                // launchRequest from also reading null and racing past the conflict check.
-                BIRunAdapter.activeAdapter = this;
 
-                // Await full termination before starting the new task to avoid port conflicts.
-                // The slot is already ours; the old adapter's taskTerminationListener will
-                // perform its own identity-guarded clear and will not clobber our reference.
-                const shouldProceed = await new Promise<boolean>((resolve) => {
-                    let listener: { dispose(): void };
-                    const timeout = setTimeout(async () => {
-                        listener.dispose();
-                        const forceChoice = await window.showWarningMessage(
-                            'The previous run has not stopped yet (terminate was already sent). Force start anyway?',
-                            'Force Start', 'Cancel new launch'
-                        );
-                        if (forceChoice === 'Force Start') {
-                            // Slot is already ours — no activeAdapter change needed.
-                            resolve(true);
-                        } else {
-                            // Abort the new launch; release the slot we claimed.
-                            // The old process will finish shutting down on its own.
-                            if (BIRunAdapter.activeAdapter === this) {
-                                BIRunAdapter.activeAdapter = null;
+                // Slot is already ours. Only wait for termination if the task has actually
+                // started — if existingTask is null the previous launch hadn't begun yet.
+                if (existingTask) {
+                    // Await full termination before starting the new task to avoid port conflicts.
+                    // The old adapter's taskTerminationListener uses an identity-guarded clear
+                    // and will not clobber our reference.
+                    const shouldProceed = await new Promise<boolean>((resolve) => {
+                        let listener: { dispose(): void };
+                        const timeout = setTimeout(async () => {
+                            listener.dispose();
+                            const forceChoice = await window.showWarningMessage(
+                                'The previous run has not stopped yet (terminate was already sent). Force start anyway?',
+                                'Force Start', 'Cancel new launch'
+                            );
+                            if (forceChoice === 'Force Start') {
+                                resolve(true);
+                            } else {
+                                // Old process is shutting down — no valid reference to restore.
+                                if (BIRunAdapter.activeAdapter === this) {
+                                    BIRunAdapter.activeAdapter = null;
+                                }
+                                resolve(false);
                             }
-                            resolve(false);
-                        }
-                    }, 10000);
-                    listener = tasks.onDidEndTaskProcess(e => {
-                        if (e.execution === existingTask) {
+                        }, 10000);
+                        listener = tasks.onDidEndTaskProcess(e => {
+                            if (e.execution === existingTask) {
+                                clearTimeout(timeout);
+                                listener.dispose();
+                                resolve(true);
+                            }
+                        });
+                        // Task may have already ended while the confirmation dialog was open.
+                        if (!tasks.taskExecutions.some(e => e === existingTask)) {
                             clearTimeout(timeout);
                             listener.dispose();
                             resolve(true);
+                            return;
                         }
+                        existingTask.terminate();
                     });
-                    // Task may have already ended while the confirmation dialog was open.
-                    if (!tasks.taskExecutions.some(e => e === existingTask)) {
-                        clearTimeout(timeout);
-                        listener.dispose();
-                        resolve(true);
+
+                    if (!shouldProceed) {
+                        (this.session.configuration as any).suggestTryit = false;
+                        response.success = true;
+                        this.sendResponse(response);
+                        this.sendEvent(new TerminatedEvent());
                         return;
                     }
-                    existingTask.terminate();
-                });
-
-                if (!shouldProceed) {
-                    (this.session.configuration as any).suggestTryit = false;
-                    response.success = true;
-                    this.sendResponse(response);
-                    this.sendEvent(new TerminatedEvent());
-                    return;
                 }
-            } else {
-                // No active run — claim the slot before any await to prevent a concurrent
-                // launchRequest from also reading null and bypassing the conflict check.
-                BIRunAdapter.activeAdapter = this;
             }
 
             const taskDefinition: TaskDefinition = {
@@ -829,6 +833,7 @@ class BIRunAdapter extends LoggingDebugSession {
             }
             response.success = false;
             this.sendResponse(response);
+            this.sendEvent(new TerminatedEvent());
         });
     }
 


### PR DESCRIPTION
## Purpose
$subject

 When a user attempts to run a new Ballerina integration while one is already running in the workspace, the extension previously terminated the existing integration silently without starting the new one. This PR improves the experience with the following changes:                                                                                                  
                                                                                                                                                                                      
- Confirmation dialog: If an integration is already running, the user is prompted with "There is already a running integration. Do you want to stop it and start this integration?" before any action is taken. Choosing "Yes" stops the current integration and starts the new one; choosing "No" cancels the new launch without affecting the running integration.                                                                                                                                              

Fixes https://github.com/wso2/product-integrator/issues/1012

https://github.com/user-attachments/assets/13045f65-788e-4319-b9c4-6c0e53df4ef9



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Debug configuration names now derive from the selected script for clearer labeling.
  * Declined launches are finalized without triggering the Try It suggestion.
  * Termination and disconnect handling refined to avoid duplicate or spurious termination notifications and to safely clear active runs.

* **New Features**
  * Prompt to stop/restart when launching while another run is active.
  * Short timeout with a “Force Start” option to proceed and ensure previous runs are cleaned up.
  * No‑debug launches now respect the active debug session for consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->