### PR TITLE
Show NodeList header during loading state in side panel

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/NodeList/index.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/NodeList/index.tsx
@@ -367,6 +367,7 @@ interface NodeListProps {
     searchText?: string;
     panelBodySx?: React.CSSProperties;
     alwaysCollapsedCategories?: string[];
+    loading?: boolean;
 }
 
 export function NodeList(props: NodeListProps) {
@@ -388,7 +389,8 @@ export function NodeList(props: NodeListProps) {
         onLinkDevantProject,
         onRefreshDevantConnections,
         panelBodySx,
-        alwaysCollapsedCategories
+        alwaysCollapsedCategories,
+        loading
     } = props;
 
     const [searchText, setSearchText] = useState<string>("");
@@ -950,12 +952,12 @@ export function NodeList(props: NodeListProps) {
                     </S.Row>
                 )}
             </S.HeaderContainer>
-            {isSearching && (
+            {(loading || isSearching) && (
                 <S.PanelBody>
                     <NodeListSkeleton />
                 </S.PanelBody>
             )}
-            {!showGeneratePanel && !isSearching && (
+            {!showGeneratePanel && !isSearching && !loading && (
                 <S.PanelBody style={{ ...props.panelBodySx }}>
                     {getCategoryContainer(filteredCategories)}
                     {/* Show More Functions button - moved outside Logging category */}
@@ -979,7 +981,7 @@ export function NodeList(props: NodeListProps) {
                     )}
                 </S.PanelBody>
             )}
-            {showAiPanel && showGeneratePanel && (
+            {showAiPanel && showGeneratePanel && !loading && (
                 <S.PanelBody style={{ ...props.panelBodySx }}>
                     <S.AiContainer>
                         <S.Title>Describe what you want you want to do</S.Title>

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/FlowDiagram/PanelManager.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/FlowDiagram/PanelManager.tsx
@@ -17,7 +17,7 @@
  */
 
 import { useEffect, useRef } from "react";
-import { PanelContainer, NodeList, CardList, ExpressionFormField, NodeListSkeleton } from "@wso2/ballerina-side-panel";
+import { PanelContainer, NodeList, CardList, ExpressionFormField } from "@wso2/ballerina-side-panel";
 import {
     FlowNode,
     LineRange,
@@ -687,7 +687,20 @@ export function PanelManager(props: PanelManagerProps) {
                 );
 
             case SidePanelView.LOADING:
-                return <NodeListSkeleton />;
+                return (
+                    <NodeList
+                        loading
+                        categories={categories}
+                        onSelect={onSelectNode}
+                        onSelectConnector={onSelectConnectorPopup}
+                        onSearchTextChange={onSearchTextChange}
+                        searchText={searchText}
+                        onClose={onClose}
+                        title={"All Components"}
+                        searchPlaceholder={"Search all components"}
+                        onBack={canGoBack ? onBack : undefined}
+                    />
+                );
 
             case SidePanelView.FORM:
                 return (


### PR DESCRIPTION
## Purpose
The loading state in the BI flow diagram side panel previously rendered a bare `NodeListSkeleton` with no header, leaving the user with no way to navigate back or close the panel while categories were being fetched.

## Goals
Preserve the panel header (title, search input, back/close controls) during the loading state by reusing `NodeList` with a new `loading` prop, rather than rendering a standalone skeleton.

## Approach
Added an optional `loading` prop to `NodeList` that shows `NodeListSkeleton` while suppressing the category body and AI panel. Updated `PanelManager`'s `SidePanelView.LOADING` case to render `<NodeList loading ...>` instead of `<NodeListSkeleton />`, passing the same props used by the standard node-list view. Also consolidated two redundant skeleton render branches in `NodeList` into a single `(loading || isSearching)` condition.

## UI Component Development
- [ ] Added reusable UI components to the ui-toolkit.
- [x] Use ui-toolkit components wherever possible.
- [x] Matches with the native VSCode look and feel.

## Manage Icons
- [x] N/A — no new icons added.

## User stories
As a user adding a node to the flow diagram, I can see the panel header and navigate back or close the panel while the available components are loading.

## Release note
The side panel now keeps its header visible (with title, search, and navigation controls) while node categories are loading, instead of showing only a skeleton with no controls.

## Documentation
N/A — internal UI loading-state improvement with no user-facing API change.

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
- Unit tests: N/A — rendering logic change only.
- Integration tests: N/A.

## Security checks
- Followed secure coding standards: yes
- Ran FindSecurityBugs plugin: N/A (frontend only)
- No keys, passwords, tokens, or secrets committed: yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
Tested in VS Code extension dev host on macOS.

## Learning
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new loading state to the component list interface that provides enhanced visual feedback during data loading.
  * The loading interface now displays a skeleton layout while suppressing other panels, creating a cleaner loading experience.
  * Updated component loading behavior to maintain consistent UI state management across different viewing modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->