### PR TITLE
Fix function form empty param diagnostics return `undefined symbol $` diagnostics

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/CodeUtils.ts
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/CodeUtils.ts
@@ -30,7 +30,8 @@ import {
     BASE_ICON_STYLES,
     getTokenIconClass,
     getTokenTypeColor,
-    getChipDisplayContent
+    getChipDisplayContent,
+    shouldRenderAsEmptySpace
 } from "./chipStyles";
 import React from "react";
 
@@ -91,33 +92,36 @@ export function createChip(text: string, type: TokenType, start: number, end: nu
             }
 
             const colors = getTokenTypeColor(this.type);
+            const isPlaceholder = shouldRenderAsEmptySpace(this.type, this.text);
 
             // Apply base styles to the chip container
             Object.assign(span.style, {
                 ...BASE_CHIP_STYLES,
-                background: colors.background,
+                background: isPlaceholder ? "transparent" : colors.background,
                 border: `1px solid ${colors.border}`,
                 marginRight: "2px",
                 marginLeft: "2px",
             });
 
-            // Create icon element for standard chip
-            const icon = document.createElement("i");
-            let iconClass = getTokenIconClass(this.type, this.metadata?.documentType);
-            if (iconClass) {
-                icon.className = iconClass;
+            if (!isPlaceholder) {
+                // Create icon element for standard chip
+                const icon = document.createElement("i");
+                let iconClass = getTokenIconClass(this.type, this.metadata?.documentType);
+                if (iconClass) {
+                    icon.className = iconClass;
+                }
+                Object.assign(icon.style, {
+                    ...BASE_ICON_STYLES,
+                    color: colors.icon
+                });
+                span.appendChild(icon);
             }
-            Object.assign(icon.style, {
-                ...BASE_ICON_STYLES,
-                color: colors.icon
-            });
 
             // Create text span with ellipsis handling
             const textSpan = document.createElement("span");
             textSpan.textContent = displayText;
             Object.assign(textSpan.style, CHIP_TEXT_STYLES);
 
-            span.appendChild(icon);
             span.appendChild(textSpan);
         }
 

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/chipStyles.ts
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/chipStyles.ts
@@ -105,7 +105,7 @@ export const shouldRenderAsEmptySpace = (tokenType: TokenType, content: string):
 };
 
 export const getChipDisplayContent = (tokenType: TokenType, content: string): string => {
-    return shouldRenderAsEmptySpace(tokenType, content) ? '  ' : content;
+    return shouldRenderAsEmptySpace(tokenType, content) ? '' : content;
 };
 
 export const BaseChip = styled('span')(BASE_CHIP_STYLES);

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/chipStyles.ts
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/chipStyles.ts
@@ -105,7 +105,7 @@ export const shouldRenderAsEmptySpace = (tokenType: TokenType, content: string):
 };
 
 export const getChipDisplayContent = (tokenType: TokenType, content: string): string => {
-    return shouldRenderAsEmptySpace(tokenType, content) ? '' : content;
+    return shouldRenderAsEmptySpace(tokenType, content) ? ' ' : content;
 };
 
 export const BaseChip = styled('span')(BASE_CHIP_STYLES);

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/ArtifactForm/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/ArtifactForm/index.tsx
@@ -76,6 +76,7 @@ import { BreadcrumbContainer, BreadcrumbItem, BreadcrumbSeparator } from "../Flo
 import { EditorContext, StackItem } from "@wso2/type-editor";
 import DynamicModal from "../../../../components/Modal";
 import { useModalStack } from "../../../../Context";
