### PR TITLE
fix(record-editor): handle readonly & record intersection types

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1398,6 +1398,9 @@ importers:
         specifier: 1.6.1
         version: 1.6.1
     devDependencies:
+      '@types/jest':
+        specifier: 29.5.14
+        version: 29.5.14
       '@types/js-yaml':
         specifier: 4.0.5
         version: 4.0.5
@@ -1452,6 +1455,9 @@ importers:
       eslint-plugin-react-refresh:
         specifier: 0.4.20
         version: 0.4.20(eslint@9.39.4(jiti@2.6.1))
+      jest:
+        specifier: 29.7.0
+        version: 29.7.0(@types/node@22.15.24)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.24)(typescript@5.8.3))
       sass-loader:
         specifier: 16.0.5
         version: 16.0.5(sass@1.89.0)(webpack@5.104.1)
@@ -1461,6 +1467,9 @@ importers:
       style-loader:
         specifier: 4.0.0
         version: 4.0.0(webpack@5.104.1)
+      ts-jest:
+        specifier: 29.3.4
+        version: 29.3.4(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest@29.7.0(@types/node@22.15.24)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.24)(typescript@5.8.3)))(typescript@5.8.3)
       ts-loader:
         specifier: 9.5.2
         version: 9.5.2(typescript@5.8.3)(webpack@5.104.1)
@@ -38671,7 +38680,7 @@ snapshots:
   '@webpack-cli/configtest@3.0.1(webpack-cli@6.0.1)(webpack@5.104.1)':
     dependencies:
       webpack: 5.104.1(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack@5.104.1)
+      webpack-cli: 6.0.1(webpack-dev-server@5.2.3)(webpack@5.104.1)
 
   '@webpack-cli/info@1.5.0(webpack-cli@4.10.0)':
     dependencies:
@@ -38686,7 +38695,7 @@ snapshots:
   '@webpack-cli/info@3.0.1(webpack-cli@6.0.1)(webpack@5.104.1)':
     dependencies:
       webpack: 5.104.1(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack@5.104.1)
+      webpack-cli: 6.0.1(webpack-dev-server@5.2.3)(webpack@5.104.1)
 
   '@webpack-cli/serve@1.7.0(webpack-cli@4.10.0)':
     dependencies:
@@ -39512,6 +39521,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  babel-jest@29.7.0(@babel/core@7.29.0):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/transform': 29.7.0
+      '@types/babel__core': 7.20.5
+      babel-plugin-istanbul: 6.1.1
+      babel-preset-jest: 29.6.3(@babel/core@7.29.0)
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   babel-jest@30.0.0(@babel/core@7.27.1):
     dependencies:
       '@babel/core': 7.27.1
@@ -40125,6 +40148,13 @@ snapshots:
       '@babel/core': 7.27.1
       babel-plugin-jest-hoist: 29.6.3
       babel-preset-current-node-syntax: 1.2.0(@babel/core@7.27.1)
+
+  babel-preset-jest@29.6.3(@babel/core@7.29.0):
+    dependencies:
+      '@babel/core': 7.29.0
+      babel-plugin-jest-hoist: 29.6.3
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0)
+    optional: true
 
   babel-preset-jest@30.0.0(@babel/core@7.27.1):
     dependencies:
@@ -46759,10 +46789,7 @@ snapshots:
       pretty-format: 25.5.0
       throat: 5.0.0
     transitivePeerDependencies:
-      - bufferutil
-      - canvas
       - supports-color
-      - utf-8-validate
 
   jest-leak-detector@25.5.0:
     dependencies:
@@ -54885,6 +54912,26 @@ snapshots:
       babel-jest: 30.0.0(@babel/core@7.27.1)
       esbuild: 0.25.12
 
+  ts-jest@29.3.4(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest@29.7.0(@types/node@22.15.24)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.24)(typescript@5.8.3)))(typescript@5.8.3):
+    dependencies:
+      bs-logger: 0.2.6
+      ejs: 3.1.10
+      fast-json-stable-stringify: 2.1.0
+      jest: 29.7.0(@types/node@22.15.24)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.24)(typescript@5.8.3))
+      jest-util: 29.7.0
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.7.4
+      type-fest: 4.41.0
+      typescript: 5.8.3
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.29.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.29.0)
+
   ts-jest@29.4.1(@babel/core@7.29.0)(@jest/transform@30.1.2)(@jest/types@30.3.0)(babel-jest@30.1.2(@babel/core@7.29.0))(esbuild@0.25.12)(jest-util@30.3.0)(jest@30.1.3(@types/node@20.19.17)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@types/node@20.19.17)(typescript@5.8.3)))(typescript@5.8.3):
     dependencies:
       bs-logger: 0.2.6
@@ -56961,7 +57008,7 @@ snapshots:
       watchpack: 2.5.1
       webpack-sources: 3.4.0
     optionalDependencies:
-      webpack-cli: 6.0.1(webpack@5.104.1)
+      webpack-cli: 6.0.1(webpack-dev-server@5.2.3)(webpack@5.104.1)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild

