### PR TITLE
Fix recursive variable creation throughs diagnostics for newly created variable

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
@@ -1686,9 +1686,6 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                         selectedNodeRef.current = undefined;
                         closeSidePanelAndFetchUpdatedFlowModel();
                     }
-                    if (options?.postUpdateCallBack) {
-                        options.postUpdateCallBack();
-                    }
                     shouldUpdateLineRangeRef.current = options?.isChangeFromHelperPane;
                     if (options?.isChangeFromHelperPane) {
                         const updatedModel = await rpcClient.getBIDiagramRpcClient().getFlowModel({});
@@ -1732,6 +1729,9 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
                         shouldUpdateLineRangeRef.current = false;
                     }
                     updatedNodeRef.current = updatedNode;
+                    if (options?.postUpdateCallBack) {
+                        options.postUpdateCallBack();
+                    }
                 } else {
                     console.error(">>> Error updating source code", response);
                 }


### PR DESCRIPTION
## Purpose
> This PR will address an issue where when users created variables on the fly through helper pane, for that newly created variable, form shows diagnostics that saying the above variable is undefined. 

Resolves: https://github.com/wso2/product-integrator/issues/957

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the execution order of post-update operations in the Flow Diagram to ensure all necessary state updates complete before invoking callbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->