+import { deserializeForDiagnosticsAPI } from "../form-utils";
 
 interface ArtifactTypeEditorState {
     isOpen: boolean;
@@ -706,7 +707,7 @@ export function ArtifactForm(props: ArtifactFormProps) {
                         const response = await rpcClient.getBIDiagramRpcClient().getExpressionDiagnostics({
                             filePath: fileName,
                             context: {
-                                expression: expression,
+                                expression: deserializeForDiagnosticsAPI(expression),
                                 startLine: getAdjustedStartLine(targetLineRange, expressionOffsetRef.current),
                                 lineOffset: 0,
                                 offset: 0,

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FlowNodeForm/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FlowNodeForm/index.tsx
@@ -92,6 +92,7 @@ import IfForm from "../IfForm";
 import { cloneDeep, debounce } from "lodash";
 import {
     createNodeWithUpdatedLineRange,
+    deserializeForDiagnosticsAPI,
     processFormData,
     removeEmptyNodes,
     updateNodeWithProperties,
@@ -706,9 +707,25 @@ export const FlowNodeForm = forwardRef<FormExpressionEditorRef, FlowNodeFormProp
         });
     }, [canFixFormDiagnostics, diagnosticsTargetRange, fileName, formDiagnostics, rpcClient]);
 
+    const buildValidationData = (data: FormValues): FormValues => {
+        const expressionFieldKeys = fields
+            .filter(field => field.types.map(type => type.fieldType).some(ft => ft === "EXPRESSION" || ft === "ACTION_OR_EXPRESSION"))
+            .map(field => field.key);
+        return {
+            ...data,
+            ...Object.fromEntries(
+                expressionFieldKeys
+                    .filter(key => typeof data[key] === "string")
+                    .map(key => [key, deserializeForDiagnosticsAPI(data[key] as string)])
+            ),
+        };
+    };
+
     const handleOnBlur = async (data: FormValues, dirtyFields: any) => {
         if (node && targetLineRange && !skipFormValidation) {
-            const updatedNode = mergeFormDataWithFlowNode(data, targetLineRange, dirtyFields);
+            const validationData = buildValidationData(data);
+
+            const updatedNode = mergeFormDataWithFlowNode(validationData, targetLineRange, dirtyFields);
             const nodeWithDiagnostics = await getFormWithDiagnostics(updatedNode);
             setDiagnosticsToFields(data, nodeWithDiagnostics!);
         }
@@ -1010,7 +1027,8 @@ export const FlowNodeForm = forwardRef<FormExpressionEditorRef, FlowNodeFormProp
 
     const handleFormValidation = async (data: FormValues, dirtyFields?: any): Promise<boolean> => {
         if (node && targetLineRange && !skipFormValidation) {
-            const updatedNode = mergeFormDataWithFlowNode(data, targetLineRange, dirtyFields);
+            const validationData = buildValidationData(data);
+            const updatedNode = mergeFormDataWithFlowNode(validationData, targetLineRange, dirtyFields);
             const nodeWithDiagnostics = await getFormWithDiagnostics(updatedNode);
             setDiagnosticsToFields(data, nodeWithDiagnostics!);
 
@@ -1069,7 +1087,7 @@ export const FlowNodeForm = forwardRef<FormExpressionEditorRef, FlowNodeFormProp
                     const response = await rpcClient.getBIDiagramRpcClient().getExpressionDiagnostics({
                         filePath: fileName,
                         context: {
-                            expression: expression,
+                            expression: deserializeForDiagnosticsAPI(expression),
                             startLine: updateLineRange(targetLineRange, expressionOffsetRef.current).startLine,
                             lineOffset: 0,
                             offset: 0,

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FlowNodeForm/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FlowNodeForm/index.tsx
@@ -180,6 +180,14 @@ interface FlowNodeFormProps {
     defaultExpandAdvanced?: boolean;
 }
 
+const EXPRESSION_FIELD_TYPES = new Set([
+    "EXPRESSION",
+    "ACTION_OR_EXPRESSION",
+    "LV_EXPRESSION",
+    "ACTION_EXPRESSION",
+    "EXPRESSION_SET",
+]);
+
 // Styled component for the action button description
 const ActionButtonDescription = styled.div`
     font-size: var(--vscode-font-size);
@@ -709,8 +717,7 @@ export const FlowNodeForm = forwardRef<FormExpressionEditorRef, FlowNodeFormProp
 
     const buildValidationData = (data: FormValues): FormValues => {
         const expressionFieldKeys = fields
-            .filter(field => field.types.map(type => type.fieldType).some(ft => ft === "EXPRESSION" || ft === "ACTION_OR_EXPRESSION"))
-            .map(field => field.key);
+            .filter(field => field.types?.some(t => EXPRESSION_FIELD_TYPES.has(t.fieldType))).map(field => field.key);
         return {
             ...data,
             ...Object.fromEntries(

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/form-utils.ts
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/form-utils.ts
@@ -72,17 +72,33 @@ export function removeEmptyNodes(updatedNode: FlowNode): FlowNode {
     return removeEmptyNodeVisitor.getNode();
 }
 
-export const deserializeForDiagnosticsAPI = (expr: string): string => {
-    return expr.replace(
-        /"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|`[^`]*`|\$\d+/g,
-        (match) => {
-            if (match.startsWith('"') || match.startsWith("'")) return match;
-            if (match.startsWith('`')) {
-                return match.replace(/\$\{([^}]*)\}/g, (_, inner) => {
-                    return '${' + deserializeForDiagnosticsAPI(inner) + '}';
-                });
+function extractInterpolations(backtickStr: string): string {
+    const inner = backtickStr.slice(1, -1); // strip surrounding backticks
+    let result = '`';
+    let i = 0;
+    while (i < inner.length) {
+        if (inner[i] === '$' && inner[i + 1] === '{') {
+            // depth-track to find the real matching }
+            let depth = 1, j = i + 2;
+            while (j < inner.length && depth > 0) {
+                if (inner[j] === '{') depth++;
+                else if (inner[j] === '}') depth--;
+                j++;
             }
-            return "";
+            const interp = inner.slice(i + 2, j - 1);
+            result += '${' + deserializeForDiagnosticsAPI(interp) + '}';
+            i = j;
+        } else {
+            result += inner[i++];
         }
-    );
+    }
+    return result + '`';
+}
+
+export const deserializeForDiagnosticsAPI = (expr: string): string => {
+    return expr.replace(/"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|`[^`]*`|\$\d+/g, (match) => {
+        if (match.startsWith('"') || match.startsWith("'")) return match;
+        if (match.startsWith('`')) return extractInterpolations(match);
+        return "";
+    });
 };

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/form-utils.ts
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/form-utils.ts
@@ -73,18 +73,16 @@ export function removeEmptyNodes(updatedNode: FlowNode): FlowNode {
 }
 
 export const deserializeForDiagnosticsAPI = (expr: string): string => {
-    return expr.replace(/"[^"]*"|'[^']*'|`[^`]*`|\$\d+/g, (match) => {
-        // Double/single quoted strings — preserve as-is
-        if (match.startsWith('"') || match.startsWith("'")) return match;
-
-        // Backtick string — sanitize inside ${...} interpolations, preserve the rest
-        if (match.startsWith('`')) {
-            return match.replace(/\$\{([^}]*)\}/g, (_, inner) => {
-                return '${' + deserializeForDiagnosticsAPI(inner) + '}';
-            });
+    return expr.replace(
+        /"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|`[^`]*`|\$\d+/g,
+        (match) => {
+            if (match.startsWith('"') || match.startsWith("'")) return match;
+            if (match.startsWith('`')) {
+                return match.replace(/\$\{([^}]*)\}/g, (_, inner) => {
+                    return '${' + deserializeForDiagnosticsAPI(inner) + '}';
+                });
+            }
+            return "";
         }
-
-        // Bare $N — remove
-        return "";
-    });
+    );
 };

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/form-utils.ts
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/form-utils.ts
@@ -71,3 +71,20 @@ export function removeEmptyNodes(updatedNode: FlowNode): FlowNode {
     traverseNode(updatedNode, removeEmptyNodeVisitor);
     return removeEmptyNodeVisitor.getNode();
 }
+
+export const deserializeForDiagnosticsAPI = (expr: string): string => {
+    return expr.replace(/"[^"]*"|'[^']*'|`[^`]*`|\$\d+/g, (match) => {
+        // Double/single quoted strings — preserve as-is
+        if (match.startsWith('"') || match.startsWith("'")) return match;
+
+        // Backtick string — sanitize inside ${...} interpolations, preserve the rest
+        if (match.startsWith('`')) {
+            return match.replace(/\$\{([^}]*)\}/g, (_, inner) => {
+                return '${' + deserializeForDiagnosticsAPI(inner) + '}';
+            });
+        }
+
+        // Bare $N — remove
+        return "";
+    });
+};


### PR DESCRIPTION
## Purpose
> This PR will remove the dollar marks used as empty place holders for function parameters from the diagnostics API calls to remove the `undefined symbol $` diagnostic from the response. This placeholder is used to render the chips in the place of empty parameters.

> Also this PR changes the styling of this placeholder chips to better communicate that this parameter is not provided yet

Resolves: https://github.com/wso2/product-integrator/issues/1119

<img width="1218" height="885" alt="Screenshot 2026-04-26 at 20 26 33" src="https://github.com/user-attachments/assets/9e444539-f2fa-4e9c-935a-5bfdb0a35509" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of placeholder tokens in the expression editor—they now display with a transparent background and no icon element for cleaner presentation.
  * Enhanced expression validation by properly preprocessing expressions before sending them to the diagnostics API, ensuring more accurate error detection and validation messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->