### PR TITLE
Show NodeList header during loading state in side panel

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/NodeList/index.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/NodeList/index.tsx
@@ -360,6 +360,7 @@ interface NodeListProps {
     searchText?: string;
     panelBodySx?: React.CSSProperties;
     alwaysCollapsedCategories?: string[];
+    loading?: boolean;
 }
 
 export function NodeList(props: NodeListProps) {
@@ -381,7 +382,8 @@ export function NodeList(props: NodeListProps) {
         onLinkDevantProject,
         onRefreshDevantConnections,
         panelBodySx,
-        alwaysCollapsedCategories
+        alwaysCollapsedCategories,
+        loading
     } = props;
 
     const [searchText, setSearchText] = useState<string>("");
@@ -939,12 +941,12 @@ export function NodeList(props: NodeListProps) {
                     </S.Row>
                 )}
             </S.HeaderContainer>
-            {isSearching && (
+            {(loading || isSearching) && (
                 <S.PanelBody>
                     <NodeListSkeleton />
                 </S.PanelBody>
             )}
-            {!showGeneratePanel && !isSearching && (
+            {!showGeneratePanel && !isSearching && !loading && (
                 <S.PanelBody style={{ ...props.panelBodySx }}>
                     {getCategoryContainer(filteredCategories)}
                     {/* Show More Functions button - moved outside Logging category */}
@@ -968,7 +970,7 @@ export function NodeList(props: NodeListProps) {
                     )}
                 </S.PanelBody>
             )}
-            {showAiPanel && showGeneratePanel && (
+            {showAiPanel && showGeneratePanel && !loading && (
                 <S.PanelBody style={{ ...props.panelBodySx }}>
                     <S.AiContainer>
                         <S.Title>Describe what you want you want to do</S.Title>

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/FlowDiagram/PanelManager.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/FlowDiagram/PanelManager.tsx
@@ -17,7 +17,7 @@
  */
 
 import { useEffect, useRef } from "react";
-import { PanelContainer, NodeList, CardList, ExpressionFormField, NodeListSkeleton } from "@wso2/ballerina-side-panel";
+import { PanelContainer, NodeList, CardList, ExpressionFormField } from "@wso2/ballerina-side-panel";
 import {
     FlowNode,
     LineRange,
@@ -649,7 +649,20 @@ export function PanelManager(props: PanelManagerProps) {
                 );
 
             case SidePanelView.LOADING:
-                return <NodeListSkeleton />;
+                return (
+                    <NodeList
+                        loading
+                        categories={categories}
+                        onSelect={onSelectNode}
+                        onSelectConnector={onSelectConnectorPopup}
+                        onSearchTextChange={onSearchTextChange}
+                        searchText={searchText}
+                        onClose={onClose}
+                        title={"All Components"}
+                        searchPlaceholder={"Search all components"}
+                        onBack={canGoBack ? onBack : undefined}
+                    />
+                );
 
             case SidePanelView.FORM:
                 return (


### PR DESCRIPTION
## Purpose
The loading state in the Ballerina flow diagram side panel previously rendered a bare `NodeListSkeleton` with no header, leaving the user with no way to navigate back or close the panel while categories were being fetched.

https://github.com/user-attachments/assets/e094d558-c7d8-4ae2-9488-c046ae7a5204



## Goals
Preserve the panel header (title, search input, back/close controls) during the loading state by reusing `NodeList` with a new `loading` prop, rather than rendering a standalone skeleton.

## Approach
Added an optional `loading` prop to `NodeList` that shows `NodeListSkeleton` while suppressing the category body and AI panel. Updated `PanelManager`'s `SidePanelView.LOADING` case to render `<NodeList loading ...>` instead of `<NodeListSkeleton />`, passing the same props used by the standard node-list view. Also consolidated two redundant skeleton render branches in `NodeList` into a single `(loading || isSearching)` condition.

## UI Component Development
- [ ] Added reusable UI components to the ui-toolkit.
- [x] Use ui-toolkit components wherever possible.
- [x] Matches with the native VSCode look and feel.

## Manage Icons
- [x] N/A — no new icons added.

## User stories
As a user adding a node to the flow diagram, I can see the panel header and navigate back or close the panel while the available components are loading.

## Release note
The side panel now keeps its header visible (with title, search, and navigation controls) while node categories are loading, instead of showing only a skeleton with no controls.

## Documentation
N/A — internal UI loading-state improvement with no user-facing API change.

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
- Unit tests: N/A — rendering logic change only.
- Integration tests: N/A.

## Security checks
- Followed secure coding standards: yes
- Ran FindSecurityBugs plugin: N/A (frontend only)
- No keys, passwords, tokens, or secrets committed: yes

## Samples
N/A

## Related PRs
https://github.com/wso2/vscode-extensions/pull/2103

## Migrations (if applicable)
N/A

## Test environment
Tested in VS Code extension dev host on macOS.

## Learning
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced side panel loading state handling with improved and more consistent skeleton display when data is being fetched.
  * Unified component loading state management to provide a seamless user experience across different loading scenarios.
  * Loading state control now ensures skeleton display takes precedence over content panels during data loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->