### PR TITLE
Fix Issues in Selecting Org at 'Add New Integration' Form

### DIFF
--- a/workspaces/ballerina/ballerina-core/src/rpc-types/common/interfaces.ts
+++ b/workspaces/ballerina/ballerina-core/src/rpc-types/common/interfaces.ts
@@ -153,7 +153,6 @@ export interface SampleDownloadRequest {
 export interface DefaultOrgNameResponse {
     orgName: string;
     isLocked?: boolean;
-    source?: 'context-yaml' | 'existing-package' | 'user-default';
 }
 
 export interface PublishToCentralResponse {

--- a/workspaces/ballerina/ballerina-core/src/rpc-types/common/interfaces.ts
+++ b/workspaces/ballerina/ballerina-core/src/rpc-types/common/interfaces.ts
@@ -152,6 +152,8 @@ export interface SampleDownloadRequest {
 
 export interface DefaultOrgNameResponse {
     orgName: string;
+    isLocked?: boolean;
+    source?: 'context-yaml' | 'existing-package' | 'user-default';
 }
 
 export interface PublishToCentralResponse {

--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/common/rpc-manager.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/common/rpc-manager.ts
@@ -506,6 +506,16 @@ export class CommonRpcManager implements CommonRPCAPI {
                     }
                 }
             }
+
+            const integrationPath = StateMachine.context()?.projectPath;
+
+            if (integrationPath) {
+                // Check for existing packages in the project Ballerina.toml
+                const projectToml = await getProjectTomlValues(integrationPath);
+                if (projectToml?.package?.org) {
+                    return { orgName: projectToml.package.org, isLocked: true, source: 'existing-package' };
+                }
+            }
         } catch {
             // fall through to default
         }

--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/common/rpc-manager.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/common/rpc-manager.ts
@@ -62,6 +62,7 @@ import { extension } from "../../BalExtensionContext";
 import { StateMachine } from "../../stateMachine";
 import {
     getProjectTomlValues,
+    getWorkspaceTomlValues,
     goToSource
 } from "../../utils";
 import { getUsername } from "../../utils/bi";
@@ -483,17 +484,32 @@ export class CommonRpcManager implements CommonRPCAPI {
             const projectPath = StateMachine.context()?.workspacePath;
 
             if (projectPath) {
-                const contextYamlPath = path.join(projectPath, ".wso2", "context.yaml");
-                const content = await fs.promises.readFile(contextYamlPath, "utf-8");
-                const parsed = loadYaml(content);
-                if (Array.isArray(parsed) && parsed.length > 0 && typeof parsed[0].org === "string" && parsed[0].org) {
-                    return { orgName: parsed[0].org };
+                // Check .wso2/context.yaml then .choreo/context.yaml
+                for (const contextDir of ['.wso2', '.choreo']) {
+                    try {
+                        const contextYamlPath = path.join(projectPath, contextDir, "context.yaml");
+                        const content = await fs.promises.readFile(contextYamlPath, "utf-8");
+                        const parsed = loadYaml(content);
+                        if (Array.isArray(parsed) && parsed.length > 0 && typeof parsed[0].org === "string" && parsed[0].org) {
+                            return { orgName: parsed[0].org, isLocked: true, source: 'context-yaml' };
+                        }
+                    } catch { /* file missing or unreadable — try next */ }
+                }
+
+                // Check existing packages listed in the workspace Ballerina.toml
+                const workspaceToml = await getWorkspaceTomlValues(projectPath);
+                const packages = workspaceToml?.workspace?.packages ?? [];
+                for (const pkg of packages) {
+                    const pkgToml = await getProjectTomlValues(path.join(projectPath, pkg));
+                    if (pkgToml?.package?.org) {
+                        return { orgName: pkgToml.package.org, isLocked: true, source: 'existing-package' };
+                    }
                 }
             }
         } catch {
             // fall through to default
         }
-        return { orgName: getUsername() };
+        return { orgName: getUsername(), isLocked: false, source: 'user-default' };
     }
 
     async publishToCentral(): Promise<PublishToCentralResponse> {

--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/common/rpc-manager.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/common/rpc-manager.ts
@@ -491,7 +491,7 @@ export class CommonRpcManager implements CommonRPCAPI {
                         const content = await fs.promises.readFile(contextYamlPath, "utf-8");
                         const parsed = loadYaml(content);
                         if (Array.isArray(parsed) && parsed.length > 0 && typeof parsed[0].org === "string" && parsed[0].org) {
-                            return { orgName: parsed[0].org, isLocked: true, source: 'context-yaml' };
+                            return { orgName: parsed[0].org, isLocked: true };
                         }
                     } catch { /* file missing or unreadable — try next */ }
                 }
@@ -502,7 +502,7 @@ export class CommonRpcManager implements CommonRPCAPI {
                 for (const pkg of packages) {
                     const pkgToml = await getProjectTomlValues(path.join(projectPath, pkg));
                     if (pkgToml?.package?.org) {
-                        return { orgName: pkgToml.package.org, isLocked: true, source: 'existing-package' };
+                        return { orgName: pkgToml.package.org, isLocked: true };
                     }
                 }
             }
@@ -513,13 +513,13 @@ export class CommonRpcManager implements CommonRPCAPI {
                 // Check for existing packages in the project Ballerina.toml
                 const projectToml = await getProjectTomlValues(integrationPath);
                 if (projectToml?.package?.org) {
-                    return { orgName: projectToml.package.org, isLocked: true, source: 'existing-package' };
+                    return { orgName: projectToml.package.org, isLocked: true };
                 }
             }
         } catch {
             // fall through to default
         }
