### PR TITLE
Improve sign-in error messages when WSO2 Cloud is unreachable

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/utils/ai/auth.ts
+++ b/workspaces/ballerina/ballerina-extension/src/utils/ai/auth.ts
@@ -199,10 +199,19 @@ export const exchangeStsToCopilotToken = async (stsToken: string): Promise<BIInt
             };
         }
 
-        throw new Error(response.data?.message || response.data?.reason || `Status ${response.status}`);
+        const statusError = Object.assign(
+            new Error(response.data?.message || response.data?.reason || `Status ${response.status}`),
+            { status: response.status }
+        );
+        throw statusError;
     } catch (error) {
-        const reason = error instanceof Error ? error.message : 'Unknown error';
-        vscode.window.showErrorMessage(`WSO2 Integrator Copilot authentication failed: ${reason}`);
+        const isOutage =
+            (typeof (error as any)?.status === 'number' && (error as any).status >= 500) ||
+            (error instanceof Error && /(ECONN|ETIMEDOUT|socket hang up|EAI_AGAIN|Status 5\d\d|<html)/i.test(error.message));
+        const userMessage = isOutage
+            ? 'WSO2 Cloud is temporarily unavailable. Please try again in a few minutes.'
+            : `WSO2 Integrator Copilot authentication failed: ${error instanceof Error ? error.message : 'Unknown error'}`;
+        vscode.window.showErrorMessage(userMessage);
         throw error;
     }
 };

--- a/workspaces/wso2-platform/wso2-platform-extension/src/cmds/sign-in-with-code-cmd.ts
+++ b/workspaces/wso2-platform/wso2-platform-extension/src/cmds/sign-in-with-code-cmd.ts
@@ -21,6 +21,7 @@ import { type ExtensionContext, commands, window } from "vscode";
 import * as vscode from "vscode";
 import { ResponseError } from "vscode-jsonrpc";
 import { ErrorCode } from "../choreo-rpc/constants";
+import { getFriendlySignInErrorMessage } from "../error-utils";
 import { ext } from "../extensionVariables";
 import { getLogger } from "../logger/logger";
 import { isRpcActive, setExtensionName } from "./cmd-utils";
@@ -52,9 +53,12 @@ export function signInWithAuthCodeCommand(context: ExtensionContext) {
 				}
 			} catch (error: any) {
 				if (!(error instanceof ResponseError) || ![ErrorCode.NoOrgsAvailable, ErrorCode.NoAccountAvailable].includes(error.code)) {
-					window.showErrorMessage("Sign in failed. Please check the logs for more details.");
+					const { userMessage, logMessage } = getFriendlySignInErrorMessage(error);
+					window.showErrorMessage(userMessage);
+					getLogger().error(`WSO2 Platform sign in Failed: ${logMessage}`);
+				} else {
+					getLogger().error(`WSO2 Platform sign in Failed: ${error.message}`);
 				}
-				getLogger().error(`WSO2 Platform sign in Failed: ${error.message}`);
 			}
 		}),
 	);

--- a/workspaces/wso2-platform/wso2-platform-extension/src/error-utils.ts
+++ b/workspaces/wso2-platform/wso2-platform-extension/src/error-utils.ts
@@ -23,6 +23,34 @@ import { ext } from "./extensionVariables";
 import { getLogger } from "./logger/logger";
 import { webviewStateStore } from "./stores/webview-state-store";
 
+const OUTAGE_PATTERNS = [
+	/status code: 5\d\d/i,
+	/5\d\d\s+(Bad\s+Gateway|Gateway\s+Time-?out|Service\s+Unavailable|Internal\s+Server\s+Error)/i,
+	/ECONNREFUSED|ECONNRESET|ETIMEDOUT|EAI_AGAIN|getaddrinfo|socket\s+hang\s+up|network\s+error|Remote\s+host\s+closed/i,
+	/<html/i,
+];
+
+function stripHtmlBody(message: string): string {
+	return message.replace(/<[^>]*>/g, "").replace(/\s+/g, " ").trim().slice(0, 200);
+}
+
+export function getFriendlySignInErrorMessage(error: any): { userMessage: string; logMessage: string } {
+	const raw: string = error?.message ?? String(error);
+	const isOutage = OUTAGE_PATTERNS.some((p) => p.test(raw));
+
+	if (isOutage) {
+		return {
+			userMessage: "WSO2 Cloud is temporarily unavailable. Please try again in a few minutes.",
+			logMessage: raw.includes("<html") ? stripHtmlBody(raw) : raw,
+		};
+	}
+
+	return {
+		userMessage: "Sign in failed. Please check the logs for more details.",
+		logMessage: raw,
+	};
+}
+
 export function handlerError(err: any) {
 	const extensionName = webviewStateStore.getState().state.extensionName;
 	if (err instanceof ResponseError) {

--- a/workspaces/wso2-platform/wso2-platform-extension/src/uri-handlers.ts
+++ b/workspaces/wso2-platform/wso2-platform-extension/src/uri-handlers.ts
@@ -32,6 +32,7 @@ import { ProgressLocation, type ProviderResult, type QuickPickItem, type Uri, co
 import { ResponseError } from "vscode-jsonrpc";
 import { ErrorCode } from "./choreo-rpc/constants";
 import { getUserInfoForCmd, isRpcActive } from "./cmds/cmd-utils";
+import { getFriendlySignInErrorMessage } from "./error-utils";
 import { updateContextFile } from "./cmds/create-directory-context-cmd";
 import { ext } from "./extensionVariables";
 import { getGitRemotes, getGitRoot } from "./git/util";
@@ -86,9 +87,12 @@ export function activateURIHandlers() {
 									}
 								} catch (error: any) {
 									if (!(error instanceof ResponseError) || ![ErrorCode.NoOrgsAvailable, ErrorCode.NoAccountAvailable].includes(error.code)) {
-										window.showErrorMessage("Sign in failed. Please check the logs for more details.");
+										const { userMessage, logMessage } = getFriendlySignInErrorMessage(error);
+										window.showErrorMessage(userMessage);
+										getLogger().error(`WSO2 Platform sign in Failed: ${logMessage}`);
+									} else {
+										getLogger().error(`WSO2 Platform sign in Failed: ${error.message}`);
 									}
-									getLogger().error(`WSO2 Platform sign in Failed: ${error.message}`);
 								}
 							},
 						);


### PR DESCRIPTION
Related to https://github.com/wso2/product-integrator/issues/1023

- Add `getFriendlySignInErrorMessage` helper to `error-utils.ts` that detects backend outage signals (5xx status codes, `ECONNREFUSED`/`ETIMEDOUT`/network errors, raw HTML bodies)
- Show `"WSO2 Cloud is temporarily unavailable. Please try again in a few minutes."` instead of the generic `"Sign in failed. Please check the logs for more details."` when the WSO2 Cloud auth backend is down
- Strip HTML body from log messages so the output log stays readable instead of containing the full 504 nginx page
- Apply the same outage detection in `exchangeStsToCopilotToken` in ballerina-extension, and preserve the HTTP status on the thrown error so the catch predicate can read it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling during sign-in flows with enhanced outage detection—users will now see distinct error messages for service unavailability versus authentication failures.
  * Enhanced token exchange failure handling to distinguish between temporary service outages and authentication issues, providing clearer feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->