### PR TITLE
Fix Copilot codebase structure representation

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/prompts.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/prompts.ts
@@ -149,7 +149,7 @@ ${getLanglibInstructions()}
 
 ### Local Connectors
 - If the codebase structure shows connector modules in generated/moduleName, import using: import packageName.moduleName
-- Generated connector files are listed as paths only in the codebase structure. Use the \`${FILE_READ_TOOL_NAME}\` tool with the listed path to fetch the content when needed.
+- Generated connector files appear under a \`<generated_files>\` block in the codebase structure as path-only entries (e.g. \`<file path="generated/moduleName/client.bal"/>\`) — no source content is included. Use the \`${FILE_READ_TOOL_NAME}\` tool with the listed path to fetch the content when needed.
 
 ## Code Structure
 - In WSO2 Integrator, Automation is simply an app with a main method unless user specifically mentions a service. Cron Job kind of requirements are handled in the deployment level for Kubernetes or Integration platform level.

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/prompts.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/prompts.ts
@@ -18,7 +18,7 @@ import { DIAGNOSTICS_TOOL_NAME } from "./tools/diagnostics";
 import { LIBRARY_GET_TOOL } from "./tools/library-get";
 import { LIBRARY_SEARCH_TOOL } from "./tools/library-search";
 import { TASK_WRITE_TOOL_NAME } from "./tools/task-writer";
-import { FILE_BATCH_EDIT_TOOL_NAME, FILE_SINGLE_EDIT_TOOL_NAME, FILE_WRITE_TOOL_NAME } from "./tools/text-editor";
+import { FILE_BATCH_EDIT_TOOL_NAME, FILE_READ_TOOL_NAME, FILE_SINGLE_EDIT_TOOL_NAME, FILE_WRITE_TOOL_NAME } from "./tools/text-editor";
 import { CONNECTOR_GENERATOR_TOOL } from "./tools/connector-generator";
 import { CONFIG_COLLECTOR_TOOL } from "./tools/config-collector";
 import { CLARIFY_TOOL } from "./tools/clarify";
@@ -149,6 +149,7 @@ ${getLanglibInstructions()}
 
 ### Local Connectors
 - If the codebase structure shows connector modules in generated/moduleName, import using: import packageName.moduleName
+- Generated connector files are listed as paths only in the codebase structure. Use the \`${FILE_READ_TOOL_NAME}\` tool with the listed path to fetch the content when needed.
 
 ## Code Structure
 - In WSO2 Integrator, Automation is simply an app with a main method unless user specifically mentions a service. Cron Job kind of requirements are handled in the deployment level for Kubernetes or Integration platform level.

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/utils.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/utils.ts
@@ -148,13 +148,17 @@ ${sourceFile.content}
 }
 
 /**
- * Collects files with content from a ProjectSource
+ * Collects files from a ProjectSource, split into regular files (with content) and
+ * generated connector files (paths only — content is large and fetched on demand).
  * @param project ProjectSource to collect files from
  * @param includePackagePath Whether to prepend packagePath to file paths (for multi-project case)
- * @returns Array of SourceFile objects with paths and content
  */
-function collectFilesFromProject(project: ProjectSource, includePackagePath: boolean = false): SourceFile[] {
+function collectFilesFromProject(
+    project: ProjectSource,
+    includePackagePath: boolean = false
+): { files: SourceFile[]; generatedFiles: SourceFile[] } {
     const files: SourceFile[] = [];
+    const generatedFiles: SourceFile[] = [];
     const prefix = includePackagePath && project.packagePath ? `${project.packagePath}/` : "";
 
     // Collect source files
@@ -165,14 +169,21 @@ function collectFilesFromProject(project: ProjectSource, includePackagePath: boo
         });
     }
 
-    // Collect module files
+    // Collect module files — generated modules go to generatedFiles (paths only)
     if (project.projectModules) {
         for (const module of project.projectModules) {
             for (const sourceFile of module.sourceFiles) {
-                files.push({
-                    filePath: `${prefix}${sourceFile.filePath}`,
-                    content: sourceFile.content,
-                });
+                if (module.isGenerated) {
+                    generatedFiles.push({
+                        filePath: `${prefix}generated/${module.moduleName}/${sourceFile.filePath}`,
+                        content: "",
+                    });
+                } else {
+                    files.push({
+                        filePath: `${prefix}${sourceFile.filePath}`,
+                        content: sourceFile.content,
+                    });
+                }
             }
         }
     }
@@ -187,7 +198,7 @@ function collectFilesFromProject(project: ProjectSource, includePackagePath: boo
         }
     }
 
-    return files;
+    return { files, generatedFiles };
 }
 
 /**
@@ -225,13 +236,19 @@ export function formatCodebaseStructure(projects: ProjectSource[], tempProjectPa
     }
 
     for (const project of projects) {
-        const files = collectFilesFromProject(project, isWorkspace);
+        const { files, generatedFiles } = collectFilesFromProject(project, isWorkspace);
         const activeStatus = project.isActive ? ' active="true"' : "";
 
         text += `<project name="${project.projectName}"${activeStatus}>\n`;
         text += "<files>\n";
         text += files.map(formatFileWithContent).join("\n");
         text += "\n</files>\n";
+
+        if (generatedFiles.length > 0) {
+            text += "<generated_files>\n";
+            text += generatedFiles.map(f => `<file path="${f.filePath}"/>`).join("\n");
+            text += "\n</generated_files>\n";
+        }
 
         if (tempProjectPath) {
             const pkgRoot = isWorkspace && project.packagePath

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/utils.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/utils.ts
@@ -181,7 +181,7 @@ function collectFilesFromProject(project: ProjectSource, includePackagePath: boo
     if (project.projectTests) {
         for (const testFile of project.projectTests) {
             files.push({
-                filePath: `${prefix}${testFile.filePath}`,
+                filePath: `${prefix}tests/${testFile.filePath}`,
                 content: testFile.content,
             });
         }

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/utils/project/temp-project.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/utils/project/temp-project.ts
@@ -283,16 +283,14 @@ async function getCurrentProjectSource(
     await populateModules(modulesDir, project);
     await populateModules(generatedDir, project);
 
-    // Read test files from tests/ directory
+    // Read test files from tests/ directory (recursive, paths relative to testsDir)
     const testsDir = path.join(targetProjectPath, 'tests');
     if (fs.existsSync(testsDir)) {
         project.tests = {};
-        const testFiles = fs.readdirSync(testsDir);
-        for (const file of testFiles) {
-            if (file.endsWith('.bal')) {
-                const filePath = path.join(testsDir, file);
-                project.tests[`tests/${file}`] = await fs.promises.readFile(filePath, 'utf-8');
-            }
+        const testFiles = findAllBalFiles(testsDir);
+        for (const relPath of testFiles) {
+            const filePath = path.join(testsDir, relPath);
+            project.tests[relPath] = await fs.promises.readFile(filePath, 'utf-8');
         }
     }
 

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/utils/project/temp-project.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/utils/project/temp-project.ts
@@ -41,6 +41,7 @@ interface BallerinaProject {
     projectName: string;
     modules?: BallerinaModule[];
     sources: { [key: string]: string };
+    tests?: { [key: string]: string };
 }
 
 interface BallerinaModule {
@@ -281,6 +282,20 @@ async function getCurrentProjectSource(
     const generatedDir = path.join(targetProjectPath, 'generated');
     await populateModules(modulesDir, project);
     await populateModules(generatedDir, project);
+
+    // Read test files from tests/ directory
+    const testsDir = path.join(targetProjectPath, 'tests');
+    if (fs.existsSync(testsDir)) {
+        project.tests = {};
+        const testFiles = fs.readdirSync(testsDir);
+        for (const file of testFiles) {
+            if (file.endsWith('.bal')) {
+                const filePath = path.join(testsDir, file);
+                project.tests[`tests/${file}`] = await fs.promises.readFile(filePath, 'utf-8');
+            }
+        }
+    }
+
     return project;
 }
 
@@ -335,6 +350,14 @@ function convertToProjectSource(project: BallerinaProject, pkgPath: string, isAc
                 projectModule.sourceFiles.push({ filePath: fileName, content });
             }
             projectSource.projectModules.push(projectModule);
+        }
+    }
+
+    // Iterate through test sources
+    if (project.tests) {
+        projectSource.projectTests = [];
+        for (const [filePath, content] of Object.entries(project.tests)) {
+            projectSource.projectTests.push({ filePath, content });
         }
     }
 

--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
@@ -535,6 +535,20 @@ export class AiPanelRpcManager implements AIPanelAPI {
                 }
             }
 
+            // Append revert notification to model messages so the LLM knows changes were reverted
+            const existingMessages = latestReview.modelMessages || [];
+            chatStateStorage.updateGeneration(projectRootPath, threadId, latestReview.id, {
+                modelMessages: [
+                    ...existingMessages,
+                    {
+                        role: "user",
+                        content: `<revert_notification>
+User reverted the last made changes. The files have been restored to the state before this generation.
+</revert_notification>`,
+                    },
+                ],
+            });
+
             // Mark ALL under_review generations as error/declined
             chatStateStorage.declineAllReviews(projectRootPath, threadId);
             console.log("[Review Actions] Marked all under_review generations as declined");


### PR DESCRIPTION
Fixes https://github.com/wso2/product-integrator/issues/1241

- Include test files from the `tests/` directory in the codebase structure sent to the AI agent
- Fix test file paths in LS notifications — keys had a `tests/` prefix causing double `tests/tests/` paths
- Use recursive scan to support nested test files
- List generated connector files (`generated/<module>/`) by path only — content is omitted to keep the prompt small; agent is instructed to use the `Read` tool when needed
- Append a `<revert_notification>` model message when the user reverts generated changes so the agent has context on the next turn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Projects now automatically detect and include test files from the tests directory.

* **Improvements**
  * Declining AI-generated changes now records a notification in chat history that files were reverted.
  * Generated/auto-created files are reported separately and will be fetched on demand rather than inlined.
  * Agent prompts updated to fetch generated connector contents via the file-read tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->