-        return { orgName: getUsername(), isLocked: false, source: 'user-default' };
+        return { orgName: getUsername(), isLocked: false };
     }
 
     async publishToCentral(): Promise<PublishToCentralResponse> {

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/ProjectForm/AddProjectFormFields.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/ProjectForm/AddProjectFormFields.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { TextField } from "@wso2/ui-toolkit";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { usePlatformExtContext } from "../../../providers/platform-ext-ctx-provider";
@@ -58,10 +58,11 @@ export function AddProjectFormFields({
 }: AddProjectFormFieldsProps) {
     const { rpcClient } = useRpcContext();
     const { platformExtState } = usePlatformExtContext();
-    const organizations = platformExtState?.userInfo?.organizations ?? [];
-    const isLoggedIn = !!platformExtState?.userInfo;
+    const isLoggedIn = !!platformExtState?.isLoggedIn;
+    const organizations = isLoggedIn ? (platformExtState?.userInfo?.organizations ?? []) : undefined;
     const [packageNameTouched, setPackageNameTouched] = useState(false);
     const [projectHandleTouched, setProjectHandleTouched] = useState(false);
+    const isOrgTouched = useRef(false);
     const [isPackageInfoExpanded, setIsPackageInfoExpanded] = useState(false);
     const [integrationNameError, setIntegrationNameError] = useState<string | null>(null);
     const [packageNameError, setPackageNameError] = useState<string | null>(null);
@@ -86,42 +87,44 @@ export function AddProjectFormFields({
         }
     };
 
-    const orgNameRef = useRef(formData.orgName);
-    orgNameRef.current = formData.orgName;
-
-    const fetchAndSetDefaultOrgName = useCallback(async (signal: AbortSignal) => {
-        try {
-            const { orgName } = await rpcClient.getCommonRpcClient().getDefaultOrgName();
-            if (!signal.aborted && orgName) {
-                onFormDataChange({ orgName });
-            }
-        } catch (error) {
-            if (!signal.aborted) {
-                console.error("Failed to fetch default org name:", error);
-            }
-        }
-    }, [rpcClient, onFormDataChange]);
+    const rpcClientRef = useRef(rpcClient);
+    rpcClientRef.current = rpcClient;
 
     useEffect(() => {
+        if (isOrgTouched.current) return;
+
         const controller = new AbortController();
 
-        if (isInProject && !orgNameRef.current) {
-            // When inside a project and no org has been set, fetch the project's org name.
-            fetchAndSetDefaultOrgName(controller.signal);
-        } else if (!orgNameRef.current) {
-            if (organizations.length > 0) {
-                // Organizations are available — use the first one as the default.
-                onFormDataChange({ orgName: organizations[0].handle });
-            } else {
-                // No organizations loaded yet — fall back to the default.
-                fetchAndSetDefaultOrgName(controller.signal);
+        (async () => {
+            try {
+                const { orgName: rpcOrg } = await rpcClientRef.current.getCommonRpcClient().getDefaultOrgName();
+                if (controller.signal.aborted) return;
+
+                if (isInProject) {
+                    // Inside a project: context.yaml (via RPC) always wins.
+                    onFormDataChange({ orgName: rpcOrg });
+                    return;
+                }
+
+                // Prefer context.yaml org if it matches one of the user's orgs,
+                // otherwise use the first org, otherwise fall back to the username.
+                const contextMatch = organizations?.find((o) => o.handle === rpcOrg);
+                if (contextMatch) {
+                    onFormDataChange({ orgName: contextMatch.handle });
+                } else if (organizations && organizations.length > 0) {
+                    onFormDataChange({ orgName: organizations[0].handle });
+                } else {
+                    onFormDataChange({ orgName: rpcOrg });
+                }
+            } catch (error) {
+                console.error("Failed to fetch default org name:", error);
             }
-        }
+        })();
 
         return () => {
             controller.abort();
         };
-    }, [isInProject, organizations, fetchAndSetDefaultOrgName, onFormDataChange]);
+    }, [isInProject, organizations, onFormDataChange]);
 
     // Real-time validation for integration/library name
     useEffect(() => {
@@ -215,6 +218,9 @@ export function AddProjectFormFields({
                     }
                     if (data.projectHandle !== undefined) {
                         setProjectHandleTouched(true);
+                    }
+                    if (data.orgName !== undefined) {
+                        isOrgTouched.current = true;
                     }
                 }}
                 isLibrary={formData.isLibrary}

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/ProjectForm/AddProjectFormFields.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/ProjectForm/AddProjectFormFields.tsx
@@ -88,21 +88,24 @@ export function AddProjectFormFields({
         }
     };
 
-    const rpcClientRef = useRef(rpcClient);
-    rpcClientRef.current = rpcClient;
-
     useEffect(() => {
         if (isOrgTouched.current) return;
 
         const controller = new AbortController();
 
+        const pickOrg = (rpcOrg: string) => {
+            const match = organizations?.find((o) => o.handle === rpcOrg);
+            if (match) return match.handle;
+            if (organizations && organizations.length > 0) return organizations[0].handle;
+            return rpcOrg;
+        };
+
         (async () => {
             try {
-                const { orgName: rpcOrg, isLocked } = await rpcClientRef.current.getCommonRpcClient().getDefaultOrgName();
+                const { orgName: rpcOrg, isLocked } = await rpcClient.getCommonRpcClient().getDefaultOrgName();
                 if (controller.signal.aborted) return;
 
                 if (isInProject && isLocked) {
-                    // Org is derived from context.yaml or an existing package — lock the field.
                     setIsOrgLocked(true);
                     setIsOrgDataLoaded(true);
                     onFormDataChange({ orgName: rpcOrg });
@@ -111,29 +114,7 @@ export function AddProjectFormFields({
 
                 setIsOrgLocked(false);
                 setIsOrgDataLoaded(true);
-
-                if (isInProject) {
-                    // No context.yaml and no existing packages — let the user pick/type.
-                    const contextMatch = organizations?.find((o) => o.handle === rpcOrg);
-                    if (contextMatch) {
-                        onFormDataChange({ orgName: contextMatch.handle });
-                    } else if (organizations && organizations.length > 0) {
-                        onFormDataChange({ orgName: organizations[0].handle });
-                    } else {
-                        onFormDataChange({ orgName: rpcOrg });
-                    }
-                    return;
-                }
-
-                // Not in project: prefer context.yaml match → first org → username fallback.
-                const contextMatch = organizations?.find((o) => o.handle === rpcOrg);
-                if (contextMatch) {
-                    onFormDataChange({ orgName: contextMatch.handle });
-                } else if (organizations && organizations.length > 0) {
-                    onFormDataChange({ orgName: organizations[0].handle });
-                } else {
-                    onFormDataChange({ orgName: rpcOrg });
-                }
+                onFormDataChange({ orgName: pickOrg(rpcOrg) });
             } catch (error) {
                 if (controller.signal.aborted) return;
 
@@ -150,7 +131,7 @@ export function AddProjectFormFields({
         return () => {
             controller.abort();
         };
-    }, [isInProject, organizations, onFormDataChange]);
+    }, [isInProject, organizations, onFormDataChange, rpcClient]);
 
     // Real-time validation for integration/library name
     useEffect(() => {

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/ProjectForm/AddProjectFormFields.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/ProjectForm/AddProjectFormFields.tsx
@@ -66,8 +66,9 @@ export function AddProjectFormFields({
     const [isPackageInfoExpanded, setIsPackageInfoExpanded] = useState(false);
     const [integrationNameError, setIntegrationNameError] = useState<string | null>(null);
     const [packageNameError, setPackageNameError] = useState<string | null>(null);
-    const [orgNameError, setOrgNameError] = useState<string | null>(null);
     const [projectHandleError, setProjectHandleError] = useState<string | null>(null);
+    const [isOrgLocked, setIsOrgLocked] = useState(isInProject);
+    const [isOrgDataLoaded, setIsOrgDataLoaded] = useState(false);
     const resourceTypeLabel = formData.isLibrary ? "Library" : "Integration";
     const resourceTypeLabelLower = resourceTypeLabel.toLowerCase();
 
@@ -97,17 +98,34 @@ export function AddProjectFormFields({
 
         (async () => {
             try {
-                const { orgName: rpcOrg } = await rpcClientRef.current.getCommonRpcClient().getDefaultOrgName();
+                const { orgName: rpcOrg, isLocked } = await rpcClientRef.current.getCommonRpcClient().getDefaultOrgName();
                 if (controller.signal.aborted) return;
 
-                if (isInProject) {
-                    // Inside a project: context.yaml (via RPC) always wins.
+                if (isInProject && isLocked) {
+                    // Org is derived from context.yaml or an existing package — lock the field.
+                    setIsOrgLocked(true);
+                    setIsOrgDataLoaded(true);
                     onFormDataChange({ orgName: rpcOrg });
                     return;
                 }
 
-                // Prefer context.yaml org if it matches one of the user's orgs,
-                // otherwise use the first org, otherwise fall back to the username.
+                setIsOrgLocked(false);
+                setIsOrgDataLoaded(true);
+
+                if (isInProject) {
+                    // No context.yaml and no existing packages — let the user pick/type.
+                    const contextMatch = organizations?.find((o) => o.handle === rpcOrg);
+                    if (contextMatch) {
+                        onFormDataChange({ orgName: contextMatch.handle });
+                    } else if (organizations && organizations.length > 0) {
+                        onFormDataChange({ orgName: organizations[0].handle });
+                    } else {
+                        onFormDataChange({ orgName: rpcOrg });
+                    }
+                    return;
+                }
+
+                // Not in project: prefer context.yaml match → first org → username fallback.
                 const contextMatch = organizations?.find((o) => o.handle === rpcOrg);
                 if (contextMatch) {
                     onFormDataChange({ orgName: contextMatch.handle });
@@ -138,18 +156,16 @@ export function AddProjectFormFields({
         setPackageNameError(error);
     }, [formData.packageName]);
 
-    // Real-time validation for organization name
-    useEffect(() => {
-        const error = validateOrgName(formData.orgName);
-        setOrgNameError(error);
-    }, [formData.orgName]);
-
     // Real-time validation for project handle
     useEffect(() => {
         if (formData.projectHandle !== undefined) {
             setProjectHandleError(validateProjectHandle(formData.projectHandle));
         }
     }, [formData.projectHandle]);
+
+    // Computed inline — avoids a one-render lag from a useState/useEffect pair which would
+    // cause hasAdvancedConfigError to briefly read a stale error while orgName is updating.
+    const orgNameError = (!isOrgLocked && isOrgDataLoaded) ? validateOrgName(formData.orgName) : null;
 
     const hasAdvancedConfigError = !!(
         projectHandlePathError ||
@@ -225,10 +241,11 @@ export function AddProjectFormFields({
                 }}
                 isLibrary={formData.isLibrary}
                 packageNameError={packageNameValidationError || packageNameError}
-                orgNameError={orgNameError}
+                orgNameError={orgNameError || undefined}
                 projectHandleError={projectHandlePathError || projectHandleError}
                 organizations={organizations}
                 hasError={hasAdvancedConfigError}
+                isOrgLocked={isOrgLocked}
             />
         </>
     );

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/ProjectForm/AddProjectFormFields.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/ProjectForm/AddProjectFormFields.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { TextField } from "@wso2/ui-toolkit";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { usePlatformExtContext } from "../../../providers/platform-ext-ctx-provider";
@@ -59,7 +59,11 @@ export function AddProjectFormFields({
     const { rpcClient } = useRpcContext();
     const { platformExtState } = usePlatformExtContext();
     const isLoggedIn = !!platformExtState?.isLoggedIn;
-    const organizations = isLoggedIn ? (platformExtState?.userInfo?.organizations ?? []) : undefined;
+    const orgsSource = platformExtState?.userInfo?.organizations;
+    const organizations = useMemo(
+        () => isLoggedIn ? (orgsSource ?? []) : undefined,
+        [isLoggedIn, orgsSource]
+    );
     const [packageNameTouched, setPackageNameTouched] = useState(false);
     const [projectHandleTouched, setProjectHandleTouched] = useState(false);
     const isOrgTouched = useRef(false);

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/ProjectForm/AddProjectFormFields.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/ProjectForm/AddProjectFormFields.tsx
@@ -108,6 +108,10 @@ export function AddProjectFormFields({
             try {
                 const { orgName: rpcOrg, isLocked } = await rpcClient.getCommonRpcClient().getDefaultOrgName();
                 if (controller.signal.aborted) return;
+                if (isOrgTouched.current) {
+                    setIsOrgDataLoaded(true);
+                    return;
+                }
 
                 if (isInProject && isLocked) {
                     setIsOrgLocked(true);
@@ -121,6 +125,10 @@ export function AddProjectFormFields({
                 onFormDataChange({ orgName: pickOrg(rpcOrg) });
             } catch (error) {
                 if (controller.signal.aborted) return;
+                if (isOrgTouched.current) {
+                    setIsOrgDataLoaded(true);
+                    return;
+                }
 
                 console.error("Failed to fetch default org name:", error);
                 setIsOrgLocked(false);

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/ProjectForm/AddProjectFormFields.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/ProjectForm/AddProjectFormFields.tsx
@@ -67,7 +67,7 @@ export function AddProjectFormFields({
     const [integrationNameError, setIntegrationNameError] = useState<string | null>(null);
     const [packageNameError, setPackageNameError] = useState<string | null>(null);
     const [projectHandleError, setProjectHandleError] = useState<string | null>(null);
-    const [isOrgLocked, setIsOrgLocked] = useState(isInProject);
+    const [isOrgLocked, setIsOrgLocked] = useState(false);
     const [isOrgDataLoaded, setIsOrgDataLoaded] = useState(false);
     const resourceTypeLabel = formData.isLibrary ? "Library" : "Integration";
     const resourceTypeLabelLower = resourceTypeLabel.toLowerCase();
@@ -135,7 +135,15 @@ export function AddProjectFormFields({
                     onFormDataChange({ orgName: rpcOrg });
                 }
             } catch (error) {
+                if (controller.signal.aborted) return;
+
                 console.error("Failed to fetch default org name:", error);
+                setIsOrgLocked(false);
+                setIsOrgDataLoaded(true);
+
+                if (organizations && organizations.length > 0) {
+                    onFormDataChange({ orgName: organizations[0].handle });
+                }
             }
         })();
 

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/ProjectForm/ProjectFormFields.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/ProjectForm/ProjectFormFields.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { TextField, CheckBox, DirectorySelector } from "@wso2/ui-toolkit";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { usePlatformExtContext } from "../../../providers/platform-ext-ctx-provider";
@@ -53,7 +53,9 @@ export function ProjectFormFields({
 }: ProjectFormFieldsProps) {
     const { rpcClient } = useRpcContext();
     const { platformExtState } = usePlatformExtContext();
-    const organizations = platformExtState?.userInfo?.organizations ?? [];
+    const isLoggedIn = !!platformExtState?.isLoggedIn;
+    const organizations = isLoggedIn ? (platformExtState?.userInfo?.organizations ?? []) : undefined;
+    const isOrgTouched = useRef(false);
     const [packageNameTouched, setPackageNameTouched] = useState(false);
     const [packageNameError, setPackageNameError] = useState<string | null>(null);
     const [orgNameError, setOrgNameError] = useState<string | null>(null);
@@ -95,7 +97,7 @@ export function ProjectFormFields({
             }
 
             // Set default org name if not already set and no orgs from platform
-            if (!formData.orgName && organizations.length === 0) {
+            if (!formData.orgName && !organizations?.length) {
                 try {
                     const { orgName } = await commonRpcClient.getDefaultOrgName();
                     onFormDataChange({ orgName });
@@ -116,9 +118,8 @@ export function ProjectFormFields({
     }, []);
 
     useEffect(() => {
-        if (organizations.length > 0 && !formData.orgName) {
-            onFormDataChange({ orgName: organizations[0].handle });
-        }
+        if (isOrgTouched.current || !organizations?.length) return;
+        onFormDataChange({ orgName: organizations[0].handle });
     }, [organizations]);
 
     useEffect(() => {
@@ -221,6 +222,9 @@ export function ProjectFormFields({
                     onFormDataChange(data);
                     if (data.packageName !== undefined) {
                         setPackageNameTouched(true);
+                    }
+                    if (data.orgName !== undefined) {
+                        isOrgTouched.current = true;
                     }
                 }}
                 isLibrary={formData.isLibrary}

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/ProjectForm/components/AdvancedConfigurationSection.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/ProjectForm/components/AdvancedConfigurationSection.tsx
@@ -178,7 +178,10 @@ export interface OrgFieldProps {
 }
 
 export function OrgField({ organizations, orgName, orgNameError, description, isSigningIn, onOrgChange, onSignIn, onCancelSignIn }: OrgFieldProps) {
-    const hasOrgs = organizations !== undefined && organizations.length > 0;
+    const hasOrgs = Array.isArray(organizations) && organizations.length > 0;
+    // Show the sign-in hint only when organizations is undefined/null (user not logged in).
+    // An empty array means the user IS logged in but has no orgs yet — no hint needed.
+    const showSignInHint = organizations === undefined || organizations === null;
 
     // Track which suggestion is keyboard-highlighted (index into filteredSuggestions).
     const [activeIndex, setActiveIndex] = useState<number>(-1);
@@ -310,7 +313,7 @@ export function OrgField({ organizations, orgName, orgNameError, description, is
                 )}
             </OrgComboboxWrapper>
             <Description>{description}</Description>
-            {!hasOrgs && (
+            {showSignInHint && (
                 <SignInHint>
                     <Codicon
                         name="account"

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/ProjectForm/components/AdvancedConfigurationSection.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/ProjectForm/components/AdvancedConfigurationSection.tsx
@@ -183,10 +183,20 @@ export interface OrgFieldProps {
     onSignIn: () => void;
     onCancelSignIn: () => void;
     isLocked?: boolean;
-    lockedTooltip?: string;
 }
 
-export function OrgField({ organizations, orgName, orgNameError, description, isSigningIn, onOrgChange, onSignIn, onCancelSignIn, isLocked }: OrgFieldProps) {
+export function OrgField(props: OrgFieldProps) {
+    const {
+        organizations,
+        orgName,
+        orgNameError,
+        description,
+        isSigningIn,
+        onOrgChange,
+        onSignIn,
+        onCancelSignIn,
+        isLocked
+    } = props;
     const hasOrgs = Array.isArray(organizations) && organizations.length > 0;
     const showSignInHint = organizations === undefined || organizations === null;
 

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/ProjectForm/components/AdvancedConfigurationSection.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/ProjectForm/components/AdvancedConfigurationSection.tsx
@@ -18,7 +18,7 @@
 
 import { useCallback, useRef, useState } from "react";
 import styled from "@emotion/styled";
-import { Codicon, TextField } from "@wso2/ui-toolkit";
+import { Codicon, TextField, Tooltip } from "@wso2/ui-toolkit";
 import { Description, FieldGroup, Note, SubSectionDivider, SubSectionLabel } from "../styles";
 import { CollapsibleSection } from "./CollapsibleSection";
 import { sanitizePackageName, sanitizeProjectHandle } from "../utils";
@@ -58,6 +58,8 @@ export interface AdvancedConfigurationSectionProps {
     organizations?: Organization[];
     /** Whether the section contains validation errors */
     hasError?: boolean;
+    /** Whether the org field is locked (derived from context.yaml or existing package) */
+    isOrgLocked?: boolean;
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
@@ -125,6 +127,11 @@ const OrgComboboxWrapper = styled.div`
     position: relative;
 `;
 
+const LockedOrgWrapper = styled.div`
+    opacity: 0.65;
+    cursor: not-allowed;
+`;
+
 // ── Sign-in hint styles ────────────────────────────────────────────────────────
 
 const SignInHint = styled.div`
@@ -175,21 +182,19 @@ export interface OrgFieldProps {
     onOrgChange: (value: string) => void;
     onSignIn: () => void;
     onCancelSignIn: () => void;
+    isLocked?: boolean;
+    lockedTooltip?: string;
 }
 
-export function OrgField({ organizations, orgName, orgNameError, description, isSigningIn, onOrgChange, onSignIn, onCancelSignIn }: OrgFieldProps) {
+export function OrgField({ organizations, orgName, orgNameError, description, isSigningIn, onOrgChange, onSignIn, onCancelSignIn, isLocked }: OrgFieldProps) {
     const hasOrgs = Array.isArray(organizations) && organizations.length > 0;
-    // Show the sign-in hint only when organizations is undefined/null (user not logged in).
-    // An empty array means the user IS logged in but has no orgs yet — no hint needed.
     const showSignInHint = organizations === undefined || organizations === null;
 
-    // Track which suggestion is keyboard-highlighted (index into filteredSuggestions).
+    // All hooks must be declared unconditionally before any early returns.
     const [activeIndex, setActiveIndex] = useState<number>(-1);
-    // Whether the suggestion list is visible.
     const [isOpen, setIsOpen] = useState(false);
     const listRef = useRef<HTMLUListElement>(null);
 
-    /** Suggestions filtered by the current input value against both handle and name. */
     const filteredSuggestions = hasOrgs
         ? (organizations as Organization[]).filter((org) => {
               const query = orgName.toLowerCase();
@@ -201,9 +206,7 @@ export function OrgField({ organizations, orgName, orgNameError, description, is
         : [];
 
     const openList = useCallback(() => {
-        if (hasOrgs) {
-            setIsOpen(true);
-        }
+        if (hasOrgs) setIsOpen(true);
     }, [hasOrgs]);
 
     const closeList = useCallback(() => {
@@ -215,7 +218,6 @@ export function OrgField({ organizations, orgName, orgNameError, description, is
         (value: string) => {
             onOrgChange(value);
             setActiveIndex(-1);
-            // Show the list whenever the user is typing and there are candidates.
             setIsOpen(hasOrgs);
         },
         [onOrgChange, hasOrgs]
@@ -229,20 +231,13 @@ export function OrgField({ organizations, orgName, orgNameError, description, is
         [onOrgChange, closeList]
     );
 
-    /**
-     * Keyboard navigation: ArrowDown/ArrowUp move through suggestions, Enter
-     * confirms, Escape dismisses without changing value.
-     */
     const handleKeyDown = useCallback(
         (e: React.KeyboardEvent<HTMLInputElement>) => {
-            if (!isOpen || filteredSuggestions.length === 0) {
-                return;
-            }
+            if (!isOpen || filteredSuggestions.length === 0) return;
             switch (e.key) {
                 case "ArrowDown": {
                     e.preventDefault();
-                    const nextDown =
-                        activeIndex < filteredSuggestions.length - 1 ? activeIndex + 1 : 0;
+                    const nextDown = activeIndex < filteredSuggestions.length - 1 ? activeIndex + 1 : 0;
                     setActiveIndex(nextDown);
                     (listRef.current?.children[nextDown] as HTMLElement | undefined)
                         ?.scrollIntoView({ block: "nearest", inline: "nearest" });
@@ -250,8 +245,7 @@ export function OrgField({ organizations, orgName, orgNameError, description, is
                 }
                 case "ArrowUp": {
                     e.preventDefault();
-                    const nextUp =
-                        activeIndex > 0 ? activeIndex - 1 : filteredSuggestions.length - 1;
+                    const nextUp = activeIndex > 0 ? activeIndex - 1 : filteredSuggestions.length - 1;
                     setActiveIndex(nextUp);
                     (listRef.current?.children[nextUp] as HTMLElement | undefined)
                         ?.scrollIntoView({ block: "nearest", inline: "nearest" });
@@ -273,6 +267,34 @@ export function OrgField({ organizations, orgName, orgNameError, description, is
         [isOpen, filteredSuggestions, activeIndex, handleSelectSuggestion, closeList]
     );
 
+    if (isLocked) {
+        const tooltip = "Organization is shared across all integrations in this project.";
+        return (
+            <>
+                <Tooltip content={tooltip} containerSx={{ width: "100%" }}>
+                    <LockedOrgWrapper>
+                        <TextField
+                            value={orgName}
+                            label="Organization Name"
+                            disabled={true}
+                            icon={{
+                                iconComponent: (
+                                    <Codicon
+                                        name="lock"
+                                        iconSx={{ fontSize: "13px", color: "var(--vscode-descriptionForeground)" }}
+                                        sx={{ display: "flex" }}
+                                    />
+                                ),
+                                position: "end",
+                            }}
+                        />
+                    </LockedOrgWrapper>
+                </Tooltip>
+                <Description>{description}</Description>
+            </>
+        );
+    }
+
     return (
         <>
             <OrgComboboxWrapper>
@@ -293,8 +315,6 @@ export function OrgField({ organizations, orgName, orgNameError, description, is
                                 role="option"
                                 aria-selected={index === activeIndex}
                                 isActive={index === activeIndex}
-                                // Use onMouseDown instead of onClick so the event fires before
-                                // the TextField's onBlur, which would close the list first.
                                 onMouseDown={(e: React.MouseEvent) => {
                                     e.preventDefault();
                                     handleSelectSuggestion(org.handle);
@@ -356,7 +376,8 @@ export function AdvancedConfigurationSection({
     packageNameError,
     projectHandleError,
     organizations,
-    hasError
+    hasError,
+    isOrgLocked
 }: AdvancedConfigurationSectionProps) {
     const { isSigningIn, handleSignIn, handleCancelSignIn } = useSignIn();
     const createWithinProject = data.projectHandle !== undefined;
@@ -382,6 +403,7 @@ export function AdvancedConfigurationSection({
                             onOrgChange={(value) => onChange({ orgName: value })}
                             onSignIn={handleSignIn}
                             onCancelSignIn={handleCancelSignIn}
+                            isLocked={isOrgLocked}
                         />
                     </FieldGroup>
                     <FieldGroup>
@@ -420,6 +442,7 @@ export function AdvancedConfigurationSection({
                         onOrgChange={(value) => onChange({ orgName: value })}
                         onSignIn={handleSignIn}
                         onCancelSignIn={handleCancelSignIn}
+                        isLocked={isOrgLocked}
                     />
                 </FieldGroup>
             )}

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/ProjectForm/utils.ts
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/ProjectForm/utils.ts
@@ -156,7 +156,7 @@ const RESTRICTED_IDENTIFIER_REGEX = /^[a-zA-Z][a-zA-Z0-9]*(_[a-zA-Z0-9]+)*$/;
 
 export const validateOrgName = (orgName: string): string | null => {
     if (!orgName || orgName.length === 0) {
-        return"Organization name is required";
+        return "Organization name is required";
     }
 
     // Check for reserved org names (case-insensitive)

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/ProjectForm/utils.ts
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/ProjectForm/utils.ts
@@ -155,9 +155,8 @@ const RESERVED_ORG_NAMES = ["ballerina", "ballerinax", "wso2"];
 const RESTRICTED_IDENTIFIER_REGEX = /^[a-zA-Z][a-zA-Z0-9]*(_[a-zA-Z0-9]+)*$/;
 
 export const validateOrgName = (orgName: string): string | null => {
-    // Empty org name is allowed (optional field)
     if (!orgName || orgName.length === 0) {
-        return null;
+        return"Organization name is required";
     }
 
     // Check for reserved org names (case-insensitive)


### PR DESCRIPTION
## Purpose
$title
Addresses: https://github.com/wso2/product-integrator/issues/1211

### Fixes & Improvements
- Fix org selection via auto-complete for logged-in users
- Fix in-place sign-in flow during integration setup
- Fix clearing/reset behavior of the org name field

### Behavior Change
Enforce a single organization per project: all integrations/libraries within a project must belong to the same org

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organization field shows a locked state (lock icon + tooltip) and becomes read-only when derived from config.
  * Default organization selection now checks multiple config sources in priority order and preserves manual user edits.
  * Sign-in hint and organization suggestions only appear when sign-in/org data is available.
  * Default-org responses now include an optional lock flag so UI can reflect locked/unlocked state.

* **Bug Fixes**
  * Organization name validation now requires a non-empty organization name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->