--- a/workspaces/ballerina/ballerina-extension/package.json
+++ b/workspaces/ballerina/ballerina-extension/package.json
@@ -1237,14 +1237,14 @@
                 "description": "start",
                 "default": {
                     "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
-                    "fontCharacter": "\\f246"
+                    "fontCharacter": "\\f247"
                 }
             },
             "ballerina-debug": {
                 "description": "debug",
                 "default": {
                     "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
-                    "fontCharacter": "\\f1be"
+                    "fontCharacter": "\\f1bf"
                 }
             },
             "ballerina-source-view": {
@@ -1258,7 +1258,7 @@
                 "description": "persist-diagram",
                 "default": {
                     "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
-                    "fontCharacter": "\\f21d"
+                    "fontCharacter": "\\f21e"
                 }
             },
             "ballerina-cached-rounded": {
@@ -1356,7 +1356,7 @@
                 "description": "design-view",
                 "default": {
                     "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
-                    "fontCharacter": "\\f1c3"
+                    "fontCharacter": "\\f1c4"
                 }
             },
             "distro-file-submodule": {

--- a/workspaces/ballerina/ballerina-visualizer/jest.config.js
+++ b/workspaces/ballerina/ballerina-visualizer/jest.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/workspaces/ballerina/ballerina-visualizer/jest.config.js
+++ b/workspaces/ballerina/ballerina-visualizer/jest.config.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+module.exports = {
+    preset: 'ts-jest',
+    testEnvironment: 'node',
+    testMatch: ['**/?(*.)+(spec|test).ts?(x)'],
+    globals: {
+        'ts-jest': {
+            isolatedModules: true,
+        },
+    },
+};

--- a/workspaces/ballerina/ballerina-visualizer/package.json
+++ b/workspaces/ballerina/ballerina-visualizer/package.json
@@ -12,7 +12,8 @@
     "build": "webpack --config webpack.config.js --mode=production && pnpm run postbuild",
     "copy:assets": "copyfiles -u 1 \"src/**/*.scss\"  \"src/**/*.svg\"  \"src/**/*.css\" \"src/resources/assets/font/*.*\" lib/",
     "deploy": "npm publish",
-    "postbuild": "node ./scripts/clean-jslibs.js && copyfiles -u 1 -V build/*.js build/fonts/* build/images/* -e build/*.txt ../ballerina-extension/resources/jslibs"
+    "postbuild": "node ./scripts/clean-jslibs.js && copyfiles -u 1 -V build/*.js build/fonts/* build/images/* -e build/*.txt ../ballerina-extension/resources/jslibs",
+    "test": "jest"
   },
   "keywords": [],
   "dependencies": {
@@ -95,7 +96,10 @@
     "@types/react-lottie": "1.2.5",
     "@types/lodash.debounce": "4.0.6",
     "webpack-cli": "5.1.4",
-    "webpack-dev-server": "5.2.3"
+    "webpack-dev-server": "5.2.3",
+    "@types/jest": "29.5.14",
+    "jest": "29.7.0",
+    "ts-jest": "29.3.4"
   },
   "author": "wso2",
   "license": "UNLICENSED",

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/Configurables/ConfigurableItem/ConfigObjectEditor.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/Configurables/ConfigurableItem/ConfigObjectEditor.tsx
@@ -16,13 +16,13 @@
  * under the License.
  */
 
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect } from "react";
 import styled from "@emotion/styled";
 import { VSCodeTextField, VSCodeButton, VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react";
 import { GetRecordConfigRequest, Property, TypeField, RecordSourceGenRequest, RecordSourceGenResponse, getPrimaryInputType } from "@wso2/ballerina-core";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { Codicon, Typography } from "@wso2/ui-toolkit";
-import { rewrapIntersectionRecord, unwrapIntersectionRecord } from "../../HelperPaneNew/Components/RecordConstructView/utils/intersection";
+import { unwrapIntersectionRecord } from "../../HelperPaneNew/Components/RecordConstructView/utils/intersection";
 
 const EditorContainer = styled.div`
     width: 100%;
@@ -457,7 +457,6 @@ export function ConfigObjectEditor(props: ObjectEditorProps) {
     const [isLoading, setIsLoading] = useState<boolean>(true);
     const [isSaving, setIsSaving] = useState<boolean>(false);
     const [error, setError] = useState<string>('');
-    const originalRecordConfigRef = useRef<TypeField | null>(null);
 
     const { rpcClient } = useRpcContext();
 
@@ -503,7 +502,6 @@ export function ConfigObjectEditor(props: ObjectEditorProps) {
             console.log('recordConfig', response);
 
             if (response.recordConfig) {
-                originalRecordConfigRef.current = response.recordConfig;
                 const configWithName: TypeField = {
                     name: typeValue.value as string,
                     ...unwrapIntersectionRecord(response.recordConfig)
@@ -587,7 +585,7 @@ export function ConfigObjectEditor(props: ObjectEditorProps) {
             try {
                 const request: RecordSourceGenRequest = {
                     filePath: fileName,
-                    type: rewrapIntersectionRecord(withOnlyFilledFields(recordConfig), originalRecordConfigRef.current)
+                    type: withOnlyFilledFields(recordConfig)
                 };
                 const response: RecordSourceGenResponse = await rpcClient.getBIDiagramRpcClient().getRecordSource(request);
                 console.log('>>> recordSourceResponse', response);

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/Configurables/ConfigurableItem/ConfigObjectEditor.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/Configurables/ConfigurableItem/ConfigObjectEditor.tsx
@@ -16,12 +16,13 @@
  * under the License.
  */
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import styled from "@emotion/styled";
 import { VSCodeTextField, VSCodeButton, VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react";
 import { GetRecordConfigRequest, Property, TypeField, RecordSourceGenRequest, RecordSourceGenResponse, getPrimaryInputType } from "@wso2/ballerina-core";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { Codicon, Typography } from "@wso2/ui-toolkit";
+import { rewrapIntersectionRecord, unwrapIntersectionRecord } from "../../HelperPaneNew/Components/RecordConstructView/utils/intersection";
 
 const EditorContainer = styled.div`
     width: 100%;
@@ -456,6 +457,7 @@ export function ConfigObjectEditor(props: ObjectEditorProps) {
     const [isLoading, setIsLoading] = useState<boolean>(true);
     const [isSaving, setIsSaving] = useState<boolean>(false);
     const [error, setError] = useState<string>('');
+    const originalRecordConfigRef = useRef<TypeField | null>(null);
 
     const { rpcClient } = useRpcContext();
 
@@ -501,9 +503,10 @@ export function ConfigObjectEditor(props: ObjectEditorProps) {
             console.log('recordConfig', response);
 
             if (response.recordConfig) {
+                originalRecordConfigRef.current = response.recordConfig;
                 const configWithName: TypeField = {
                     name: typeValue.value as string,
-                    ...response.recordConfig
+                    ...unwrapIntersectionRecord(response.recordConfig)
                 };
                 // Set all fields and nested fields' selected to true recursively
                 function setAllValuesTrue(field: TypeField) {
@@ -584,7 +587,7 @@ export function ConfigObjectEditor(props: ObjectEditorProps) {
             try {
                 const request: RecordSourceGenRequest = {
                     filePath: fileName,
-                    type: withOnlyFilledFields(recordConfig)
+                    type: rewrapIntersectionRecord(withOnlyFilledFields(recordConfig), originalRecordConfigRef.current)
                 };
                 const response: RecordSourceGenResponse = await rpcClient.getBIDiagramRpcClient().getRecordSource(request);
                 console.log('>>> recordSourceResponse', response);

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPane/ConfigureRecordPage.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPane/ConfigureRecordPage.tsx
@@ -22,6 +22,7 @@ import styled from "@emotion/styled";
 import { useEffect, useRef, useState} from "react";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { RecordConfigView } from "./RecordConfigView";
+import { rewrapIntersectionRecord, unwrapIntersectionRecord } from "../HelperPaneNew/Components/RecordConstructView/utils/intersection";
 
 type ConfigureRecordPageProps = {
     fileName: string;
@@ -47,6 +48,7 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
     const [selectedMemberName, setSelectedMemberName] = useState<string>("");
     const firstRender = useRef<boolean>(true);
     const sourceCode = useRef<string>(currentValue);
+    const originalRecordConfigRef = useRef<TypeField | null>(null);
     const [isLoading, setIsLoading] = useState<boolean>(false);
 
     useEffect(() => {
@@ -77,9 +79,10 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
         const newRecordModel = getRecordModelFromSourceResponse.recordConfig;
 
         if (newRecordModel) {
+            originalRecordConfigRef.current = newRecordModel;
             const recordConfig: TypeField = {
                 name: newRecordModel.name,
-                ...newRecordModel
+                ...unwrapIntersectionRecord(newRecordModel)
             }
 
             setRecordModel([recordConfig]);
@@ -130,9 +133,10 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
         const typeFieldResponse: GetRecordConfigResponse = await rpcClient.getBIDiagramRpcClient().getRecordConfig(request);
         console.log(">>> GetRecordConfigResponse", typeFieldResponse);
         if (typeFieldResponse.recordConfig) {
+            originalRecordConfigRef.current = typeFieldResponse.recordConfig;
             const recordConfig: TypeField = {
                 name: defaultSelection.type,
-                ...typeFieldResponse.recordConfig
+                ...unwrapIntersectionRecord(typeFieldResponse.recordConfig)
             }
 
             setRecordModel([recordConfig]);
@@ -179,10 +183,10 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
 
             const typeFieldResponse: GetRecordConfigResponse = await rpcClient.getBIDiagramRpcClient().getRecordConfig(request);
             if (typeFieldResponse.recordConfig) {
-
+                originalRecordConfigRef.current = typeFieldResponse.recordConfig;
                 const recordConfig: TypeField = {
                     name: member.type,
-                    ...typeFieldResponse.recordConfig
+                    ...unwrapIntersectionRecord(typeFieldResponse.recordConfig)
                 }
 
                 setRecordModel([recordConfig]);
@@ -195,7 +199,7 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
     const handleModelChange = async (updatedModel: TypeField[]) => {
         const request: RecordSourceGenRequest = {
             filePath: fileName,
-            type: updatedModel[0]
+            type: rewrapIntersectionRecord(updatedModel[0], originalRecordConfigRef.current)
         }
         const recordSourceResponse: RecordSourceGenResponse = await rpcClient.getBIDiagramRpcClient().getRecordSource(request);
         console.log(">>> recordSourceResponse", recordSourceResponse);

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPane/ConfigureRecordPage.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPane/ConfigureRecordPage.tsx
@@ -22,7 +22,7 @@ import styled from "@emotion/styled";
 import { useEffect, useRef, useState} from "react";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { RecordConfigView } from "./RecordConfigView";
-import { rewrapIntersectionRecord, unwrapIntersectionRecord } from "../HelperPaneNew/Components/RecordConstructView/utils/intersection";
+import { unwrapIntersectionRecord } from "../HelperPaneNew/Components/RecordConstructView/utils/intersection";
 
 type ConfigureRecordPageProps = {
     fileName: string;
@@ -48,7 +48,6 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
     const [selectedMemberName, setSelectedMemberName] = useState<string>("");
     const firstRender = useRef<boolean>(true);
     const sourceCode = useRef<string>(currentValue);
-    const originalRecordConfigRef = useRef<TypeField | null>(null);
     const [isLoading, setIsLoading] = useState<boolean>(false);
 
     useEffect(() => {
@@ -79,7 +78,6 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
         const newRecordModel = getRecordModelFromSourceResponse.recordConfig;
 
         if (newRecordModel) {
-            originalRecordConfigRef.current = newRecordModel;
             const recordConfig: TypeField = {
                 name: newRecordModel.name,
                 ...unwrapIntersectionRecord(newRecordModel)
@@ -133,7 +131,6 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
         const typeFieldResponse: GetRecordConfigResponse = await rpcClient.getBIDiagramRpcClient().getRecordConfig(request);
         console.log(">>> GetRecordConfigResponse", typeFieldResponse);
         if (typeFieldResponse.recordConfig) {
-            originalRecordConfigRef.current = typeFieldResponse.recordConfig;
             const recordConfig: TypeField = {
                 name: defaultSelection.type,
                 ...unwrapIntersectionRecord(typeFieldResponse.recordConfig)
@@ -183,7 +180,6 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
 
             const typeFieldResponse: GetRecordConfigResponse = await rpcClient.getBIDiagramRpcClient().getRecordConfig(request);
             if (typeFieldResponse.recordConfig) {
-                originalRecordConfigRef.current = typeFieldResponse.recordConfig;
                 const recordConfig: TypeField = {
                     name: member.type,
                     ...unwrapIntersectionRecord(typeFieldResponse.recordConfig)
@@ -199,7 +195,7 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
     const handleModelChange = async (updatedModel: TypeField[]) => {
         const request: RecordSourceGenRequest = {
             filePath: fileName,
-            type: rewrapIntersectionRecord(updatedModel[0], originalRecordConfigRef.current)
+            type: updatedModel[0]
         }
         const recordSourceResponse: RecordSourceGenResponse = await rpcClient.getBIDiagramRpcClient().getRecordSource(request);
         console.log(">>> recordSourceResponse", recordSourceResponse);

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Components/RecordConstructView/utils/intersection.test.ts
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Components/RecordConstructView/utils/intersection.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Components/RecordConstructView/utils/intersection.test.ts
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Components/RecordConstructView/utils/intersection.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { TypeField } from "@wso2/ballerina-core";
+import {
+    isIntersectionRecord,
+    rewrapIntersectionRecord,
+    unwrapIntersectionRecord,
+} from "./intersection";
+
+const plainRecord: TypeField = {
+    typeName: "record",
+    fields: [
+        { typeName: "string", name: "name", optional: false, defaultable: false, selected: false },
+        { typeName: "int", name: "id", optional: true, defaultable: false, selected: false },
+    ],
+    hasRestType: true,
+    restType: { typeName: "anydata", optional: false, defaultable: false, isRestType: false, selected: false },
+    optional: false,
+    defaultable: false,
+    selected: false,
+};
+
+const intersectionPet: TypeField = {
+    typeName: "intersection",
+    members: [
+        { typeName: "readonly", optional: false, defaultable: false, selected: false },
+        {
+            typeName: "record",
+            fields: [
+                {
+                    typeName: "array",
+                    name: "photoUrls",
+                    memberType: { typeName: "string", optional: false, defaultable: false, selected: false },
+                    optional: false,
+                    defaultable: false,
+                    selected: false,
+                },
+                { typeName: "string", name: "name", optional: false, defaultable: false, selected: false },
+                { typeName: "int", name: "id", optional: true, defaultable: false, selected: false },
+            ],
+            hasRestType: true,
+            restType: { typeName: "anydata", optional: false, defaultable: false, isRestType: false, selected: false },
+            optional: false,
+            defaultable: false,
+            selected: false,
+        },
+    ],
+    optional: false,
+    defaultable: false,
+    selected: false,
+};
+
+describe("isIntersectionRecord", () => {
+    it("returns false for a plain record", () => {
+        expect(isIntersectionRecord(plainRecord)).toBe(false);
+    });
+
+    it("returns true for intersection containing a record", () => {
+        expect(isIntersectionRecord(intersectionPet)).toBe(true);
+    });
+
+    it("returns false for intersection without a record member", () => {
+        const tf: TypeField = {
+            typeName: "intersection",
+            members: [
+                { typeName: "readonly", selected: false },
+                { typeName: "json", selected: false },
+            ],
+        };
+        expect(isIntersectionRecord(tf)).toBe(false);
+    });
+
+    it("returns false for null/undefined", () => {
+        expect(isIntersectionRecord(null)).toBe(false);
+        expect(isIntersectionRecord(undefined)).toBe(false);
+    });
+});
+
+describe("unwrapIntersectionRecord", () => {
+    it("returns input unchanged for a plain record", () => {
+        const result = unwrapIntersectionRecord(plainRecord);
+        expect(result).toBe(plainRecord);
+    });
+
+    it("extracts the inner record from an intersection", () => {
+        const result = unwrapIntersectionRecord(intersectionPet);
+        expect(result.typeName).toBe("record");
+        expect(result.fields).toBeDefined();
+        expect(result.fields!.length).toBe(3);
+        expect(result.fields!.map(f => f.name)).toEqual(["photoUrls", "name", "id"]);
+    });
+
+    it("carries forward identity fields from the wrapper", () => {
+        const wrapped: TypeField = {
+            ...intersectionPet,
+            name: "Pet",
+            typeInfo: {
+                name: "Pet",
+                orgName: "kanushkagayan",
+                moduleName: "test_4_25_1.petStore",
+                version: "0.1.0",
+            },
+        };
+        const result = unwrapIntersectionRecord(wrapped);
+        expect(result.typeName).toBe("record");
+        expect(result.name).toBe("Pet");
+        expect(result.typeInfo?.name).toBe("Pet");
+    });
+
+    it("returns input unchanged when intersection has no record member", () => {
+        const tf: TypeField = {
+            typeName: "intersection",
+            members: [
+                { typeName: "readonly", selected: false },
+                { typeName: "json", selected: false },
+            ],
+        };
+        expect(unwrapIntersectionRecord(tf)).toBe(tf);
+    });
+});
+
+describe("rewrapIntersectionRecord", () => {
+    it("returns the modified record as-is when original was a plain record", () => {
+        const modified: TypeField = { ...plainRecord, selected: true };
+        expect(rewrapIntersectionRecord(modified, plainRecord)).toBe(modified);
+    });
+
+    it("returns the modified record as-is when original is null", () => {
+        const modified: TypeField = { ...plainRecord, selected: true };
+        expect(rewrapIntersectionRecord(modified, null)).toBe(modified);
+    });
+
+    it("preserves readonly member ordering and replaces only the record member", () => {
+        const unwrapped = unwrapIntersectionRecord(intersectionPet);
+        const modified: TypeField = {
+            ...unwrapped,
+            fields: unwrapped.fields!.map(f =>
+                f.name === "id" ? { ...f, selected: true } : f
+            ),
+        };
+        const result = rewrapIntersectionRecord(modified, intersectionPet);
+        expect(result.typeName).toBe("intersection");
+        expect(result.selected).toBe(true);
+        expect(result.members).toBeDefined();
+        expect(result.members!.length).toBe(2);
+        expect(result.members![0].typeName).toBe("readonly");
+        expect(result.members![1].typeName).toBe("record");
+        const recordMember = result.members![1];
+        const idField = recordMember.fields!.find(f => f.name === "id");
+        expect(idField?.selected).toBe(true);
+    });
+
+    it("composes with unwrap to round-trip the wrapper structure", () => {
+        const unwrapped = unwrapIntersectionRecord(intersectionPet);
+        const round = rewrapIntersectionRecord(unwrapped, intersectionPet);
+        expect(round.typeName).toBe("intersection");
+        expect(round.members!.map(m => m.typeName)).toEqual(["readonly", "record"]);
+        expect(round.members![1].fields!.length).toBe(3);
+    });
+});

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Components/RecordConstructView/utils/intersection.test.ts
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Components/RecordConstructView/utils/intersection.test.ts
@@ -19,7 +19,6 @@
 import { TypeField } from "@wso2/ballerina-core";
 import {
     isIntersectionRecord,
-    rewrapIntersectionRecord,
     unwrapIntersectionRecord,
 } from "./intersection";
 
@@ -135,42 +134,3 @@ describe("unwrapIntersectionRecord", () => {
     });
 });
 
-describe("rewrapIntersectionRecord", () => {
-    it("returns the modified record as-is when original was a plain record", () => {
-        const modified: TypeField = { ...plainRecord, selected: true };
-        expect(rewrapIntersectionRecord(modified, plainRecord)).toBe(modified);
-    });
-
-    it("returns the modified record as-is when original is null", () => {
-        const modified: TypeField = { ...plainRecord, selected: true };
-        expect(rewrapIntersectionRecord(modified, null)).toBe(modified);
-    });
-
-    it("preserves readonly member ordering and replaces only the record member", () => {
-        const unwrapped = unwrapIntersectionRecord(intersectionPet);
-        const modified: TypeField = {
-            ...unwrapped,
-            fields: unwrapped.fields!.map(f =>
-                f.name === "id" ? { ...f, selected: true } : f
-            ),
-        };
-        const result = rewrapIntersectionRecord(modified, intersectionPet);
-        expect(result.typeName).toBe("intersection");
-        expect(result.selected).toBe(true);
-        expect(result.members).toBeDefined();
-        expect(result.members!.length).toBe(2);
-        expect(result.members![0].typeName).toBe("readonly");
-        expect(result.members![1].typeName).toBe("record");
-        const recordMember = result.members![1];
-        const idField = recordMember.fields!.find(f => f.name === "id");
-        expect(idField?.selected).toBe(true);
-    });
-
-    it("composes with unwrap to round-trip the wrapper structure", () => {
-        const unwrapped = unwrapIntersectionRecord(intersectionPet);
-        const round = rewrapIntersectionRecord(unwrapped, intersectionPet);
-        expect(round.typeName).toBe("intersection");
-        expect(round.members!.map(m => m.typeName)).toEqual(["readonly", "record"]);
-        expect(round.members![1].fields!.length).toBe(3);
-    });
-});

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Components/RecordConstructView/utils/intersection.ts
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Components/RecordConstructView/utils/intersection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Components/RecordConstructView/utils/intersection.ts
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Components/RecordConstructView/utils/intersection.ts
@@ -20,8 +20,10 @@ import { TypeField } from "@wso2/ballerina-core";
 
 // `readonly & record { ... }` arrives from the language server as an
 // `intersection` whose members are a `readonly` marker and the inner record.
-// The record editor only knows how to render `record`, so we hide the
-// wrapper from the form and re-apply it when sending back to the server.
+// The record editor only knows how to render `record`, so we unwrap the
+// inner record before handing it to the form. The send path uses that same
+// inner record directly — `typeInfo` carries the `readonly & record` identity,
+// and the LS rejects `intersection` typeName when generating a record literal.
 
 export function isIntersectionRecord(tf: TypeField | null | undefined): boolean {
     if (!tf || tf.typeName !== "intersection" || !Array.isArray(tf.members)) {
@@ -47,15 +49,3 @@ export function unwrapIntersectionRecord(tf: TypeField): TypeField {
     return merged;
 }
 
-export function rewrapIntersectionRecord(
-    modifiedRecord: TypeField,
-    original: TypeField | null | undefined
-): TypeField {
-    if (!original || !isIntersectionRecord(original)) {
-        return modifiedRecord;
-    }
-    const members = original.members!.map(m =>
-        m?.typeName === "record" ? { ...modifiedRecord, name: undefined } : m
-    );
-    return { ...original, members, selected: true };
-}

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Components/RecordConstructView/utils/intersection.ts
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Components/RecordConstructView/utils/intersection.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { TypeField } from "@wso2/ballerina-core";
+
+// `readonly & record { ... }` arrives from the language server as an
+// `intersection` whose members are a `readonly` marker and the inner record.
+// The record editor only knows how to render `record`, so we hide the
+// wrapper from the form and re-apply it when sending back to the server.
+
+export function isIntersectionRecord(tf: TypeField | null | undefined): boolean {
+    if (!tf || tf.typeName !== "intersection" || !Array.isArray(tf.members)) {
+        return false;
+    }
+    return tf.members.some(m => m?.typeName === "record");
+}
+
+export function unwrapIntersectionRecord(tf: TypeField): TypeField {
+    if (!isIntersectionRecord(tf)) {
+        return tf;
+    }
+    const record = tf.members!.find(m => m?.typeName === "record")!;
+    const merged: TypeField = { ...record };
+    if (tf.name !== undefined) merged.name = tf.name;
+    if (tf.typeInfo !== undefined) merged.typeInfo = tf.typeInfo;
+    if (tf.documentation !== undefined && record.documentation === undefined) {
+        merged.documentation = tf.documentation;
+    }
+    if (tf.optional !== undefined) merged.optional = tf.optional;
+    if (tf.defaultable !== undefined) merged.defaultable = tf.defaultable;
+    if (tf.selected !== undefined) merged.selected = tf.selected;
+    return merged;
+}
+
+export function rewrapIntersectionRecord(
+    modifiedRecord: TypeField,
+    original: TypeField | null | undefined
+): TypeField {
+    if (!original || !isIntersectionRecord(original)) {
+        return modifiedRecord;
+    }
+    const members = original.members!.map(m =>
+        m?.typeName === "record" ? { ...modifiedRecord, name: undefined } : m
+    );
+    return { ...original, members, selected: true };
+}

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/RecordConfigModal.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/RecordConfigModal.tsx
@@ -27,7 +27,7 @@ import { useForm } from "react-hook-form";
 import { debounce } from "lodash";
 import ReactMarkdown from "react-markdown";
 import { updateFieldsSelection } from "../Components/RecordConstructView/utils";
-import { rewrapIntersectionRecord, unwrapIntersectionRecord } from "../Components/RecordConstructView/utils/intersection";
+import { unwrapIntersectionRecord } from "../Components/RecordConstructView/utils/intersection";
 import { ChipExpressionEditorDefaultConfiguration } from "@wso2/ballerina-side-panel/lib/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/ChipExpressionDefaultConfig";
 
 type ConfigureRecordPageProps = {
@@ -142,7 +142,6 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
 
     const [recordModel, setRecordModel] = useState<TypeField[]>([]);
     const recordModelRef = useRef<TypeField[]>([]);
-    const originalRecordConfigRef = useRef<TypeField | null>(null);
     const [selectedMemberName, setSelectedMemberName] = useState<string>("");
     const firstRender = useRef<boolean>(true);
     const initialMountRef = useRef<boolean>(true);
@@ -271,7 +270,6 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
         const newRecordModel = getRecordModelFromSourceResponse.recordConfig;
 
         if (newRecordModel) {
-            originalRecordConfigRef.current = newRecordModel;
             const unwrapped = unwrapIntersectionRecord(newRecordModel);
             const recordConfig: TypeField = {
                 name: newRecordModel.name,
@@ -349,7 +347,6 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
         const typeFieldResponse: GetRecordConfigResponse = await rpcClient.getBIDiagramRpcClient().getRecordConfig(request);
         console.log(">>> GetRecordConfigResponse", typeFieldResponse);
         if (typeFieldResponse.recordConfig) {
-            originalRecordConfigRef.current = typeFieldResponse.recordConfig;
             const recordConfig: TypeField = {
                 name: defaultSelection.type,
                 ...unwrapIntersectionRecord(typeFieldResponse.recordConfig)
@@ -403,7 +400,6 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
 
             const typeFieldResponse: GetRecordConfigResponse = await rpcClient.getBIDiagramRpcClient().getRecordConfig(request);
             if (typeFieldResponse.recordConfig) {
-                originalRecordConfigRef.current = typeFieldResponse.recordConfig;
                 const recordConfig: TypeField = {
                     name: member.type,
                     ...unwrapIntersectionRecord(typeFieldResponse.recordConfig)
@@ -427,7 +423,7 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
     const handleModelChange = async (updatedModel: TypeField[]) => {
         const request: RecordSourceGenRequest = {
             filePath: fileName,
-            type: rewrapIntersectionRecord(updatedModel[0], originalRecordConfigRef.current)
+            type: updatedModel[0]
         }
         const recordSourceResponse: RecordSourceGenResponse = await rpcClient.getBIDiagramRpcClient().getRecordSource(request);
         console.log(">>> recordSourceResponse", recordSourceResponse);

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/RecordConfigModal.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/RecordConfigModal.tsx
@@ -27,6 +27,7 @@ import { useForm } from "react-hook-form";
 import { debounce } from "lodash";
 import ReactMarkdown from "react-markdown";
 import { updateFieldsSelection } from "../Components/RecordConstructView/utils";
+import { rewrapIntersectionRecord, unwrapIntersectionRecord } from "../Components/RecordConstructView/utils/intersection";
 import { ChipExpressionEditorDefaultConfiguration } from "@wso2/ballerina-side-panel/lib/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/ChipExpressionDefaultConfig";
 
 type ConfigureRecordPageProps = {
@@ -141,6 +142,7 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
 
     const [recordModel, setRecordModel] = useState<TypeField[]>([]);
     const recordModelRef = useRef<TypeField[]>([]);
+    const originalRecordConfigRef = useRef<TypeField | null>(null);
     const [selectedMemberName, setSelectedMemberName] = useState<string>("");
     const firstRender = useRef<boolean>(true);
     const initialMountRef = useRef<boolean>(true);
@@ -269,9 +271,11 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
         const newRecordModel = getRecordModelFromSourceResponse.recordConfig;
 
         if (newRecordModel) {
+            originalRecordConfigRef.current = newRecordModel;
+            const unwrapped = unwrapIntersectionRecord(newRecordModel);
             const recordConfig: TypeField = {
                 name: newRecordModel.name,
-                ...newRecordModel
+                ...unwrapped
             }
 
             setRecordModel([recordConfig]);
@@ -345,9 +349,10 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
         const typeFieldResponse: GetRecordConfigResponse = await rpcClient.getBIDiagramRpcClient().getRecordConfig(request);
         console.log(">>> GetRecordConfigResponse", typeFieldResponse);
         if (typeFieldResponse.recordConfig) {
+            originalRecordConfigRef.current = typeFieldResponse.recordConfig;
             const recordConfig: TypeField = {
                 name: defaultSelection.type,
-                ...typeFieldResponse.recordConfig
+                ...unwrapIntersectionRecord(typeFieldResponse.recordConfig)
             }
 
             const newModel = [recordConfig];
@@ -398,10 +403,10 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
 
             const typeFieldResponse: GetRecordConfigResponse = await rpcClient.getBIDiagramRpcClient().getRecordConfig(request);
             if (typeFieldResponse.recordConfig) {
-
+                originalRecordConfigRef.current = typeFieldResponse.recordConfig;
                 const recordConfig: TypeField = {
                     name: member.type,
-                    ...typeFieldResponse.recordConfig
+                    ...unwrapIntersectionRecord(typeFieldResponse.recordConfig)
                 }
 
                 const newModel = [recordConfig];
@@ -422,7 +427,7 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
     const handleModelChange = async (updatedModel: TypeField[]) => {
         const request: RecordSourceGenRequest = {
             filePath: fileName,
-            type: updatedModel[0]
+            type: rewrapIntersectionRecord(updatedModel[0], originalRecordConfigRef.current)
         }
         const recordSourceResponse: RecordSourceGenResponse = await rpcClient.getBIDiagramRpcClient().getRecordSource(request);
         console.log(">>> recordSourceResponse", recordSourceResponse);

--- a/workspaces/ballerina/ballerina-visualizer/tsconfig.json
+++ b/workspaces/ballerina/ballerina-visualizer/tsconfig.json
@@ -39,6 +39,10 @@
   "include": ["src"],
   "exclude": [
     "node_modules",
-    "build"
+    "build",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx"
   ]
 }

--- a/workspaces/choreo/choreo-extension/package.json
+++ b/workspaces/choreo/choreo-extension/package.json
@@ -157,7 +157,7 @@
         "description": "choreo-2",
         "default": {
           "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
-          "fontCharacter": "\\f1a8"
+          "fontCharacter": "\\f1a9"
         }
       }
     }

--- a/workspaces/mi/mi-extension/package.json
+++ b/workspaces/mi/mi-extension/package.json
@@ -988,14 +988,14 @@
         "description": "design-view",
         "default": {
           "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
-          "fontCharacter": "\\f1c3"
+          "fontCharacter": "\\f1c4"
         }
       },
       "mi-build-package": {
         "description": "build-package",
         "default": {
           "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
-          "fontCharacter": "\\f19b"
+          "fontCharacter": "\\f19c"
         }
       }
     }


### PR DESCRIPTION
## Summary

The `typesManager/recordConfig` response now wraps `readonly & record { ... }` types as:

```json
{ "typeName": "intersection", "members": [{ "typeName": "readonly" }, { "typeName": "record", "fields": [...] }] }
```

The record editor dispatches renderers by `typeName` and has no `intersection` renderer, so the form rendered nothing and the subsequent `typesManager/generateValue` call returned the literal `"intersection"` instead of a record value.

This PR hides the wrapper from the form: unwrap the inner `record` on receive, store the original wrapper, and re-wrap before sending the `RecordSourceGenRequest` so the backend sees the same shape it sent. Renderer code is untouched — the non-readonly path is unchanged.

## Changes

- New `intersection.ts` util with `unwrapIntersectionRecord` / `rewrapIntersectionRecord` / `isIntersectionRecord`
- Wired into all three call sites: `RecordConfigModal.tsx`, `ConfigureRecordPage.tsx`, `ConfigObjectEditor.tsx`
- Adds 12 unit tests + minimal Jest config to `ballerina-visualizer` (no test infra existed before)

Refs https://github.com/wso2/product-integrator/issues/710, https://github.com/wso2/product-integrator/issues/1073


https://github.com/user-attachments/assets/681efe3b-a78e-4937-b230-79661dc2064f



## Test plan

- [x] Unit tests: `pnpm --filter @wso2/ballerina-visualizer test` — 12/12 pass
- [x] Manual: with `public type Pet record { ... }` (no `readonly`), open resource action call → click Payload → record editor renders fields and generated source is `{ photoUrls: [], name: "" }` (regression baseline)
- [x] Manual: change to `public type Pet readonly & record { ... }` → same field tree renders, no `intersection`/`readonly` shown, generated source is `{ photoUrls: [], name: "" }` (not `"intersection"`)
- [x] Manual: toggle optional fields (e.g. `id`) and confirm source updates correctly — exercises the rewrap path
- [x] Manual: repeat through `ConfigureRecordPage` and `ConfigObjectEditor` entry points

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive Jest test suite for intersection/type utilities.

* **Chores**
  * Added Jest+TypeScript test setup and test script; excluded tests from TypeScript compilation.

* **Bug Fixes / UI Improvements**
  * Normalized record-type handling across record editors and modals to unwrap intersection-record shapes for consistent editing.

* **Style**
  * Updated icon glyph mappings for several editor/extension icons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->