### PR TITLE
Fix infinite rerender in ftp forms causing to break when adding eleme…

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/Form/index.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/Form/index.tsx
@@ -17,6 +17,7 @@
  */
 
 import React, { forwardRef, useCallback, useMemo, useEffect, useState, useRef } from "react";
+import isEqual from "lodash/isEqual";
 import { useForm } from "react-hook-form";
 import ReactMarkdown from "react-markdown";
 import {
@@ -907,7 +908,7 @@ export const Form = forwardRef((props: FormProps, _ref) => {
         if (props.onChange) {
             const prevValues = prevValuesRef.current;
             Object.entries(watchedValues).forEach(([key, value]) => {
-                if (prevValues[key] !== value) {
+                if (!isEqual(prevValues[key], value)) {
                     props.onChange?.(key, value, watchedValues);
                 }
             });


### PR DESCRIPTION
## Purpose
> This PR will fix an issue where in someforms adding an item to the expression editor array mode causes infinte rerender loop causing the form to break when inserting values
Resolves: https://github.com/wso2/product-integrator/issues/170

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form change detection to accurately identify meaningful value changes rather than reference changes, reducing unnecessary change notifications and re-renders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->