### PR TITLE
Show error msg in record editor

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/RecordConfigModal.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/RecordConfigModal.tsx
@@ -299,7 +299,6 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
             setHasTooManyFieldsError(false);
             setRecordModel([]);
             recordModelRef.current = [];
-            throw error;
         } finally {
             setIsLoading(false);
         }
@@ -382,6 +381,10 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
                 autoSelectFirstRecord(newModel);
                 await handleModelChange(newModel);
             }
+        } catch (error) {
+            setHasTooManyFieldsError(false);
+            setRecordModel([]);
+            recordModelRef.current = [];
         } finally {
             setIsLoading(false);
         }

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/RecordConfigModal.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/RecordConfigModal.tsx
@@ -420,6 +420,8 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
             const typeFieldResponse: GetRecordConfigResponse = await rpcClient.getBIDiagramRpcClient().getRecordConfig(request);
             if (typeFieldResponse.errorMsg) {
                 setHasTooManyFieldsError(typeFieldResponse.errorMsg === TOO_MANY_FIELDS_ERROR);
+                setRecordModel([]);
+                recordModelRef.current = [];
                 return;
             }
             if (typeFieldResponse.recordConfig) {
@@ -693,7 +695,7 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
                             </LabelContainer>
                         )}
                         {hasTooManyFieldsError ? (
-                            <Typography variant="body3">Record construction assistance is unavailable. Due to too many fields in the record type. Use the expression editor.</Typography>
+                            <Typography variant="body3">Record construction assistance is unavailable due to too many fields in the record type. Use the expression editor.</Typography>
                         ) : selectedMemberName && recordModel?.length > 0 ? (
                             <RecordConfigView
                                 recordModel={recordModel}

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/RecordConfigModal.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/RecordConfigModal.tsx
@@ -338,7 +338,7 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
             let version = "";
             let packageName = "";
 
-            if (defaultSelection?.packageInfo.length > 0) {
+            if (defaultSelection?.packageInfo?.length > 0) {
                 const parts = defaultSelection.packageInfo.split(':');
                 if (parts.length === 3) {
                     [org, module, version] = parts;

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/RecordConfigModal.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/RecordConfigModal.tsx
@@ -148,6 +148,7 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
     const sourceCode = useRef<string>(currentValue);
     const [isLoading, setIsLoading] = useState<boolean>(false);
     const [hasTooManyFieldsError, setHasTooManyFieldsError] = useState<boolean>(false);
+    const TOO_MANY_FIELDS_ERROR = "Record config is too large to send. The record type has too many nested fields.";
     // Local state for expression value - only update form on save/close
     const [localExpressionValue, setLocalExpressionValue] = useState<string>(currentValue);
     // Diagnostics state
@@ -240,60 +241,61 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
     const fetchRecordModelFromSource = async (currentValue: string) => {
         setIsLoading(true);
         setHasTooManyFieldsError(false);
-        let org = "";
-        let module = "";
-        let version = "";
-        let packageInfo = "";
+        try {
+            let org = "";
+            let module = "";
+            let version = "";
+            let packageInfo = "";
 
-        if (recordTypeField.recordTypeMembers[0].packageInfo?.length > 0) {
-            const parts = recordTypeField.recordTypeMembers[0].packageInfo.split(':');
-            if (parts.length === 3) {
-                [org, module, version] = parts;
-                packageInfo = recordTypeField.recordTypeMembers[0].packageInfo;
+            if (recordTypeField.recordTypeMembers[0].packageInfo?.length > 0) {
+                const parts = recordTypeField.recordTypeMembers[0].packageInfo.split(':');
+                if (parts.length === 3) {
+                    [org, module, version] = parts;
+                    packageInfo = recordTypeField.recordTypeMembers[0].packageInfo;
+                }
+            } else {
+                const tomValues = await rpcClient.getCommonRpcClient().getCurrentProjectTomlValues();
+                org = tomValues?.package?.org || "";
+                module = tomValues?.package?.name || "";
+                version = tomValues?.package?.version || "";
             }
-        } else {
-            const tomValues = await rpcClient.getCommonRpcClient().getCurrentProjectTomlValues();
-            org = tomValues?.package?.org || "";
-            module = tomValues?.package?.name || "";
-            version = tomValues?.package?.version || "";
-        }
-        packageInfo = `${org}:${module}:${version}`;
-        recordTypeField.recordTypeMembers[0].packageInfo = packageInfo;
-        const getRecordModelFromSourceRequest: GetRecordModelFromSourceRequest = {
-            filePath: fileName,
-            typeMembers: recordTypeField.recordTypeMembers,
-            expr: currentValue
-        }
+            packageInfo = `${org}:${module}:${version}`;
+            recordTypeField.recordTypeMembers[0].packageInfo = packageInfo;
+            const getRecordModelFromSourceRequest: GetRecordModelFromSourceRequest = {
+                filePath: fileName,
+                typeMembers: recordTypeField.recordTypeMembers,
+                expr: currentValue
+            }
 
-        const getRecordModelFromSourceResponse: GetRecordModelFromSourceResponse =
-            await rpcClient.getBIDiagramRpcClient().getRecordModelFromSource(getRecordModelFromSourceRequest);
-        console.log(">>> getRecordModelFromSourceResponse", getRecordModelFromSourceResponse);
+            const getRecordModelFromSourceResponse: GetRecordModelFromSourceResponse =
+                await rpcClient.getBIDiagramRpcClient().getRecordModelFromSource(getRecordModelFromSourceRequest);
+            console.log(">>> getRecordModelFromSourceResponse", getRecordModelFromSourceResponse);
 
-        if (getRecordModelFromSourceResponse.errorMsg) {
-            setHasTooManyFieldsError(true);
+            if (getRecordModelFromSourceResponse.errorMsg) {
+                setHasTooManyFieldsError(getRecordModelFromSourceResponse.errorMsg === TOO_MANY_FIELDS_ERROR);
+                return;
+            }
+
+            const newRecordModel = getRecordModelFromSourceResponse.recordConfig;
+
+            if (newRecordModel) {
+                const recordConfig: TypeField = {
+                    name: newRecordModel.name,
+                    ...newRecordModel
+                }
+
+                setRecordModel([recordConfig]);
+                recordModelRef.current = [recordConfig];
+                setSelectedMemberName(newRecordModel.name);
+
+                // Update selected flags so the backend receives the correct type on submit
+                recordTypeField.recordTypeMembers.forEach(m => {
+                    m.selected = m.type === newRecordModel.name;
+                });
+            }
+        } finally {
             setIsLoading(false);
-            return;
         }
-
-        const newRecordModel = getRecordModelFromSourceResponse.recordConfig;
-
-        if (newRecordModel) {
-            const recordConfig: TypeField = {
-                name: newRecordModel.name,
-                ...newRecordModel
-            }
-
-            setRecordModel([recordConfig]);
-            recordModelRef.current = [recordConfig];
-            setSelectedMemberName(newRecordModel.name);
-
-            // Update selected flags so the backend receives the correct type on submit
-            recordTypeField.recordTypeMembers.forEach(m => {
-                m.selected = m.type === newRecordModel.name;
-            });
-        }
-
-        setIsLoading(false);
     }
 
     const getExistingRecordModel = async () => {
@@ -322,73 +324,77 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
         setHasTooManyFieldsError(false);
         const defaultSelection = recordTypeField.recordTypeMembers[0];
         setSelectedMemberName(defaultSelection.type);
+        try {
+            let org = "";
+            let module = "";
+            let version = "";
+            let packageName = "";
 
-        let org = "";
-        let module = "";
-        let version = "";
-        let packageName = "";
-
-        if (defaultSelection?.packageInfo.length > 0) {
-            const parts = defaultSelection.packageInfo.split(':');
-            if (parts.length === 3) {
-                [org, module, version] = parts;
-                packageName = defaultSelection.packageName;
+            if (defaultSelection?.packageInfo.length > 0) {
+                const parts = defaultSelection.packageInfo.split(':');
+                if (parts.length === 3) {
+                    [org, module, version] = parts;
+                    packageName = defaultSelection.packageName;
+                }
+            } else {
+                const tomValues = await rpcClient.getCommonRpcClient().getCurrentProjectTomlValues();
+                org = tomValues?.package?.org || "";
+                module = tomValues?.package?.name || "";
+                version = tomValues?.package?.version || "";
+                packageName = tomValues?.package?.name || "";
             }
-        } else {
-            const tomValues = await rpcClient.getCommonRpcClient().getCurrentProjectTomlValues();
-            org = tomValues?.package?.org || "";
-            module = tomValues?.package?.name || "";
-            version = tomValues?.package?.version || "";
-            packageName = tomValues?.package?.name || "";
-        }
 
-        const request: GetRecordConfigRequest = {
-            filePath: fileName,
-            codedata: {
-                org: org,
-                module: module,
-                version: version,
-                packageName: packageName,
-            },
-            typeConstraint: defaultSelection.type,
-        }
-        const typeFieldResponse: GetRecordConfigResponse = await rpcClient.getBIDiagramRpcClient().getRecordConfig(request);
-        console.log(">>> GetRecordConfigResponse", typeFieldResponse);
-        if (typeFieldResponse.errorMsg) {
-            setHasTooManyFieldsError(true);
+            const request: GetRecordConfigRequest = {
+                filePath: fileName,
+                codedata: {
+                    org: org,
+                    module: module,
+                    version: version,
+                    packageName: packageName,
+                },
+                typeConstraint: defaultSelection.type,
+            }
+            const typeFieldResponse: GetRecordConfigResponse = await rpcClient.getBIDiagramRpcClient().getRecordConfig(request);
+            console.log(">>> GetRecordConfigResponse", typeFieldResponse);
+            if (typeFieldResponse.errorMsg) {
+                setHasTooManyFieldsError(typeFieldResponse.errorMsg === TOO_MANY_FIELDS_ERROR);
+                return;
+            }
+            if (typeFieldResponse.recordConfig) {
+                const recordConfig: TypeField = {
+                    name: defaultSelection.type,
+                    ...typeFieldResponse.recordConfig
+                }
+
+                const newModel = [recordConfig];
+                setRecordModel(newModel);
+                recordModelRef.current = newModel;
+
+                // Auto-select the first field for new models
+                autoSelectFirstRecord(newModel);
+
+                // Generate source with the auto-selected field
+                await handleModelChange(newModel);
+            }
+        } finally {
             setIsLoading(false);
-            return;
         }
-        if (typeFieldResponse.recordConfig) {
-            const recordConfig: TypeField = {
-                name: defaultSelection.type,
-                ...typeFieldResponse.recordConfig
-            }
-
-            const newModel = [recordConfig];
-            setRecordModel(newModel);
-            recordModelRef.current = newModel;
-
-            // Auto-select the first field for new models
-            autoSelectFirstRecord(newModel);
-
-            // Generate source with the auto-selected field
-            await handleModelChange(newModel);
-        }
-        setIsLoading(false);
     }
 
     const handleMemberChange = async (value: string) => {
         const member = recordTypeField.recordTypeMembers.find(m => m.type === value);
-        if (member) {
-            // Update selected flags so the backend receives the correct type on submit
-            recordTypeField.recordTypeMembers.forEach(m => {
-                m.selected = m.type === value;
-            });
-            setIsLoading(true);
-            setHasTooManyFieldsError(false);
-            setSelectedMemberName(member.type);
+        if (!member) {
+            return;
+        }
 
+        // Update selected flags so the backend receives the correct type on submit
+        recordTypeField.recordTypeMembers.forEach(m => {
+            m.selected = m.type === value;
+        });
+        setIsLoading(true);
+        setHasTooManyFieldsError(false);
+        setSelectedMemberName(member.type);
+        try {
             let org = "";
             let module = "";
             let version = "";
@@ -414,12 +420,10 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
 
             const typeFieldResponse: GetRecordConfigResponse = await rpcClient.getBIDiagramRpcClient().getRecordConfig(request);
             if (typeFieldResponse.errorMsg) {
-                setHasTooManyFieldsError(true);
-                setIsLoading(false);
+                setHasTooManyFieldsError(typeFieldResponse.errorMsg === TOO_MANY_FIELDS_ERROR);
                 return;
             }
             if (typeFieldResponse.recordConfig) {
-
                 const recordConfig: TypeField = {
                     name: member.type,
                     ...typeFieldResponse.recordConfig
@@ -435,9 +439,9 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
                 // Generate source with the auto-selected field
                 await handleModelChange(newModel);
             }
+        } finally {
+            setIsLoading(false);
         }
-
-        setIsLoading(false);
     };
 
     const handleModelChange = async (updatedModel: TypeField[]) => {
@@ -690,7 +694,7 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
                             </LabelContainer>
                         )}
                         {hasTooManyFieldsError ? (
-                            <Typography variant="body3">Too many fields in the record type. Use the expression editor.</Typography>
+                            <Typography variant="body3">Record construction assistance is unavailable. Due to too many fields in the record type. Use the expression editor.</Typography>
                         ) : selectedMemberName && recordModel?.length > 0 ? (
                             <RecordConfigView
                                 recordModel={recordModel}

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/RecordConfigModal.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/RecordConfigModal.tsx
@@ -147,6 +147,7 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
     const onChangeRef = useRef(onChange);
     const sourceCode = useRef<string>(currentValue);
     const [isLoading, setIsLoading] = useState<boolean>(false);
+    const [hasTooManyFieldsError, setHasTooManyFieldsError] = useState<boolean>(false);
     // Local state for expression value - only update form on save/close
     const [localExpressionValue, setLocalExpressionValue] = useState<string>(currentValue);
     // Diagnostics state
@@ -238,6 +239,7 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
 
     const fetchRecordModelFromSource = async (currentValue: string) => {
         setIsLoading(true);
+        setHasTooManyFieldsError(false);
         let org = "";
         let module = "";
         let version = "";
@@ -266,6 +268,13 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
         const getRecordModelFromSourceResponse: GetRecordModelFromSourceResponse =
             await rpcClient.getBIDiagramRpcClient().getRecordModelFromSource(getRecordModelFromSourceRequest);
         console.log(">>> getRecordModelFromSourceResponse", getRecordModelFromSourceResponse);
+
+        if (getRecordModelFromSourceResponse.errorMsg) {
+            setHasTooManyFieldsError(true);
+            setIsLoading(false);
+            return;
+        }
+
         const newRecordModel = getRecordModelFromSourceResponse.recordConfig;
 
         if (newRecordModel) {
@@ -310,6 +319,7 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
 
     const getNewRecordModel = async () => {
         setIsLoading(true);
+        setHasTooManyFieldsError(false);
         const defaultSelection = recordTypeField.recordTypeMembers[0];
         setSelectedMemberName(defaultSelection.type);
 
@@ -344,6 +354,11 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
         }
         const typeFieldResponse: GetRecordConfigResponse = await rpcClient.getBIDiagramRpcClient().getRecordConfig(request);
         console.log(">>> GetRecordConfigResponse", typeFieldResponse);
+        if (typeFieldResponse.errorMsg) {
+            setHasTooManyFieldsError(true);
+            setIsLoading(false);
+            return;
+        }
         if (typeFieldResponse.recordConfig) {
             const recordConfig: TypeField = {
                 name: defaultSelection.type,
@@ -371,6 +386,7 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
                 m.selected = m.type === value;
             });
             setIsLoading(true);
+            setHasTooManyFieldsError(false);
             setSelectedMemberName(member.type);
 
             let org = "";
@@ -397,6 +413,11 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
             }
 
             const typeFieldResponse: GetRecordConfigResponse = await rpcClient.getBIDiagramRpcClient().getRecordConfig(request);
+            if (typeFieldResponse.errorMsg) {
+                setHasTooManyFieldsError(true);
+                setIsLoading(false);
+                return;
+            }
             if (typeFieldResponse.recordConfig) {
 
                 const recordConfig: TypeField = {
@@ -668,7 +689,9 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
                                 />
                             </LabelContainer>
                         )}
-                        {selectedMemberName && recordModel?.length > 0 ? (
+                        {hasTooManyFieldsError ? (
+                            <Typography variant="body3">Too many fields in the record type. Use the expression editor.</Typography>
+                        ) : selectedMemberName && recordModel?.length > 0 ? (
                             <RecordConfigView
                                 recordModel={recordModel}
                                 onModelChange={handleModelChange}

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/RecordConfigModal.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/RecordConfigModal.tsx
@@ -274,6 +274,8 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
 
             if (getRecordModelFromSourceResponse.errorMsg) {
                 setHasTooManyFieldsError(getRecordModelFromSourceResponse.errorMsg === TOO_MANY_FIELDS_ERROR);
+                setRecordModel([]);
+                recordModelRef.current = [];
                 return;
             }
 

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/RecordConfigModal.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/RecordConfigModal.tsx
@@ -295,6 +295,11 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
                     m.selected = m.type === newRecordModel.name;
                 });
             }
+        } catch (error) {
+            setHasTooManyFieldsError(false);
+            setRecordModel([]);
+            recordModelRef.current = [];
+            throw error;
         } finally {
             setIsLoading(false);
         }
@@ -442,6 +447,9 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
                 // Generate source with the auto-selected field
                 await handleModelChange(newModel);
             }
+        } catch (error) {
+            setRecordModel([]);
+            recordModelRef.current = [];
         } finally {
             setIsLoading(false);
         }
@@ -704,7 +712,7 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
                                 onModelChange={handleModelChange}
                             />
                         ) : !isLoading ? (
-                            <Typography variant="body3">Record construction assistance is unavailable.</Typography>
+                            <Typography variant="body3">Record construction assistance is unavailable. Use the expression editor.</Typography>
                         ) : null}
                     </LeftColumn>
                     <RightColumn>

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/RecordConfigModal.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/RecordConfigModal.tsx
@@ -708,14 +708,14 @@ export function ConfigureRecordPage(props: ConfigureRecordPageProps) {
                             </LabelContainer>
                         )}
                         {hasTooManyFieldsError ? (
-                            <Typography variant="body3">Record construction assistance is unavailable due to too many fields in the record type. Use the expression editor.</Typography>
+                            <Typography variant="body3">Record construction assistance is unavailable due to too many fields in the record type. Please switch to Expression mode.</Typography>
                         ) : selectedMemberName && recordModel?.length > 0 ? (
                             <RecordConfigView
                                 recordModel={recordModel}
                                 onModelChange={handleModelChange}
                             />
                         ) : !isLoading ? (
-                            <Typography variant="body3">Record construction assistance is unavailable. Use the expression editor.</Typography>
+                            <Typography variant="body3">Record construction assistance is unavailable. Please switch to Expression mode.</Typography>
                         ) : null}
                     </LeftColumn>
                     <RightColumn>


### PR DESCRIPTION
## Purpose
When the record type is too large we are getting a errorMsg from LS. Now we are showing a msg asking the user to use expression editor.

Fixes part of https://github.com/wso2/product-integrator/issues/134

<img width="800" height="600" alt="Screenshot 2026-04-26 at 21 03 42" src="https://github.com/user-attachments/assets/aee88f27-4d7b-4da9-8a6c-150475465598" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hides the record configuration pane and displays a clear instruction in the expression editor when a record exceeds the allowed field limit; updates the unavailable message to point users to the expression editor.

* **Bug Fixes**
  * More reliable detection and handling of the "too many fields" condition, clears invalid record state to prevent incorrect generation, and ensures loading state is always reset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->