### PR TITLE
Prevent running integrations when required configs are missing

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/features/config-generator/configGenerator.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/config-generator/configGenerator.ts
@@ -115,7 +115,7 @@ export async function prepareAndGenerateConfig(
         return true;
     }
 
-    return await handleOnUnSetValues(packageName, configFile, ignoreFile, ballerinaExtInstance, isCommand, isBi, executeRun);
+    return await handleOnUnSetValues(packageName, packagePath, configFile, ignoreFile, ballerinaExtInstance, isCommand, isBi, executeRun);
 }
 
 export async function checkConfigUpdateRequired(
@@ -210,7 +210,7 @@ export async function getCurrentBIProject(projectPath: string): Promise<Ballerin
     return await getCurrentBallerinaProject(projectRoot || projectPath);
 }
 
-export async function handleOnUnSetValues(packageName: string, configFile: string, ignoreFile: string, ballerinaExtInstance: BallerinaExtension, isCommand: boolean, isBi: boolean, executeRun: boolean = true): Promise<boolean> {
+export async function handleOnUnSetValues(packageName: string, packagePath: string, configFile: string, ignoreFile: string, ballerinaExtInstance: BallerinaExtension, isCommand: boolean, isBi: boolean, executeRun: boolean = true): Promise<boolean> {
     let result;
     let btnTitle: string;
     let message: string;
@@ -273,7 +273,7 @@ export async function handleOnUnSetValues(packageName: string, configFile: strin
         return false;
     } else if (!isCommand && result === ignoreButton) {
         if (executeRun) {
-            executeRunCommand(ballerinaExtInstance, configFile, isBi);
+            executeRunCommand(ballerinaExtInstance, packagePath, isBi);
         }
         return true;
     }

--- a/workspaces/ballerina/ballerina-extension/src/features/config-generator/configGenerator.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/config-generator/configGenerator.ts
@@ -43,7 +43,7 @@ export async function prepareAndGenerateConfig(
     isBi?: boolean,
     executeRun: boolean = true,
     needsPackageSelection: boolean = false
-): Promise<void> {
+): Promise<boolean> {
 
     let packagePath: string;
     let packageName: string;
@@ -55,7 +55,7 @@ export async function prepareAndGenerateConfig(
 
             const selectedPackage = await selectPackageOrPrompt(packageList, "Select an integration to run");
             if (!selectedPackage) {
-                return;
+                return false;
             }
 
             const selectedPackageInfo = packages?.find((child) => child.projectPath === selectedPackage);
@@ -76,14 +76,14 @@ export async function prepareAndGenerateConfig(
             }
         } catch (error) {
             console.error("Error selecting integration:", error);
-            return;
+            return false;
         }
     } else {
         const currentProject: BallerinaProject | undefined = await getCurrentBIProject(projectPath);
 
         if (!currentProject) {
             window.showErrorMessage(MESSAGES.NO_PROJECT_FOUND);
-            return;
+            return false;
         }
 
         packagePath = currentProject.path;
@@ -112,10 +112,10 @@ export async function prepareAndGenerateConfig(
         if (!isCommand && executeRun) {
             executeRunCommand(ballerinaExtInstance, packagePath, isBi);
         }
-        return;
+        return true;
     }
 
-    await handleOnUnSetValues(packageName, configFile, ignoreFile, ballerinaExtInstance, isCommand, isBi);
+    return await handleOnUnSetValues(packageName, configFile, ignoreFile, ballerinaExtInstance, isCommand, isBi, executeRun);
 }
 
 export async function checkConfigUpdateRequired(
@@ -210,7 +210,7 @@ export async function getCurrentBIProject(projectPath: string): Promise<Ballerin
     return await getCurrentBallerinaProject(projectRoot || projectPath);
 }
 
-export async function handleOnUnSetValues(packageName: string, configFile: string, ignoreFile: string, ballerinaExtInstance: BallerinaExtension, isCommand: boolean, isBi: boolean): Promise<void> {
+export async function handleOnUnSetValues(packageName: string, configFile: string, ignoreFile: string, ballerinaExtInstance: BallerinaExtension, isCommand: boolean, isBi: boolean, executeRun: boolean = true): Promise<boolean> {
     let result;
     let btnTitle: string;
     let message: string;
@@ -270,9 +270,14 @@ export async function handleOnUnSetValues(packageName: string, configFile: strin
         }
 
         openView(EVENT_TYPE.OPEN_VIEW, { view: MACHINE_VIEW.ViewConfigVariables });
+        return false;
     } else if (!isCommand && result === ignoreButton) {
-        executeRunCommand(ballerinaExtInstance, configFile, isBi);
+        if (executeRun) {
+            executeRunCommand(ballerinaExtInstance, configFile, isBi);
+        }
+        return true;
     }
+    return false;
 }
 
 

--- a/workspaces/ballerina/ballerina-extension/src/features/config-generator/configGenerator.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/config-generator/configGenerator.ts
@@ -206,8 +206,11 @@ export async function getCurrentBallerinaProjectFromContext(ballerinaExtInstance
 }
 
 export async function getCurrentBIProject(projectPath: string): Promise<BallerinaProject | undefined> {
+    if (projectPath) {
+        return await getCurrentBallerinaProject(projectPath);
+    }
     const projectRoot = await getCurrentProjectRoot();
-    return await getCurrentBallerinaProject(projectRoot || projectPath);
+    return await getCurrentBallerinaProject(projectRoot);
 }
 
 export async function handleOnUnSetValues(packageName: string, packagePath: string, configFile: string, ignoreFile: string, ballerinaExtInstance: BallerinaExtension, isCommand: boolean, isBi: boolean, executeRun: boolean = true): Promise<boolean> {

--- a/workspaces/ballerina/ballerina-extension/src/features/config-generator/configGenerator.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/config-generator/configGenerator.ts
@@ -206,11 +206,16 @@ export async function getCurrentBallerinaProjectFromContext(ballerinaExtInstance
 }
 
 export async function getCurrentBIProject(projectPath: string): Promise<BallerinaProject | undefined> {
-    if (projectPath) {
-        return await getCurrentBallerinaProject(projectPath);
+    try {
+        if (projectPath) {
+            return await getCurrentBallerinaProject(projectPath);
+        }
+        const projectRoot = await getCurrentProjectRoot();
+        return await getCurrentBallerinaProject(projectRoot);
+    } catch (error) {
+        console.error('Failed to resolve current BI project:', error);
+        return undefined;
     }
-    const projectRoot = await getCurrentProjectRoot();
-    return await getCurrentBallerinaProject(projectRoot);
 }
 
 export async function handleOnUnSetValues(packageName: string, packagePath: string, configFile: string, ignoreFile: string, ballerinaExtInstance: BallerinaExtension, isCommand: boolean, isBi: boolean, executeRun: boolean = true): Promise<boolean> {

--- a/workspaces/ballerina/ballerina-extension/src/features/debugger/config-provider.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/debugger/config-provider.ts
@@ -91,8 +91,14 @@ class DebugConfigProvider implements DebugConfigurationProvider {
         if (!config.type) {
             commands.executeCommand('workbench.action.debug.configure');
             return Promise.resolve({ request: '', type: '', name: '' });
-
         }
+
+        // Check if config generation is required before starting the debug session
+        const shouldProceed = await prepareAndGenerateConfig(extension.ballerinaExtInstance, config.script, false, StateMachine.context().isBI, false);
+        if (!shouldProceed) {
+            return Promise.resolve({ request: '', type: '', name: '' });
+        }
+
         if (config.noDebug && (extension.ballerinaExtInstance.enabledRunFast() || StateMachine.context().isBI)) {
             await handleMainFunctionParams(config);
         }
@@ -538,12 +544,6 @@ class BallerinaDebugAdapterDescriptorFactory implements DebugAdapterDescriptorFa
         const projectRoot = await getCurrentProjectRoot();
         await cleanAndValidateProject(langClient, projectRoot);
 
-        // Check if config generation is required before starting the debug session
-        const shouldProceed = await prepareAndGenerateConfig(extension.ballerinaExtInstance, session.configuration.script, false, StateMachine.context().isBI, false);
-        if (!shouldProceed) {
-            return new DebugAdapterInlineImplementation(new TerminatingDebugAdapter());
-        }
-
         if (session.configuration.noDebug && extension.ballerinaExtInstance.enabledRunFast()) {
             return new Promise((resolve) => {
                 resolve(new DebugAdapterInlineImplementation(new FastRunDebugAdapter()));
@@ -748,13 +748,6 @@ class BIRunAdapter extends LoggingDebugSession {
             this.notificationHandler.dispose();
             this.notificationHandler = null;
         }
-    }
-}
-
-class TerminatingDebugAdapter extends LoggingDebugSession {
-    protected initializeRequest(response: DebugProtocol.InitializeResponse): void {
-        this.sendResponse(response);
-        this.sendEvent(new TerminatedEvent());
     }
 }
 

--- a/workspaces/ballerina/ballerina-extension/src/features/debugger/config-provider.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/debugger/config-provider.ts
@@ -87,10 +87,10 @@ export enum DEBUG_CONFIG {
 
 class DebugConfigProvider implements DebugConfigurationProvider {
     async resolveDebugConfiguration(_folder: WorkspaceFolder, config: DebugConfiguration)
-        : Promise<DebugConfiguration> {
+        : Promise<DebugConfiguration | null | undefined> {
         if (!config.type) {
             commands.executeCommand('workbench.action.debug.configure');
-            return Promise.resolve({ request: '', type: '', name: '' });
+            return undefined;
         }
 
         if (config.noDebug && (extension.ballerinaExtInstance.enabledRunFast() || StateMachine.context().isBI)) {
@@ -101,7 +101,7 @@ class DebugConfigProvider implements DebugConfigurationProvider {
         // Check if config generation is required before starting the debug session
         const shouldProceed = await prepareAndGenerateConfig(extension.ballerinaExtInstance, configs.script, false, StateMachine.context().isBI, false);
         if (!shouldProceed) {
-            return Promise.resolve({ request: '', type: '', name: '' });
+            return undefined;
         }
 
         // connect to Devant if applicable

--- a/workspaces/ballerina/ballerina-extension/src/features/debugger/config-provider.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/debugger/config-provider.ts
@@ -539,7 +539,10 @@ class BallerinaDebugAdapterDescriptorFactory implements DebugAdapterDescriptorFa
         await cleanAndValidateProject(langClient, projectRoot);
 
         // Check if config generation is required before starting the debug session
-        await prepareAndGenerateConfig(extension.ballerinaExtInstance, session.configuration.script, false, StateMachine.context().isBI, false);
+        const shouldProceed = await prepareAndGenerateConfig(extension.ballerinaExtInstance, session.configuration.script, false, StateMachine.context().isBI, false);
+        if (!shouldProceed) {
+            return new DebugAdapterInlineImplementation(new TerminatingDebugAdapter());
+        }
 
         if (session.configuration.noDebug && extension.ballerinaExtInstance.enabledRunFast()) {
             return new Promise((resolve) => {
@@ -745,6 +748,13 @@ class BIRunAdapter extends LoggingDebugSession {
             this.notificationHandler.dispose();
             this.notificationHandler = null;
         }
+    }
+}
+
+class TerminatingDebugAdapter extends LoggingDebugSession {
+    protected initializeRequest(response: DebugProtocol.InitializeResponse): void {
+        this.sendResponse(response);
+        this.sendEvent(new TerminatedEvent());
     }
 }
 

--- a/workspaces/ballerina/ballerina-extension/src/features/debugger/config-provider.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/debugger/config-provider.ts
@@ -93,16 +93,16 @@ class DebugConfigProvider implements DebugConfigurationProvider {
             return Promise.resolve({ request: '', type: '', name: '' });
         }
 
-        // Check if config generation is required before starting the debug session
-        const shouldProceed = await prepareAndGenerateConfig(extension.ballerinaExtInstance, config.script, false, StateMachine.context().isBI, false);
-        if (!shouldProceed) {
-            return Promise.resolve({ request: '', type: '', name: '' });
-        }
-
         if (config.noDebug && (extension.ballerinaExtInstance.enabledRunFast() || StateMachine.context().isBI)) {
             await handleMainFunctionParams(config);
         }
         const configs = await getModifiedConfigs(_folder, config);
+
+        // Check if config generation is required before starting the debug session
+        const shouldProceed = await prepareAndGenerateConfig(extension.ballerinaExtInstance, configs.script, false, StateMachine.context().isBI, false);
+        if (!shouldProceed) {
+            return Promise.resolve({ request: '', type: '', name: '' });
+        }
 
         // connect to Devant if applicable
         await new PlatformExtRpcManager().setupDevantProxyForDebugging(configs);


### PR DESCRIPTION
This PR updates WSO2 Integrator's config generation flow so debug sessions don’t continue when required configuration values are missing.

**Changes:**
- Changed `prepareAndGenerateConfig` to return a `boolean` indicating whether the run/debug flow should proceed.
- Updated the debug adapter factory to terminate the debug session early when config generation indicates it should not proceed.
- Updated config generator handling so “open config/update configurables” paths explicitly stop the caller flow.

Fixes https://github.com/wso2/product-integrator/issues/667

## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## UI Component Development
> Specify the reason if following are not followed.
- [ ] Added reusable UI components to the ui-toolkit. Follow the [intructions](./workspaces/common-libs/ui-toolkit/README.md) when adding the componenent.
- [ ] Use ui-toolkit components wherever possible. Run `npm run storybook` from the root directory to view current components.
- [ ] Matches with the native VSCode look and feel.

## Manage Icons
> Specify the reason if following are not followed.
- [ ] Added Icons to the font-wso2-vscode. Follow the [instructions](./workspaces/common-libs/font-wso2-vscode/README.md).

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Debug sessions now stop gracefully when configuration generation indicates the session should not proceed.
  * Improved handling when the current project or configuration cannot be determined to avoid errors or unexpected debug attempts.

* **New Features**
  * Configuration generation avoids duplicate prompts and respects the user’s “Run Anyway” choice to prevent redundant executions.
  * Remediation UI flows now correctly gate running behavior so actions only occur when intended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->