### PR TITLE
Display map<T> instead of "MAP" in type editor field input

### DIFF
--- a/workspaces/ballerina/type-editor/src/TypeEditor/TypeUtil.ts
+++ b/workspaces/ballerina/type-editor/src/TypeEditor/TypeUtil.ts
@@ -147,7 +147,7 @@ export const typeToSource = (type: string | Type): string => {
 
     if (type.codedata.node === 'MAP') {
         const valueType = type.members?.[0]?.type;
-        return valueType ? `map<${typeToSource(valueType)}>` : 'map<>';
+        return valueType ? `map<${typeToSource(valueType)}>` : 'map<anydata>';
     }
 
     return type.codedata.node;

--- a/workspaces/ballerina/type-editor/src/TypeEditor/TypeUtil.ts
+++ b/workspaces/ballerina/type-editor/src/TypeEditor/TypeUtil.ts
@@ -145,6 +145,11 @@ export const typeToSource = (type: string | Type): string => {
         return typeToSource(type.members[0].type) + '[]';
     }
 
+    if (type.codedata.node === 'MAP') {
+        const valueType = type.members?.[0]?.type;
+        return valueType ? `map<${typeToSource(valueType)}>` : 'map<>';
+    }
+
     return type.codedata.node;
 };
 


### PR DESCRIPTION
## Summary

- `typeToSource()` in `workspaces/ballerina/type-editor/src/TypeEditor/TypeUtil.ts` had explicit branches for `UNION` and `ARRAY` but none for `MAP`, so it fell through to `return type.codedata.node` and leaked the literal string `"MAP"` into the type input when editing a record member of type `map<T>`.
- Added a `MAP` branch that recursively reconstructs `map<V>` from `members[0].type`, mirroring how `ARRAY` is handled. Recursion through `typeToSource` covers nested cases (`map<MyType>`, `map<string|int>`, `map<string[]>`, `map<map<…>>`) for free.

Fixes wso2/product-integrator#1057

<img width="1316" height="783" alt="Screenshot 2026-04-27 at 00 11 04" src="https://github.com/user-attachments/assets/9e85554e-e252-48d3-8437-567b41bae350" />


## Test plan

- [ ] Build the `type-editor` workspace.
- [ ] In a Ballerina project, define `type MyType record { string id; string[] nameArr; map<string> nameMap; };`.
- [ ] Open the type diagram, click Edit on `MyType`, confirm the `nameMap` row's type input shows `map<string>` instead of `MAP`.
- [ ] Regression: `nameArr` still shows `string[]`, `id` still shows `string`, union/optional fields render unchanged.
- [ ] Spot-check nested cases: `map<MyType>`, `map<string|int>`, `map<string[]>`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced type editor to properly recognize and convert MAP types to source code format, with improved handling for edge cases where value type information is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->