### PR TITLE
Fix copilot config collector and make approval overlay closable

### DIFF
--- a/workspaces/ballerina/ballerina-core/src/state-machine-types.ts
+++ b/workspaces/ballerina/ballerina-core/src/state-machine-types.ts
@@ -181,6 +181,7 @@ export interface AgentMetadata {
 export interface ApprovalOverlayState {
     show: boolean;
     message?: string;
+    requestId?: string;
 }
 
 export interface VisualizerMetadata {

--- a/workspaces/ballerina/ballerina-core/src/state-machine-types.ts
+++ b/workspaces/ballerina/ballerina-core/src/state-machine-types.ts
@@ -166,7 +166,7 @@ export interface ConfigurationCollectorMetadata {
     variables: Array<{
         name: string;
         description: string;
-        type?: "string" | "int";
+        type?: "string" | "int" | "decimal";
         secret?: boolean;
     }>;
     existingValues?: Record<string, string>;
@@ -502,7 +502,7 @@ export interface ConfigurationCollectionEvent {
     variables?: Array<{
         name: string;
         description: string;
-        type?: "string" | "int";
+        type?: "string" | "int" | "decimal";
         secret?: boolean;
     }>;
     existingValues?: Record<string, string>;

--- a/workspaces/ballerina/ballerina-core/src/state-machine-types.ts
+++ b/workspaces/ballerina/ballerina-core/src/state-machine-types.ts
@@ -166,7 +166,7 @@ export interface ConfigurationCollectorMetadata {
     variables: Array<{
         name: string;
         description: string;
-        type?: "string" | "int" | "decimal";
+        type?: string;
         secret?: boolean;
     }>;
     existingValues?: Record<string, string>;
@@ -502,7 +502,7 @@ export interface ConfigurationCollectionEvent {
     variables?: Array<{
         name: string;
         description: string;
-        type?: "string" | "int" | "decimal";
+        type?: string;
         secret?: boolean;
     }>;
     existingValues?: Record<string, string>;

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/prompts.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/prompts.ts
@@ -203,7 +203,7 @@ When working with Ballerina workspace projects (projects with a root Ballerina.t
 # Running, invoking and tests
 - You should only Run or write tests if the user explicitly asks to do so.
 - Providing values to configurables is a runtime task and should only do it before running or executing the tests.
-- For Config.toml configuration value management, use ${CONFIG_COLLECTOR_TOOL} to request for values. Check the different modes of the tool for various usecases.
+- For Config.toml configuration value management, use ${CONFIG_COLLECTOR_TOOL}. The codebase listing shows <config_files main="present|absent" tests="present|absent"/> per project indicating whether Config.toml files exist.
 - You can call ${BALLERINA_STOP_TOOL_NAME} when you need to restart a service (e.g. after code changes) or when the user explicitly asks to stop it.
 
 ## Test Runner

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/config-collector.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/config-collector.ts
@@ -40,7 +40,7 @@ const TEST_CONFIG_FILE_PATH = "tests/Config.toml";
 const ConfigVariableSchema = z.object({
     name: z.string().describe("Variable name in camelCase — must match the Ballerina configurable identifier exactly"),
     description: z.string().describe("Human-readable description"),
-    type: z.enum(["string", "int"]).optional().describe("Data type: string (default) or int"),
+    type: z.enum(["string", "int", "decimal"]).optional().describe("Data type: string (default), int, or decimal"),
     secret: z.boolean().optional().describe("Mark as true for sensitive values (API keys, passwords, tokens) to render as a masked input"),
 });
 

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/config-collector.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/config-collector.ts
@@ -258,6 +258,18 @@ async function handleCollectMode(
     const validationError = validateConfigVariables(variables);
     if (validationError) { return validationError; }
 
+    if (!variables || variables.length === 0) {
+        return {
+            success: false,
+            message:
+                "No variables provided to collect. " +
+                "Always pass `variables` with the configurable identifiers from the code. " +
+                "Use mode: 'check' first if you need to discover existing variable names in Config.toml.",
+            error: "No variables provided",
+            errorCode: "NO_VARIABLES",
+        };
+    }
+
     // Resolve and validate the package base path. For workspace projects, the
     // agent must pass packagePath so Config.toml lands inside the target
     // package rather than the workspace root. The helper rejects directory

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/config-collector.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/config-collector.ts
@@ -48,7 +48,10 @@ const ConfigCollectorSchema = z.object({
     mode: z.enum(["collect", "check"]).describe("Operation mode"),
     filePath: z.string().optional().describe("Path to config file (for check mode)"),
     variables: z.array(ConfigVariableSchema).optional().describe("Configuration variables"),
-    variableNames: z.array(z.string()).optional().describe("Variable names for check mode"),
+    variableNames: z.array(z.string()).optional().describe(
+        "Variable names to verify in check mode. " +
+        "Omit to discover ALL existing variable names in the file — useful when you want to reuse names that are already there."
+    ),
     isTestConfig: z.boolean().optional().describe("Set to true when collecting configuration for tests. Tool will automatically read from Config.toml and write to tests/Config.toml"),
     packagePath: z.string().optional().describe(
         "Relative path to the target package within the workspace project (e.g., \"pkg1\"). " +
@@ -122,10 +125,14 @@ export function createConfigCollectorTool(
         description: `
 Manages configuration values in Config.toml for Ballerina integrations securely.
 
+The codebase listing includes a <config_files main="present|absent" tests="present|absent"/> tag per project.
+Use it to know whether Config.toml already exists before deciding to check or collect.
+
 IMPORTANT: Only call COLLECT mode immediately before executing the project (running or testing). Do NOT call it during code writing or implementation — even if the code has sensitive configurables. Write the code first, then collect config only when you are about to run or test.
 
 Operation Modes:
 1. COLLECT: Collect configuration values from the user
+   - ALWAYS provide `variables` — never call collect without them
    - Call ONLY immediately before running or testing the project — never during code writing
    - Shows a form; nothing is written until the user confirms. If skipped, no file is created or modified
    - Pre-populates from existing Config.toml if it exists
@@ -136,10 +143,12 @@ Operation Modes:
    - Example (workspace): { mode: "collect", variables: [...], packagePath: "pkg1" }
 
 2. CHECK: Inspect which values are filled or missing — can be called at any time
-   - Returns status only, never actual values
+   - Returns variable names and status; never actual values
+   - Omit variableNames to discover ALL existing variables in the file — use this when Config.toml is present and you want to reuse existing names in a later collect call
    - For workspace projects, pass packagePath to inspect the Config.toml of a specific package
-   - Example: { mode: "check", variableNames: ["dbPassword", "apiKey"], filePath: "Config.toml" }
-   - Example (workspace): { mode: "check", variableNames: ["dbPassword"], packagePath: "pkg1" }
+   - Example (discover all): { mode: "check" }
+   - Example (verify specific): { mode: "check", variableNames: ["dbPassword", "apiKey"] }
+   - Example (workspace): { mode: "check", packagePath: "pkg1" }
    - Returns: { status: { dbPassword: "filled", apiKey: "missing" } }
 
 VARIABLE NAMING:
@@ -377,7 +386,7 @@ async function handleCollectMode(
 }
 
 async function handleCheckMode(
-    variableNames: string[],
+    variableNames: string[] | undefined,
     filePath: string | undefined,
     paths: ConfigCollectorPaths,
     isTestConfig?: boolean,
@@ -408,23 +417,26 @@ async function handleCheckMode(
         };
     }
 
-    // Read all variables from the file
     const status = getAllConfigStatus(configPath);
 
-    // Any requested variable names not found in file → mark as missing
-    for (const name of variableNames) {
-        if (!(name in status)) {
-            status[name] = "missing";
+    // When specific names are provided, pad any that are absent from the file as "missing"
+    if (variableNames && variableNames.length > 0) {
+        for (const name of variableNames) {
+            if (!(name in status)) {
+                status[name] = "missing";
+            }
         }
     }
 
-    const filledCount = Object.values(status).filter((s) => s === "filled").length;
-    const missingCount = Object.values(status).filter((s) => s === "missing").length;
-    const totalCount = filledCount + missingCount;
+    const filledNames = Object.entries(status).filter(([, s]) => s === "filled").map(([n]) => n);
+    const missingNames = Object.entries(status).filter(([, s]) => s === "missing").map(([n]) => n);
 
     return {
         success: true,
-        message: `${configFileName} has ${totalCount} variable(s): ${filledCount} filled, ${missingCount} with placeholder`,
+        message:
+            `${configFileName} — ` +
+            `filled: [${filledNames.join(", ") || "none"}], ` +
+            `missing: [${missingNames.join(", ") || "none"}]`,
         status,
     };
 }

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/config-collector.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/config-collector.ts
@@ -30,6 +30,7 @@ import {
     readExistingConfigValues,
 } from "../../../../utils/toml-utils";
 import { resolveContained, resolvePackageBasePath } from "./path-utils";
+import { getOrgPackageName } from "../../../../utils/config";
 
 export const CONFIG_COLLECTOR_TOOL = "ConfigCollector";
 
@@ -278,6 +279,13 @@ async function handleCollectMode(
     // package rather than the workspace root. The helper rejects directory
     // traversal attempts and missing-but-required values.
     const packageBasePath = resolvePackageBasePath(paths.tempPath, packagePath);
+    const { orgName, packageName } = getOrgPackageName(packageBasePath);
+    if (!orgName || !packageName) {
+        return createErrorResult(
+            "MISSING_PACKAGE_INFO",
+            "Ballerina.toml is missing or does not declare both 'org' and 'name' under [package]. Cannot scope Config.toml to the correct section."
+        );
+    }
 
     // Determine paths based on isTestConfig flag
     const configPath = getConfigPath(packageBasePath, isTestConfig);
@@ -291,7 +299,9 @@ async function handleCollectMode(
     // Read existing configuration values from source config (if they exist) for pre-populating the form
     const existingValues = readExistingConfigValues(
         sourceConfigPath,
-        variables.map(v => v.name)
+        variables.map(v => v.name),
+        orgName,
+        packageName
     );
 
     // Analyze existing values to determine appropriate messaging
@@ -340,7 +350,7 @@ async function handleCollectMode(
     }
 
     // Write actual configuration values to determined config path
-    writeConfigValuesToConfig(configPath, userResponse.configValues!, variables);
+    writeConfigValuesToConfig(configPath, userResponse.configValues!, variables, orgName, packageName);
 
     // Track modified file for syncing to workspace.
     // Path is relative to tempProjectPath, so prefix with packagePath for workspace projects.
@@ -389,6 +399,13 @@ async function handleCheckMode(
     // Resolve and validate the package base path. For workspace projects the
     // agent must pass packagePath to inspect a specific package's Config.toml.
     const packageBasePath = resolvePackageBasePath(paths.tempPath, packagePath);
+    const { orgName, packageName } = getOrgPackageName(packageBasePath);
+    if (!orgName || !packageName) {
+        return createErrorResult(
+            "MISSING_PACKAGE_INFO",
+            "Ballerina.toml is missing or does not declare both 'org' and 'name' under [package]. Cannot scope Config.toml to the correct section."
+        );
+    }
 
     let configPath: string;
     let configFileName: string;
@@ -411,7 +428,7 @@ async function handleCheckMode(
         };
     }
 
-    const status = getAllConfigStatus(configPath);
+    const status = getAllConfigStatus(configPath, orgName, packageName);
 
     // When specific names are provided, pad any that are absent from the file as "missing"
     if (variableNames && variableNames.length > 0) {

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/config-collector.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/config-collector.ts
@@ -269,11 +269,12 @@ export async function ConfigCollectorTool(
     }
 }
 
+// Returns null on LS error (transient failure), {} when LS responded but found no configurables.
 async function getConfigurableTypesFromSource(
     projectPath: string,
     orgName: string,
     packageName: string
-): Promise<Record<string, string>> {
+): Promise<Record<string, string> | null> {
     try {
         const response = await langClient.getConfigVariablesV2({ projectPath, includeLibraries: false }) as any;
         const configVariables = response?.configVariables;
@@ -303,7 +304,7 @@ async function getConfigurableTypesFromSource(
         return types;
     } catch (error) {
         console.error("[ConfigCollector] Failed to query configurables from LS:", error);
-        return {};
+        return null;
     }
 }
 
@@ -335,6 +336,12 @@ async function handleCollectMode(
     // Derive variable types from the LS rather than accepting them from the agent.
     // The LS reads the 'configurable' declarations already written in source.
     const sourceTypes = await getConfigurableTypesFromSource(packageBasePath, orgName, packageName);
+    if (sourceTypes === null) {
+        return createErrorResult(
+            "LS_UNAVAILABLE",
+            "Language server is unavailable or failed to respond. Wait a moment and retry."
+        );
+    }
     if (Object.keys(sourceTypes).length === 0) {
         return createErrorResult(
             "NO_CONFIGURABLES_IN_SOURCE",

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/config-collector.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/config-collector.ts
@@ -430,6 +430,8 @@ async function handleCheckMode(
     const filledNames = Object.entries(status).filter(([, s]) => s === "filled").map(([n]) => n);
     const missingNames = Object.entries(status).filter(([, s]) => s === "missing").map(([n]) => n);
 
+    console.log(`[ConfigCollector] check ${configFileName} — filled: [${filledNames.join(", ") || "none"}], missing: [${missingNames.join(", ") || "none"}]`);
+
     return {
         success: true,
         message:

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/config-collector.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/config-collector.ts
@@ -125,14 +125,14 @@ export function createConfigCollectorTool(
         description: `
 Manages configuration values in Config.toml for Ballerina integrations securely.
 
-The codebase listing includes a <config_files main="present|absent" tests="present|absent"/> tag per project.
-Use it to know whether Config.toml already exists before deciding to check or collect.
+The codebase listing includes a <config_files main="present|absent" tests="present|absent"/> tag per project showing the initial state.
+Before collecting, always call CHECK first (without variableNames) to discover any existing variable names and reuse them — Config.toml may have been added mid-session even if the listing shows absent.
 
 IMPORTANT: Only call COLLECT mode immediately before executing the project (running or testing). Do NOT call it during code writing or implementation — even if the code has sensitive configurables. Write the code first, then collect config only when you are about to run or test.
 
 Operation Modes:
 1. COLLECT: Collect configuration values from the user
-   - ALWAYS provide `variables` — never call collect without them
+   - ALWAYS provide 'variables' — never call collect without them
    - Call ONLY immediately before running or testing the project — never during code writing
    - Shows a form; nothing is written until the user confirms. If skipped, no file is created or modified
    - Pre-populates from existing Config.toml if it exists
@@ -144,10 +144,9 @@ Operation Modes:
 
 2. CHECK: Inspect which values are filled or missing — can be called at any time
    - Returns variable names and status; never actual values
-   - Omit variableNames to discover ALL existing variables in the file — use this when Config.toml is present and you want to reuse existing names in a later collect call
    - For workspace projects, pass packagePath to inspect the Config.toml of a specific package
-   - Example (discover all): { mode: "check" }
-   - Example (verify specific): { mode: "check", variableNames: ["dbPassword", "apiKey"] }
+   - Example (discover): { mode: "check" }
+   - Example (verify): { mode: "check", variableNames: ["dbPassword", "apiKey"], filePath: "Config.toml" }
    - Example (workspace): { mode: "check", packagePath: "pkg1" }
    - Returns: { status: { dbPassword: "filled", apiKey: "missing" } }
 

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/config-collector.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/config-collector.ts
@@ -31,6 +31,7 @@ import {
 } from "../../../../utils/toml-utils";
 import { resolveContained, resolvePackageBasePath } from "./path-utils";
 import { getOrgPackageName } from "../../../../utils/config";
+import { langClient } from "../../activator";
 
 export const CONFIG_COLLECTOR_TOOL = "ConfigCollector";
 
@@ -41,7 +42,6 @@ const TEST_CONFIG_FILE_PATH = "tests/Config.toml";
 const ConfigVariableSchema = z.object({
     name: z.string().describe("Variable name in camelCase — must match the Ballerina configurable identifier exactly"),
     description: z.string().describe("Human-readable description"),
-    type: z.enum(["string", "int", "decimal"]).optional().describe("Data type: string (default), int, or decimal"),
     secret: z.boolean().optional().describe("Mark as true for sensitive values (API keys, passwords, tokens) to render as a masked input"),
 });
 
@@ -138,6 +138,13 @@ The codebase listing includes a <config_files main="present|absent" tests="prese
 Before collecting, always call CHECK first (without variableNames) to discover any existing variable names and reuse them — Config.toml may have been added mid-session even if the listing shows absent.
 
 IMPORTANT: Only call COLLECT mode immediately before executing the project (running or testing). Do NOT call it during code writing or implementation — even if the code has sensitive configurables. Write the code first, then collect config only when you are about to run or test.
+
+REQUIRED ORDER:
+1. Write the Ballerina source code including all 'configurable' declarations and save the file.
+2. Only then call collect. Variable names are validated against the LS's view of the source.
+   - If a name is not declared in source, you get UNKNOWN_CONFIGURABLE — check the code first.
+   - If no configurables are found at all, you get NO_CONFIGURABLES_IN_SOURCE — write the code first.
+Variable type is derived automatically from the source declaration — do NOT pass a type field.
 
 Operation Modes:
 1. COLLECT: Collect configuration values from the user
@@ -262,6 +269,44 @@ export async function ConfigCollectorTool(
     }
 }
 
+async function getConfigurableTypesFromSource(
+    projectPath: string,
+    orgName: string,
+    packageName: string
+): Promise<Record<string, string>> {
+    try {
+        const response = await langClient.getConfigVariablesV2({ projectPath, includeLibraries: false }) as any;
+        const configVariables = response?.configVariables;
+        if (!configVariables || typeof configVariables !== "object") {
+            return {};
+        }
+
+        // Response is { [pkgKey: string]: { [moduleName: string]: ConfigVariable[] } }
+        // where pkgKey is "org/packageName"
+        const pkgKey = `${orgName}/${packageName}`;
+        const modules = configVariables[pkgKey];
+        if (!modules || typeof modules !== "object") {
+            return {};
+        }
+
+        const types: Record<string, string> = {};
+        for (const moduleVars of Object.values(modules)) {
+            if (!Array.isArray(moduleVars)) { continue; }
+            for (const variable of moduleVars) {
+                const name = variable?.properties?.variable?.value;
+                const type = variable?.properties?.type?.value;
+                if (typeof name === "string" && name) {
+                    types[name] = typeof type === "string" && type ? type : "string";
+                }
+            }
+        }
+        return types;
+    } catch (error) {
+        console.error("[ConfigCollector] Failed to query configurables from LS:", error);
+        return {};
+    }
+}
+
 async function handleCollectMode(
     variables: ConfigVariable[] | undefined,
     paths: ConfigCollectorPaths,
@@ -286,6 +331,29 @@ async function handleCollectMode(
             "Ballerina.toml is missing or does not declare both 'org' and 'name' under [package]. Cannot scope Config.toml to the correct section."
         );
     }
+
+    // Derive variable types from the LS rather than accepting them from the agent.
+    // The LS reads the 'configurable' declarations already written in source.
+    const sourceTypes = await getConfigurableTypesFromSource(packageBasePath, orgName, packageName);
+    if (Object.keys(sourceTypes).length === 0) {
+        return createErrorResult(
+            "NO_CONFIGURABLES_IN_SOURCE",
+            "No configurables found in source. Write the 'configurable' declarations in code first and save, then call collect again."
+        );
+    }
+
+    const unknownNames = variables.filter(v => !(v.name in sourceTypes));
+    if (unknownNames.length > 0) {
+        return createErrorResult(
+            "UNKNOWN_CONFIGURABLE",
+            `Variables not declared in source: ${unknownNames.map(v => v.name).join(", ")}. ` +
+            `Available in source: ${Object.keys(sourceTypes).join(", ")}. ` +
+            `Verify the configurable declarations in your .bal files match the names you're passing, then retry.`
+        );
+    }
+
+    // Enrich variables with LS-derived types so the writer uses the correct type.
+    const enrichedVariables: ConfigVariable[] = variables.map(v => ({ ...v, type: sourceTypes[v.name] }));
 
     // Determine paths based on isTestConfig flag
     const configPath = getConfigPath(packageBasePath, isTestConfig);
@@ -325,7 +393,7 @@ async function handleCollectMode(
     // This returns ACTUAL values (not exposed to agent)
     const userResponse = await approvalManager.requestConfiguration(
         requestId,
-        variables,
+        enrichedVariables,
         existingValues,
         eventHandler,
         isTestConfig,
@@ -350,7 +418,7 @@ async function handleCollectMode(
     }
 
     // Write actual configuration values to determined config path
-    writeConfigValuesToConfig(configPath, userResponse.configValues!, variables, orgName, packageName);
+    writeConfigValuesToConfig(configPath, userResponse.configValues!, enrichedVariables, orgName, packageName);
 
     // Track modified file for syncing to workspace.
     // Path is relative to tempProjectPath, so prefix with packagePath for workspace projects.
@@ -384,7 +452,7 @@ async function handleCollectMode(
 
     return {
         success: true,
-        message: `Successfully collected ${variables.length} configuration value(s) and saved to ${configFileName}${userResponse.comment ? ". User note: " + userResponse.comment : ""}`,
+        message: `Successfully collected ${enrichedVariables.length} configuration value(s) and saved to ${configFileName}${userResponse.comment ? ". User note: " + userResponse.comment : ""}`,
         status: statusMetadata,
     };
 }

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/config-collector.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/config-collector.ts
@@ -94,8 +94,16 @@ function getConfigFileName(isTestConfig?: boolean): string {
 }
 
 function validateConfigVariables(
-    variables: ConfigVariable[]
+    variables: ConfigVariable[] | undefined
 ): ConfigCollectorResult | null {
+    if (!variables || variables.length === 0) {
+        return createErrorResult(
+            "NO_VARIABLES",
+            "No variables provided to collect. " +
+            "Always pass `variables` with the configurable identifiers from the code. " +
+            "Use mode: 'check' first if you need to discover existing variable names in Config.toml."
+        );
+    }
     for (const variable of variables) {
         if (!validateVariableName(variable.name)) {
             return createErrorResult(
@@ -254,7 +262,7 @@ export async function ConfigCollectorTool(
 }
 
 async function handleCollectMode(
-    variables: ConfigVariable[],
+    variables: ConfigVariable[] | undefined,
     paths: ConfigCollectorPaths,
     eventHandler: CopilotEventHandler,
     requestId: string,
@@ -262,21 +270,8 @@ async function handleCollectMode(
     modifiedFiles?: string[],
     packagePath?: string
 ): Promise<ConfigCollectorResult> {
-    // Validate variable names
     const validationError = validateConfigVariables(variables);
     if (validationError) { return validationError; }
-
-    if (!variables || variables.length === 0) {
-        return {
-            success: false,
-            message:
-                "No variables provided to collect. " +
-                "Always pass `variables` with the configurable identifiers from the code. " +
-                "Use mode: 'check' first if you need to discover existing variable names in Config.toml.",
-            error: "No variables provided",
-            errorCode: "NO_VARIABLES",
-        };
-    }
 
     // Resolve and validate the package base path. For workspace projects, the
     // agent must pass packagePath so Config.toml lands inside the target

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/utils.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/utils.ts
@@ -232,6 +232,16 @@ export function formatCodebaseStructure(projects: ProjectSource[], tempProjectPa
         text += "<files>\n";
         text += files.map(formatFileWithContent).join("\n");
         text += "\n</files>\n";
+
+        if (tempProjectPath) {
+            const pkgRoot = isWorkspace && project.packagePath
+                ? path.join(tempProjectPath, project.packagePath)
+                : tempProjectPath;
+            const mainConfig = fs.existsSync(path.join(pkgRoot, "Config.toml")) ? "present" : "absent";
+            const testConfig = fs.existsSync(path.join(pkgRoot, "tests", "Config.toml")) ? "present" : "absent";
+            text += `<config_files main="${mainConfig}" tests="${testConfig}"/>\n`;
+        }
+
         text += "</project>\n";
     }
 

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/state/ApprovalViewManager.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/state/ApprovalViewManager.ts
@@ -115,12 +115,12 @@ export class ApprovalViewManager {
         });
 
         const overlayMessage = this.getOverlayMessage(approvalType);
-        this.sendChatOverlayNotification(true, overlayMessage);
+        this.sendChatOverlayNotification(true, overlayMessage, requestId);
     }
 
-    private sendChatOverlayNotification(show: boolean, message?: string): void {
+    private sendChatOverlayNotification(show: boolean, message?: string, requestId?: string): void {
         try {
-            notifyApprovalOverlayState({ show, message });
+            notifyApprovalOverlayState({ show, message, requestId });
             console.log(`[ApprovalViewManager] Chat overlay ${show ? 'enabled' : 'disabled'}`, message ? `with message: ${message}` : '');
         } catch (error) {
             console.error('[ApprovalViewManager] Failed to send chat overlay notification:', error);
@@ -161,6 +161,15 @@ export class ApprovalViewManager {
         });
 
         view.isClosed = true;
+
+        // Close the popup webview if it is still open (e.g. when dismissed via the overlay X).
+        // When the popup itself triggered this call, ctx.view won't match so this is a no-op.
+        if (view.viewType === 'popup') {
+            const popupCtx = StateMachinePopup.context();
+            if (popupCtx.view === view.machineView) {
+                StateMachinePopup.sendEvent(EVENT_TYPE.CLOSE_VIEW, { view: null, agentMetadata: undefined });
+            }
+        }
 
         if (!this.hasActiveApprovals()) {
             this.sendChatOverlayNotification(false);
@@ -311,7 +320,7 @@ export class ApprovalViewManager {
         view.isAutoOpened = false;
 
         const overlayMessage = this.getOverlayMessage(view.approvalType);
-        this.sendChatOverlayNotification(true, overlayMessage);
+        this.sendChatOverlayNotification(true, overlayMessage, view.requestId);
 
         const { viewType, hadExistingVisualizer } = this._openApprovalViewPopup(
             view.machineView,

--- a/workspaces/ballerina/ballerina-extension/src/utils/toml-utils.ts
+++ b/workspaces/ballerina/ballerina-extension/src/utils/toml-utils.ts
@@ -21,7 +21,7 @@ import { parse, stringify } from "@iarna/toml";
 export interface ConfigVariable {
     name: string;
     description: string;
-    type?: "string" | "int";
+    type?: "string" | "int" | "decimal";
     secret?: boolean;
 }
 
@@ -112,6 +112,12 @@ export function writeConfigValuesToConfig(
             }
             config[variableName] = intValue;
             intKeys.add(variableName);
+        } else if (varType === "decimal") {
+            const decimalValue = parseFloat(value);
+            if (isNaN(decimalValue)) {
+                throw new Error(`Invalid decimal value for ${variableName}`);
+            }
+            config[variableName] = decimalValue;
         } else {
             config[variableName] = value;
         }

--- a/workspaces/ballerina/ballerina-extension/src/utils/toml-utils.ts
+++ b/workspaces/ballerina/ballerina-extension/src/utils/toml-utils.ts
@@ -90,7 +90,7 @@ export function writeConfigValuesToConfig(
         }
     }
 
-    const intKeys = new Set<string>();
+    const numericKeys = new Set<string>();
     for (const [variableName, value] of Object.entries(configValues)) {
         const varType = typeMap.get(variableName) || "string";
         if (varType === "int") {
@@ -99,13 +99,14 @@ export function writeConfigValuesToConfig(
                 throw new Error(`Invalid integer value for ${variableName}`);
             }
             section[variableName] = intValue;
-            intKeys.add(variableName);
+            numericKeys.add(variableName);
         } else if (varType === "decimal") {
             const decimalValue = parseFloat(value);
             if (isNaN(decimalValue)) {
                 throw new Error(`Invalid decimal value for ${variableName}`);
             }
             section[variableName] = decimalValue;
+            numericKeys.add(variableName);
         } else {
             section[variableName] = value;
         }
@@ -119,13 +120,13 @@ export function writeConfigValuesToConfig(
 
         let tomlContent = stringify(config);
 
-        // @iarna/toml formats large integers with underscores (e.g. 8_080); Ballerina requires plain digits
-        for (const intKey of intKeys) {
-            const intValue = section[intKey];
-            if (typeof intValue === "number") {
-                const escapedKey = intKey.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-                const formattedPattern = new RegExp(`^\\s*${escapedKey}\\s*=\\s*[0-9_]+`, "gm");
-                tomlContent = tomlContent.replace(formattedPattern, `${intKey} = ${intValue}`);
+        // @iarna/toml formats large numbers with underscores (e.g. 8_080); Ballerina requires plain digits
+        for (const key of numericKeys) {
+            const numValue = section[key];
+            if (typeof numValue === "number") {
+                const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+                const formattedPattern = new RegExp(`^\\s*${escapedKey}\\s*=\\s*[0-9][0-9_]*(?:\\.[0-9]+)?`, "gm");
+                tomlContent = tomlContent.replace(formattedPattern, `${key} = ${numValue}`);
             }
         }
 

--- a/workspaces/ballerina/ballerina-extension/src/utils/toml-utils.ts
+++ b/workspaces/ballerina/ballerina-extension/src/utils/toml-utils.ts
@@ -120,13 +120,27 @@ export function writeConfigValuesToConfig(
 
         let tomlContent = stringify(config);
 
-        // @iarna/toml formats large numbers with underscores (e.g. 8_080); Ballerina requires plain digits
-        for (const key of numericKeys) {
-            const numValue = section[key];
-            if (typeof numValue === "number") {
-                const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-                const formattedPattern = new RegExp(`^\\s*${escapedKey}\\s*=\\s*[0-9][0-9_]*(?:\\.[0-9]+)?`, "gm");
-                tomlContent = tomlContent.replace(formattedPattern, `${key} = ${numValue}`);
+        // @iarna/toml formats large numbers with underscores (e.g. 8_080); Ballerina requires plain digits.
+        // Scope replacements to the [org.name] section only to avoid touching identically-named keys
+        // in other sections of the same file.
+        if (numericKeys.size > 0) {
+            const sectionHeader = `[${orgName}.${packageName}]`;
+            const sectionStart = tomlContent.indexOf(sectionHeader);
+            if (sectionStart !== -1) {
+                const afterHeader = sectionStart + sectionHeader.length;
+                const nextSection = tomlContent.indexOf("\n[", afterHeader);
+                const sectionEnd = nextSection !== -1 ? nextSection : tomlContent.length;
+
+                let sectionSlice = tomlContent.slice(sectionStart, sectionEnd);
+                for (const key of numericKeys) {
+                    const numValue = section[key];
+                    if (typeof numValue === "number") {
+                        const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+                        const pattern = new RegExp(`^(\\s*${escapedKey}\\s*=\\s*)[0-9][0-9_]*(?:\\.[0-9]+)?`, "gm");
+                        sectionSlice = sectionSlice.replace(pattern, `$1${numValue}`);
+                    }
+                }
+                tomlContent = tomlContent.slice(0, sectionStart) + sectionSlice + tomlContent.slice(sectionEnd);
             }
         }
 

--- a/workspaces/ballerina/ballerina-extension/src/utils/toml-utils.ts
+++ b/workspaces/ballerina/ballerina-extension/src/utils/toml-utils.ts
@@ -25,74 +25,64 @@ export interface ConfigVariable {
     secret?: boolean;
 }
 
-/**
- * Read all keys from Config.toml and return their fill status.
- * Returns empty object if file doesn't exist.
- */
+function readTomlSection(
+    configPath: string,
+    orgName: string,
+    packageName: string
+): Record<string, any> | null {
+    if (!fs.existsSync(configPath)) {
+        return null;
+    }
+    try {
+        const config = parse(fs.readFileSync(configPath, "utf-8")) as Record<string, any>;
+        const section = config[orgName]?.[packageName];
+        return section && typeof section === "object" ? section : null;
+    } catch (error) {
+        console.error(`[TOML Utils] Error reading ${configPath}:`, error);
+        return null;
+    }
+}
+
 export function getAllConfigStatus(
-    configPath: string
+    configPath: string,
+    orgName: string,
+    packageName: string
 ): Record<string, "filled" | "missing"> {
     const status: Record<string, "filled" | "missing"> = {};
-
-    if (!fs.existsSync(configPath)) {
+    const section = readTomlSection(configPath, orgName, packageName);
+    if (!section) {
         return status;
     }
-
-    try {
-        const content = fs.readFileSync(configPath, "utf-8");
-        const config = parse(content) as Record<string, any>;
-
-        function collectStatus(obj: any, prefix: string = "") {
-            for (const [key, value] of Object.entries(obj)) {
-                const fullKey = prefix ? `${prefix}.${key}` : key;
-                if (Array.isArray(value)) {
-                    value.forEach((item, index) => {
-                        if (item !== null && typeof item === "object") {
-                            collectStatus(item, `${fullKey}[${index}]`);
-                        } else {
-                            status[`${fullKey}[${index}]`] = "filled";
-                        }
-                    });
-                    if (value.length === 0) {
-                        status[fullKey] = "filled";
-                    }
-                } else if (value !== null && typeof value === "object") {
-                    collectStatus(value, fullKey);
-                } else {
-                    status[fullKey] = "filled";
-                }
-            }
+    for (const [key, value] of Object.entries(section)) {
+        if (value !== null && typeof value !== "object") {
+            status[key] = "filled";
         }
-
-        collectStatus(config);
-    } catch (error) {
-        console.error(`[TOML Utils] Error reading config status:`, error);
     }
-
     return status;
 }
 
-/**
- * Write configuration values to Config.toml - SECURITY: never logs values
- */
 export function writeConfigValuesToConfig(
     configPath: string,
     configValues: Record<string, string>,
-    variables?: ConfigVariable[]
+    variables: ConfigVariable[] | undefined,
+    orgName: string,
+    packageName: string
 ): void {
     let config: Record<string, any> = {};
 
     if (fs.existsSync(configPath)) {
         try {
-            const content = fs.readFileSync(configPath, "utf-8");
-            config = parse(content) as Record<string, any>;
+            config = parse(fs.readFileSync(configPath, "utf-8")) as Record<string, any>;
         } catch (error) {
             console.error(`[TOML Utils] Error reading config for value write:`, error);
             throw error;
         }
     }
 
-    // Create a map of variable types for quick lookup
+    if (!config[orgName]) { config[orgName] = {}; }
+    if (!config[orgName][packageName]) { config[orgName][packageName] = {}; }
+    const section = config[orgName][packageName];
+
     const typeMap = new Map<string, string>();
     if (variables) {
         for (const variable of variables) {
@@ -103,23 +93,21 @@ export function writeConfigValuesToConfig(
     const intKeys = new Set<string>();
     for (const [variableName, value] of Object.entries(configValues)) {
         const varType = typeMap.get(variableName) || "string";
-
-        // Convert value based on type
         if (varType === "int") {
             const intValue = parseInt(value, 10);
             if (isNaN(intValue)) {
                 throw new Error(`Invalid integer value for ${variableName}`);
             }
-            config[variableName] = intValue;
+            section[variableName] = intValue;
             intKeys.add(variableName);
         } else if (varType === "decimal") {
             const decimalValue = parseFloat(value);
             if (isNaN(decimalValue)) {
                 throw new Error(`Invalid decimal value for ${variableName}`);
             }
-            config[variableName] = decimalValue;
+            section[variableName] = decimalValue;
         } else {
-            config[variableName] = value;
+            section[variableName] = value;
         }
     }
 
@@ -131,21 +119,17 @@ export function writeConfigValuesToConfig(
 
         let tomlContent = stringify(config);
 
-        // Fix TOML integer formatting - remove underscores from integer values
-        // The @iarna/toml library adds underscores to large numbers for readability (e.g., 8_080)
-        // We need to remove them for Ballerina compatibility
+        // @iarna/toml formats large integers with underscores (e.g. 8_080); Ballerina requires plain digits
         for (const intKey of intKeys) {
-            const intValue = config[intKey];
-            if (typeof intValue === 'number') {
-                // Replace formatted number (with underscores) with plain number
-                const escapedKey = intKey.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-                const formattedPattern = new RegExp(`^\\s*${escapedKey}\\s*=\\s*[0-9_]+`, 'gm');
+            const intValue = section[intKey];
+            if (typeof intValue === "number") {
+                const escapedKey = intKey.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+                const formattedPattern = new RegExp(`^\\s*${escapedKey}\\s*=\\s*[0-9_]+`, "gm");
                 tomlContent = tomlContent.replace(formattedPattern, `${intKey} = ${intValue}`);
             }
         }
 
         fs.writeFileSync(configPath, tomlContent, "utf-8");
-
         console.log(`[TOML Utils] Updated ${Object.keys(configValues).length} configuration value(s) in Config.toml`);
     } catch (error) {
         console.error(`[TOML Utils] Error writing configuration values:`, error);
@@ -153,73 +137,40 @@ export function writeConfigValuesToConfig(
     }
 }
 
-function getNestedValue(obj: any, key: string): any {
-    if (key.includes(".")) {
-        const parts = key.split(".");
-        let current = obj;
-        for (const part of parts) {
-            if (current && typeof current === "object") {
-                current = current[part];
-            } else {
-                return undefined;
-            }
-        }
-        return current;
-    }
-    return obj[key];
-}
-
 export function validateVariableName(name: string): boolean {
     return /^[a-zA-Z][a-zA-Z0-9]*$/.test(name);
 }
 
-/**
- * Read existing configuration values from Config.toml
- * Returns actual values (to be shown in UI for editing)
- */
 export function readExistingConfigValues(
     configPath: string,
-    variableNames: string[]
+    variableNames: string[],
+    orgName: string,
+    packageName: string
 ): Record<string, string> {
     const existingValues: Record<string, string> = {};
-
-    if (!fs.existsSync(configPath)) {
+    const section = readTomlSection(configPath, orgName, packageName);
+    if (!section) {
         return existingValues;
     }
-
-    try {
-        const content = fs.readFileSync(configPath, "utf-8");
-        const config = parse(content) as Record<string, any>;
-
-        for (const name of variableNames) {
-            const value = getNestedValue(config, name);
-
-            if (value !== undefined && value !== null) {
-                if (typeof value === "string") {
-                    existingValues[name] = value;
-                } else if (typeof value === "number") {
-                    existingValues[name] = value.toString();
-                }
+    for (const name of variableNames) {
+        const value = section[name];
+        if (value !== undefined && value !== null) {
+            if (typeof value === "string") {
+                existingValues[name] = value;
+            } else if (typeof value === "number") {
+                existingValues[name] = value.toString();
             }
         }
-    } catch (error) {
-        console.error(`[TOML Utils] Error reading existing configuration values:`, error);
     }
-
     return existingValues;
 }
 
-/**
- * Create status metadata from configuration values - returns only fill status, never values
- */
 export function createStatusMetadata(
     configValues: Record<string, string>
 ): Record<string, "filled" | "missing"> {
     const status: Record<string, "filled" | "missing"> = {};
-
     for (const [key, value] of Object.entries(configValues)) {
         status[key] = value && value.trim() !== "" ? "filled" : "missing";
     }
-
     return status;
 }

--- a/workspaces/ballerina/ballerina-extension/src/utils/toml-utils.ts
+++ b/workspaces/ballerina/ballerina-extension/src/utils/toml-utils.ts
@@ -21,7 +21,7 @@ import { parse, stringify } from "@iarna/toml";
 export interface ConfigVariable {
     name: string;
     description: string;
-    type?: "string" | "int" | "decimal";
+    type?: string;
     secret?: boolean;
 }
 
@@ -93,20 +93,22 @@ export function writeConfigValuesToConfig(
     const numericKeys = new Set<string>();
     for (const [variableName, value] of Object.entries(configValues)) {
         const varType = typeMap.get(variableName) || "string";
-        if (varType === "int") {
+        if (varType === "int" || varType === "byte") {
             const intValue = parseInt(value, 10);
             if (isNaN(intValue)) {
                 throw new Error(`Invalid integer value for ${variableName}`);
             }
             section[variableName] = intValue;
             numericKeys.add(variableName);
-        } else if (varType === "decimal") {
+        } else if (varType === "decimal" || varType === "float") {
             const decimalValue = parseFloat(value);
             if (isNaN(decimalValue)) {
                 throw new Error(`Invalid decimal value for ${variableName}`);
             }
             section[variableName] = decimalValue;
             numericKeys.add(variableName);
+        } else if (varType === "boolean") {
+            section[variableName] = value === "true";
         } else {
             section[variableName] = value;
         }

--- a/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -55,7 +55,7 @@ import { ConfigurationCollectorSegment, ConfigurationCollectionData } from "../C
 import CheckpointSeparator from "../CheckpointSeparator";
 import { Attachment, AttachmentStatus, TaskApprovalRequest } from "@wso2/ballerina-core";
 
-import { AIChatView, Header, HeaderButtons, ChatMessage, TurnGroup, AuthProviderChip, UsageBadge, ApprovalOverlay, OverlayMessage } from "../../styles";
+import { AIChatView, Header, HeaderButtons, ChatMessage, TurnGroup, AuthProviderChip, UsageBadge, ApprovalOverlay, OverlayMessage, OverlayCloseButton } from "../../styles";
 import ReferenceDropdown from "../ReferenceDropdown";
 import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
 import MarkdownRenderer from "../MarkdownRenderer";
@@ -1729,7 +1729,22 @@ const AIChat: React.FC = () => {
                 <AIChatView style={{ position: "relative" }}>
                     {approvalOverlay.show && (
                         <ApprovalOverlay>
-                            <OverlayMessage>{approvalOverlay.message || 'Processing...'}</OverlayMessage>
+                            <OverlayMessage>
+                                <span>{approvalOverlay.message || 'Processing...'}</span>
+                                {approvalOverlay.requestId && (
+                                    <OverlayCloseButton
+                                        title="Close"
+                                        aria-label="Close"
+                                        onClick={() => {
+                                            rpcClient
+                                                .getVisualizerRpcClient()
+                                                .handleApprovalPopupClose({ requestId: approvalOverlay.requestId! });
+                                        }}
+                                    >
+                                        <span className="codicon codicon-close" />
+                                    </OverlayCloseButton>
+                                )}
+                            </OverlayMessage>
                         </ApprovalOverlay>
                     )}
                     <Header>

--- a/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/ConfigurationCollector/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/ConfigurationCollector/index.tsx
@@ -169,7 +169,12 @@ export const ConfigurationCollector: React.FC<ConfigurationCollectorProps> = ({ 
             } else if (variable.type === "int") {
                 const intValue = parseInt(value, 10);
                 if (isNaN(intValue)) {
-                    newErrors[variable.name] = "Please enter a valid number";
+                    newErrors[variable.name] = "Please enter a valid integer";
+                }
+            } else if (variable.type === "decimal") {
+                const decimalValue = parseFloat(value);
+                if (isNaN(decimalValue)) {
+                    newErrors[variable.name] = "Please enter a valid decimal number";
                 }
             }
         });
@@ -274,7 +279,7 @@ export const ConfigurationCollector: React.FC<ConfigurationCollectorProps> = ({ 
                             const isVisible = visibleFields[variable.name];
                             const inputType = isSecret
                                 ? (isVisible ? "text" : "password")
-                                : (variable.type === "int" ? "number" : "text");
+                                : (variable.type === "int" || variable.type === "decimal" ? "number" : "text");
                             return (
                                 <ConfigurationField key={variable.name}>
                                     <FieldLabel>
@@ -286,7 +291,7 @@ export const ConfigurationCollector: React.FC<ConfigurationCollectorProps> = ({ 
                                     <FieldInputWrapper>
                                         <FieldInput
                                             type={inputType}
-                                            placeholder={variable.type === "int" ? "Enter number" : "Enter value"}
+                                            placeholder={variable.type === "int" || variable.type === "decimal" ? "Enter number" : "Enter value"}
                                             value={configValues[variable.name] || ""}
                                             onChange={(e) => handleInputChange(variable.name, e.target.value)}
                                             onKeyDown={handleKeyDown}

--- a/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/ConfigurationCollector/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/ConfigurationCollector/index.tsx
@@ -33,7 +33,8 @@ import {
     PopupFooter,
 } from "../../../BI/Connection/styles";
 
-// Form styled components
+// ─── Styled components ────────────────────────────────────────────────────────
+
 const FormSection = styled.div`
     display: flex;
     flex-direction: column;
@@ -89,6 +90,24 @@ const FieldInput = styled.input<{ hasError: boolean; hasToggle?: boolean }>`
     }
 `;
 
+const FieldSelect = styled.select<{ hasError: boolean }>`
+    width: 100%;
+    padding: 10px 12px;
+    background-color: ${ThemeColors.SURFACE_DIM};
+    color: ${ThemeColors.ON_SURFACE};
+    border: 1px solid ${(props: { hasError: boolean }) =>
+        props.hasError ? ThemeColors.ERROR : ThemeColors.OUTLINE_VARIANT};
+    border-radius: 6px;
+    font-size: 13px;
+    box-sizing: border-box;
+    cursor: pointer;
+
+    &:focus {
+        outline: none;
+        border-color: ${ThemeColors.PRIMARY};
+    }
+`;
+
 const ToggleVisibilityButton = styled.button`
     position: absolute;
     right: 8px;
@@ -120,36 +139,181 @@ const LoadingContainer = styled.div`
     color: ${ThemeColors.ON_SURFACE_VARIANT};
 `;
 
+// ─── Field type config (single source of truth) ───────────────────────────────
+//
+// To add a new Ballerina type: add an entry here. No other code needs to change.
+
+type InputKind = "text" | "number" | "select";
+
+interface SelectOption {
+    label: string;
+    value: string;
+}
+
+interface FieldConfig {
+    inputKind: InputKind;
+    placeholder?: string;
+    selectOptions?: SelectOption[];
+    defaultValue?: string;
+    validate: (value: string) => string | null;
+}
+
+const NUMERIC_INT_TYPES = new Set(["int", "byte"]);
+const NUMERIC_FLOAT_TYPES = new Set(["decimal", "float"]);
+
+function getFieldConfig(type: string | undefined): FieldConfig {
+    if (NUMERIC_INT_TYPES.has(type ?? "")) {
+        return {
+            inputKind: "number",
+            placeholder: "Enter integer",
+            validate: (v) => {
+                if (!v.trim()) return "This field is required";
+                if (isNaN(parseInt(v, 10)) || !Number.isInteger(parseFloat(v))) return "Enter a valid integer";
+                return null;
+            },
+        };
+    }
+    if (NUMERIC_FLOAT_TYPES.has(type ?? "")) {
+        return {
+            inputKind: "number",
+            placeholder: "Enter number",
+            validate: (v) => {
+                if (!v.trim()) return "This field is required";
+                if (isNaN(parseFloat(v))) return "Enter a valid number";
+                return null;
+            },
+        };
+    }
+    if (type === "boolean") {
+        return {
+            inputKind: "select",
+            defaultValue: "true",
+            selectOptions: [
+                { label: "true", value: "true" },
+                { label: "false", value: "false" },
+            ],
+            validate: () => null, // select always holds a valid option
+        };
+    }
+    // Default: string, records, arrays, maps, or any unknown LS type
+    return {
+        inputKind: "text",
+        placeholder: "Enter value",
+        validate: (v) => (!v || !v.trim() ? "This field is required" : null),
+    };
+}
+
+// ─── ConfigField sub-component ────────────────────────────────────────────────
+
+interface ConfigFieldProps {
+    variable: { name: string; description?: string; type?: string; secret?: boolean };
+    value: string;
+    error?: string;
+    isVisible: boolean;
+    onToggleVisibility: () => void;
+    onChange: (name: string, value: string) => void;
+    onKeyDown: (e: React.KeyboardEvent) => void;
+}
+
+const ConfigField: React.FC<ConfigFieldProps> = ({
+    variable, value, error, isVisible, onToggleVisibility, onChange, onKeyDown,
+}) => {
+    const config = getFieldConfig(variable.type);
+    const isSecret = variable.secret === true;
+
+    const renderInput = () => {
+        if (!isSecret && config.inputKind === "select") {
+            return (
+                <FieldSelect
+                    hasError={!!error}
+                    value={value}
+                    onChange={(e) => onChange(variable.name, e.target.value)}
+                >
+                    {config.selectOptions!.map((opt) => (
+                        <option key={opt.value} value={opt.value}>{opt.label}</option>
+                    ))}
+                </FieldSelect>
+            );
+        }
+
+        const htmlInputType = isSecret
+            ? (isVisible ? "text" : "password")
+            : config.inputKind;
+
+        return (
+            <FieldInputWrapper>
+                <FieldInput
+                    type={htmlInputType}
+                    placeholder={config.placeholder}
+                    value={value}
+                    onChange={(e) => onChange(variable.name, e.target.value)}
+                    onKeyDown={onKeyDown}
+                    hasError={!!error}
+                    hasToggle={isSecret}
+                />
+                {isSecret && (
+                    <ToggleVisibilityButton
+                        type="button"
+                        onClick={onToggleVisibility}
+                        title={isVisible ? "Hide value" : "Show value"}
+                    >
+                        <Codicon name={isVisible ? "eye-closed" : "eye"} />
+                    </ToggleVisibilityButton>
+                )}
+            </FieldInputWrapper>
+        );
+    };
+
+    return (
+        <ConfigurationField>
+            <FieldLabel>
+                {variable.name}
+                {variable.description && (
+                    <FieldDescription>- {variable.description}</FieldDescription>
+                )}
+            </FieldLabel>
+            {renderInput()}
+            {error && <FieldError>{error}</FieldError>}
+        </ConfigurationField>
+    );
+};
+
+// ─── ConfigurationCollector ───────────────────────────────────────────────────
+
 interface ConfigurationCollectorProps {
     data?: ConfigurationCollectorMetadata;
     onClose: (parent?: ParentPopupData) => void;
 }
 
+function buildInitialValues(data: ConfigurationCollectorMetadata | undefined): Record<string, string> {
+    const values: Record<string, string> = { ...(data?.existingValues ?? {}) };
+    data?.variables?.forEach((v) => {
+        const config = getFieldConfig(v.type);
+        if (!(v.name in values) && config.defaultValue !== undefined) {
+            values[v.name] = config.defaultValue;
+        }
+    });
+    return values;
+}
+
 export const ConfigurationCollector: React.FC<ConfigurationCollectorProps> = ({ data, onClose }) => {
     const { rpcClient } = useRpcContext();
-    const [configValues, setConfigValues] = useState<Record<string, string>>(data?.existingValues || {});
+    const [configValues, setConfigValues] = useState<Record<string, string>>(buildInitialValues(data));
     const [errors, setErrors] = useState<Record<string, string>>({});
     const [isProcessing, setIsProcessing] = useState(false);
     const [visibleFields, setVisibleFields] = useState<Record<string, boolean>>({});
 
-    const toggleVisibility = (name: string) => {
-        setVisibleFields((prev) => ({ ...prev, [name]: !prev[name] }));
-    };
-
-    // Initialize configuration values when data prop changes
     useEffect(() => {
-        if (data?.existingValues) {
-            setConfigValues(data.existingValues);
-        }
+        setConfigValues(buildInitialValues(data));
         setVisibleFields({});
     }, [data]);
 
     const handleInputChange = (variableName: string, value: string) => {
         setConfigValues((prev) => ({ ...prev, [variableName]: value }));
         setErrors((prev) => {
-            const newErrors = { ...prev };
-            delete newErrors[variableName];
-            return newErrors;
+            const next = { ...prev };
+            delete next[variableName];
+            return next;
         });
     };
 
@@ -161,24 +325,10 @@ export const ConfigurationCollector: React.FC<ConfigurationCollectorProps> = ({ 
 
     const validateConfiguration = (): boolean => {
         const newErrors: Record<string, string> = {};
-
         data?.variables?.forEach((variable) => {
-            const value = configValues[variable.name];
-            if (!value || !value.trim()) {
-                newErrors[variable.name] = "This field is required";
-            } else if (variable.type === "int") {
-                const intValue = parseInt(value, 10);
-                if (isNaN(intValue)) {
-                    newErrors[variable.name] = "Please enter a valid integer";
-                }
-            } else if (variable.type === "decimal") {
-                const decimalValue = parseFloat(value);
-                if (isNaN(decimalValue)) {
-                    newErrors[variable.name] = "Please enter a valid decimal number";
-                }
-            }
+            const error = getFieldConfig(variable.type).validate(configValues[variable.name] ?? "");
+            if (error) newErrors[variable.name] = error;
         });
-
         setErrors(newErrors);
         return Object.keys(newErrors).length === 0;
     };
@@ -218,7 +368,6 @@ export const ConfigurationCollector: React.FC<ConfigurationCollectorProps> = ({ 
             onClose();
             return;
         }
-
         try {
             await rpcClient.getAiPanelRpcClient().cancelConfiguration({
                 requestId: data.requestId,
@@ -231,14 +380,10 @@ export const ConfigurationCollector: React.FC<ConfigurationCollectorProps> = ({ 
 
     // Close button (X) just closes the popup without canceling configuration collection
     // User can reopen via the Configure button in the chat segment
-    const handleClose = () => {
-        onClose();
-    };
+    const handleClose = () => onClose();
 
     // Prevent overlay clicks from closing the popup
-    const handleOverlayClick = (e: React.MouseEvent) => {
-        e.stopPropagation();
-    };
+    const handleOverlayClick = (e: React.MouseEvent) => e.stopPropagation();
 
     if (!data) {
         return (
@@ -274,44 +419,18 @@ export const ConfigurationCollector: React.FC<ConfigurationCollectorProps> = ({ 
                 </PopupHeader>
                 <PopupContent>
                     <FormSection>
-                        {data.variables?.map((variable) => {
-                            const isSecret = variable.secret === true;
-                            const isVisible = visibleFields[variable.name];
-                            const inputType = isSecret
-                                ? (isVisible ? "text" : "password")
-                                : (variable.type === "int" || variable.type === "decimal" ? "number" : "text");
-                            return (
-                                <ConfigurationField key={variable.name}>
-                                    <FieldLabel>
-                                        {variable.name}
-                                        {variable.description && (
-                                            <FieldDescription>- {variable.description}</FieldDescription>
-                                        )}
-                                    </FieldLabel>
-                                    <FieldInputWrapper>
-                                        <FieldInput
-                                            type={inputType}
-                                            placeholder={variable.type === "int" || variable.type === "decimal" ? "Enter number" : "Enter value"}
-                                            value={configValues[variable.name] || ""}
-                                            onChange={(e) => handleInputChange(variable.name, e.target.value)}
-                                            onKeyDown={handleKeyDown}
-                                            hasError={!!errors[variable.name]}
-                                            hasToggle={isSecret}
-                                        />
-                                        {isSecret && (
-                                            <ToggleVisibilityButton
-                                                type="button"
-                                                onClick={() => toggleVisibility(variable.name)}
-                                                title={isVisible ? "Hide value" : "Show value"}
-                                            >
-                                                <Codicon name={isVisible ? "eye-closed" : "eye"} />
-                                            </ToggleVisibilityButton>
-                                        )}
-                                    </FieldInputWrapper>
-                                    {errors[variable.name] && <FieldError>{errors[variable.name]}</FieldError>}
-                                </ConfigurationField>
-                            );
-                        })}
+                        {data.variables?.map((variable) => (
+                            <ConfigField
+                                key={variable.name}
+                                variable={variable}
+                                value={configValues[variable.name] ?? ""}
+                                error={errors[variable.name]}
+                                isVisible={visibleFields[variable.name] ?? false}
+                                onToggleVisibility={() => setVisibleFields((prev) => ({ ...prev, [variable.name]: !prev[variable.name] }))}
+                                onChange={handleInputChange}
+                                onKeyDown={handleKeyDown}
+                            />
+                        ))}
                     </FormSection>
                 </PopupContent>
                 <PopupFooter>

--- a/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/ConfigurationCollectorSegment.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/ConfigurationCollectorSegment.tsx
@@ -71,7 +71,7 @@ const ButtonGroup = styled.div`
 interface ConfigurationVariable {
     name: string;
     description: string;
-    type?: "string" | "int" | "decimal";
+    type?: string;
 }
 
 export interface ConfigurationCollectionData {

--- a/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/ConfigurationCollectorSegment.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/ConfigurationCollectorSegment.tsx
@@ -71,7 +71,7 @@ const ButtonGroup = styled.div`
 interface ConfigurationVariable {
     name: string;
     description: string;
-    type?: "string" | "int";
+    type?: "string" | "int" | "decimal";
 }
 
 export interface ConfigurationCollectionData {

--- a/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/styles.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/styles.tsx
@@ -114,4 +114,23 @@ export const OverlayMessage = styled.div`
     background: var(--vscode-editor-background);
     border: 1px solid var(--vscode-panel-border);
     border-radius: 4px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+`;
+
+export const OverlayCloseButton = styled.button`
+    background: transparent;
+    border: none;
+    color: var(--vscode-descriptionForeground);
+    cursor: pointer;
+    padding: 2px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 3px;
+    &:hover {
+        color: var(--vscode-foreground);
+        background: var(--vscode-toolbar-hoverBackground);
+    }
 `;


### PR DESCRIPTION
Fixes https://github.com/wso2/product-integrator/issues/663
Related to https://github.com/wso2/product-integrator/issues/964

- Reject collect calls with no variables; agent receives a corrective error
- Surface Config.toml presence per project in the codebase listing
- Make check mode act as discovery — variableNames is optional; omit to list all names currently in Config.toml
- Add X close button on the AI panel approval overlay; keeps agent waiting so the in-chat Configure chip can re-open it
- Scope Config.toml reads and writes to the [org.package] section as required by the Ballerina runtime
- Derive configurable types from LS source instead of agent-supplied type; unsupported names and missing declarations surface structured errors
- Support all Ballerina configurable types in the collection form: int/byte, float/decimal, boolean, string, and composite types


https://github.com/user-attachments/assets/bf45968c-a041-46fd-a207-eb476a8b9a7f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI now maps variable types to appropriate input fields, supports decimals, and shows secrets with toggleable masking.
  * Projects now report Config.toml presence (main/tests) to AI prompts.

* **Bug Fixes**
  * Config read/write/check operations are scoped per project package and validate requested variables against source; clearer filled/missing feedback and stricter error handling.

* **Style**
  * Approval overlay layout improved and includes a dismiss/close control that forwards request IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->