### PR TITLE
Show warning for toggling tracing button when running integration

### DIFF
--- a/workspaces/ballerina/ballerina-core/src/rpc-types/agent-chat/index.ts
+++ b/workspaces/ballerina/ballerina-core/src/rpc-types/agent-chat/index.ts
@@ -16,12 +16,12 @@
  * under the License.
  */
 
-import { ChatReqMessage, ChatRespMessage, TraceInput, TraceStatus, ChatHistoryResponse, AgentStatusResponse, ClearChatResponse, ExecutionStep, SessionInput, SessionInfoResponse, AgentInfo, AvailableAgentsResponse, SwitchAgentRequest, SwitchAgentResponse } from "./interfaces";
+import { ChatReqMessage, ChatRespMessage, TraceInput, TraceStatus, TraceStatusRequest, ChatHistoryResponse, AgentStatusResponse, ClearChatResponse, ExecutionStep, SessionInput, SessionInfoResponse, AgentInfo, AvailableAgentsResponse, SwitchAgentRequest, SwitchAgentResponse } from "./interfaces";
 
 export interface AgentChatAPI {
     getChatMessage: (params: ChatReqMessage) => Promise<ChatRespMessage>;
     abortChatRequest: () => void;
-    getTracingStatus: () => Promise<TraceStatus>;
+    getTracingStatus: (params?: TraceStatusRequest) => Promise<TraceStatus>;
     showTraceView: (params: TraceInput) => Promise<void>;
     showSessionOverview: (params: SessionInput) => Promise<void>;
     getChatHistory: () => Promise<ChatHistoryResponse>;
@@ -32,4 +32,4 @@ export interface AgentChatAPI {
     switchChatAgent: (params: SwitchAgentRequest) => Promise<SwitchAgentResponse>;
 }
 
-export type { ChatReqMessage, ChatRespMessage, TraceInput, TraceStatus, ChatHistoryResponse, AgentStatusResponse, ClearChatResponse, ExecutionStep, SessionInput, SessionInfoResponse, AgentInfo, AvailableAgentsResponse, SwitchAgentRequest, SwitchAgentResponse };
+export type { ChatReqMessage, ChatRespMessage, TraceInput, TraceStatus, TraceStatusRequest, ChatHistoryResponse, AgentStatusResponse, ClearChatResponse, ExecutionStep, SessionInput, SessionInfoResponse, AgentInfo, AvailableAgentsResponse, SwitchAgentRequest, SwitchAgentResponse };

--- a/workspaces/ballerina/ballerina-core/src/rpc-types/agent-chat/interfaces.ts
+++ b/workspaces/ballerina/ballerina-core/src/rpc-types/agent-chat/interfaces.ts
@@ -41,6 +41,10 @@ export interface TraceStatus {
     enabled: boolean;
 }
 
+export interface TraceStatusRequest {
+    projectPath?: string;
+}
+
 export interface TraceInput {
     message?: string;
     traceId?: string;

--- a/workspaces/ballerina/ballerina-core/src/rpc-types/agent-chat/rpc-type.ts
+++ b/workspaces/ballerina/ballerina-core/src/rpc-types/agent-chat/rpc-type.ts
@@ -17,13 +17,13 @@
  * 
  * THIS FILE INCLUDES AUTO GENERATED CODE
  */
-import { ChatReqMessage, ChatRespMessage, TraceInput, TraceStatus, ChatHistoryResponse, AgentStatusResponse, ClearChatResponse, SessionInput, SessionInfoResponse, AvailableAgentsResponse, SwitchAgentRequest, SwitchAgentResponse } from "./interfaces";
+import { ChatReqMessage, ChatRespMessage, TraceInput, TraceStatus, TraceStatusRequest, ChatHistoryResponse, AgentStatusResponse, ClearChatResponse, SessionInput, SessionInfoResponse, AvailableAgentsResponse, SwitchAgentRequest, SwitchAgentResponse } from "./interfaces";
 import { RequestType, NotificationType } from "vscode-messenger-common";
 
 const _preFix = "agent-chat";
 export const getChatMessage: RequestType<ChatReqMessage, ChatRespMessage> = { method: `${_preFix}/getChatMessage` };
 export const abortChatRequest: NotificationType<void> = { method: `${_preFix}/abortChatRequest` };
-export const getTracingStatus: RequestType<void, TraceStatus> = { method: `${_preFix}/getTracingStatus` };
+export const getTracingStatus: RequestType<TraceStatusRequest, TraceStatus> = { method: `${_preFix}/getTracingStatus` };
 export const showTraceView: NotificationType<TraceInput> = { method: `${_preFix}/showTraceView` };
 export const showSessionOverview: NotificationType<SessionInput> = { method: `${_preFix}/showSessionOverview` };
 export const getChatHistory: RequestType<void, ChatHistoryResponse> = { method: `${_preFix}/getChatHistory` };
@@ -33,3 +33,4 @@ export const getSessionInfo: RequestType<void, SessionInfoResponse> = { method: 
 export const getAvailableChatAgents: RequestType<void, AvailableAgentsResponse> = { method: `${_preFix}/getAvailableChatAgents` };
 export const switchChatAgent: RequestType<SwitchAgentRequest, SwitchAgentResponse> = { method: `${_preFix}/switchChatAgent` };
 export const activeAgentChanged: NotificationType<string> = { method: `${_preFix}/activeAgentChanged` };
+export const tracingStatusChanged: NotificationType<TraceStatus> = { method: `${_preFix}/tracingStatusChanged` };

--- a/workspaces/ballerina/ballerina-extension/src/RPCLayer.ts
+++ b/workspaces/ballerina/ballerina-extension/src/RPCLayer.ts
@@ -43,7 +43,8 @@ import { registerTestManagerRpcHandlers } from './rpc-managers/test-manager/rpc-
 import { registerIcpServiceRpcHandlers } from './rpc-managers/icp-service/rpc-handler';
 import { extension } from './BalExtensionContext';
 import { registerAgentChatRpcHandlers } from './rpc-managers/agent-chat/rpc-handler';
-import { activeAgentChanged } from '@wso2/ballerina-core';
+import { ChatPanel } from './views/agent-chat/webview';
+import { activeAgentChanged, tracingStatusChanged, TraceStatus } from '@wso2/ballerina-core';
 import { ArtifactsUpdated, ArtifactNotificationHandler } from './utils/project-artifacts-handler';
 import { registerMigrateIntegrationRpcHandlers } from './rpc-managers/migrate-integration/rpc-handler';
 import { registerPlatformExtRpcHandlers } from './rpc-managers/platform-ext/rpc-handler';
@@ -237,5 +238,11 @@ export function notifyOnIdentifierUpdated(artifacts: ProjectStructureArtifactRes
 }
 
 export function sendAgentChangedNotification(agentName: string) {
-    RPCLayer._messenger.sendNotification(activeAgentChanged, { type: 'webview', webviewType: 'ballerina.agent-chat-panel' }, agentName);
+    RPCLayer._messenger.sendNotification(activeAgentChanged, { type: 'webview', webviewType: ChatPanel.viewType }, agentName);
+}
+
+export function sendTracingStatusChangedNotification(status: TraceStatus) {
+    for (const webviewType of [ChatPanel.viewType, VisualizerWebview.viewType]) {
+        RPCLayer._messenger.sendNotification(tracingStatusChanged, { type: 'webview', webviewType }, status);
+    }
 }

--- a/workspaces/ballerina/ballerina-extension/src/features/bi/activator.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/bi/activator.ts
@@ -52,6 +52,7 @@ import { handleAIAgentServiceDeletion } from "../../utils/ai-service-utils";
 import { findWorkspaceTypeFromWorkspaceFolders } from "../../rpc-managers/common/utils";
 import { MESSAGES } from "../project";
 import { ensureICPServerRunning } from "../icp";
+import { TracerMachine } from "../tracing";
 
 const FOCUS_DEBUG_CONSOLE_COMMAND = 'workbench.debug.action.focusRepl';
 const TRACE_SERVER_OFF = "off";
@@ -295,6 +296,7 @@ async function handleCommandWithContext(
 
 /** Handles the debug command based on current workspace context. */
 async function handleDebugCommandWithContext() {
+    TracerMachine.startServer();
     const { workspacePath, view, projectPath, projectInfo } = StateMachine.context();
     const isWebviewOpen = VisualizerWebview.currentPanel !== undefined;
     const hasActiveTextEditor = !!window.activeTextEditor;

--- a/workspaces/ballerina/ballerina-extension/src/features/project/activator.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/project/activator.ts
@@ -29,10 +29,14 @@ import { activateRenameCommand } from "./cmds/rename";
 import { activateExtractCommand } from "./cmds/extract";
 import { activateConfigRunCommand } from "./cmds/configRun";
 import { activateTryItCommand } from "../tryit/activator";
+import { activateIntegrationRunnerState } from "./integration-runner-state";
 
 export * from "./cmds/cmd-runner";
 
 export function activate() {
+    // track integration run terminal/debug-session lifecycle
+    activateIntegrationRunnerState();
+
     // activate ballerina test command
     activateTestRunner();
     

--- a/workspaces/ballerina/ballerina-extension/src/features/project/cmds/cmd-runner.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/project/cmds/cmd-runner.ts
@@ -21,6 +21,7 @@ import { Terminal, window, workspace } from "vscode";
 import { isSupportedSLVersion, isWindows, createVersionNumber, quoteShellPath } from "../../../utils";
 import { extension } from "../../../BalExtensionContext";
 import { TracerMachine } from "../../../features/tracing";
+import { markTerminalRunStarted } from "../integration-runner-state";
 
 
 export const PALETTE_COMMANDS = {
@@ -178,6 +179,15 @@ export function runCommandWithConf(file: BallerinaProject | string, executor: st
         terminal.sendText(isWindows() ? `echo $Env:${BAL_CONFIG_FILES}` : `echo $${BAL_CONFIG_FILES}`);
     }
     terminal.sendText(commandText, true);
+    if (isRunCommand(cmd)) {
+        markTerminalRunStarted(terminal, filePath);
+    }
+}
+
+function isRunCommand(cmd: BALLERINA_COMMANDS): boolean {
+    return cmd === BALLERINA_COMMANDS.RUN
+        || cmd === BALLERINA_COMMANDS.RUN_WITH_WATCH
+        || cmd === BALLERINA_COMMANDS.RUN_WITH_EXPERIMENTAL;
 }
 
 export function runTerminalCommand(executor: string, file?: BallerinaProject | string, env?: { [key: string]: string }) {

--- a/workspaces/ballerina/ballerina-extension/src/features/project/integration-runner-state.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/project/integration-runner-state.ts
@@ -52,11 +52,23 @@ export function isIntegrationRunningAt(targetPath: string): boolean {
 
 export async function restartIntegration(targetPath: string): Promise<void> {
     if (runDebugSession) {
-        await debug.stopDebugging(runDebugSession);
+        const session = runDebugSession;
+        // Preserve original mode so debug restarts keep breakpoints.
+        const wasNoDebug = session.configuration.noDebug ?? true;
+        // Wait for actual terminate; stopDebugging only sends the request.
+        await new Promise<void>((resolve) => {
+            const sub = debug.onDidTerminateDebugSession((ended) => {
+                if (ended === session) {
+                    sub.dispose();
+                    resolve();
+                }
+            });
+            debug.stopDebugging(session);
+        });
         runDebugSession = undefined;
         TracerMachine.startServer();
         // Direct re-launch skips the BI run flow's Try-It suggestion.
-        await startDebugging(Uri.file(targetPath), false, false, true);
+        await startDebugging(Uri.file(targetPath), false, false, wasNoDebug);
         return;
     }
     if (runTerminal) {

--- a/workspaces/ballerina/ballerina-extension/src/features/project/integration-runner-state.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/project/integration-runner-state.ts
@@ -44,7 +44,10 @@ export function isIntegrationRunningAt(targetPath: string): boolean {
     if (!isIntegrationRunning() || !lastRunPath) {
         return false;
     }
-    return path.resolve(lastRunPath) === path.resolve(targetPath);
+    const runningPath = path.resolve(lastRunPath);
+    const selectedPath = path.resolve(targetPath);
+    const relative = path.relative(selectedPath, runningPath);
+    return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
 }
 
 export async function restartIntegration(targetPath: string): Promise<void> {

--- a/workspaces/ballerina/ballerina-extension/src/features/project/integration-runner-state.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/project/integration-runner-state.ts
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import * as path from "path";
+import { commands, debug, DebugSession, Terminal, Uri, window } from "vscode";
+import { extension } from "../../BalExtensionContext";
+import { startDebugging } from "../editor-support/activator";
+import { TracerMachine } from "../tracing";
+import { PALETTE_COMMANDS } from "./cmds/cmd-runner";
+
+const BALLERINA_DEBUG_TYPE = "ballerina";
+
+function isIntegrationRunDebugSession(session: DebugSession): boolean {
+    if (session.type !== BALLERINA_DEBUG_TYPE) {
+        return false;
+    }
+    return !(session.configuration as { debugTests?: boolean })?.debugTests;
+}
+
+let runTerminal: Terminal | undefined;
+let runDebugSession: DebugSession | undefined;
+let lastRunPath: string | undefined;
+
+export function markTerminalRunStarted(terminal: Terminal, projectPath: string): void {
+    runTerminal = terminal;
+    lastRunPath = projectPath;
+}
+
+export function isIntegrationRunning(): boolean {
+    const terminalAlive = !!runTerminal && runTerminal.exitStatus === undefined;
+    const debugAlive = !!runDebugSession;
+    return terminalAlive || debugAlive;
+}
+
+export function isIntegrationRunningAt(targetPath: string): boolean {
+    if (!isIntegrationRunning() || !lastRunPath) {
+        return false;
+    }
+    return path.resolve(lastRunPath) === path.resolve(targetPath);
+}
+
+export async function restartIntegration(targetPath: string): Promise<void> {
+    if (runDebugSession) {
+        await debug.stopDebugging(runDebugSession);
+        runDebugSession = undefined;
+        TracerMachine.startServer();
+        // Direct re-launch skips the BI run flow's Try-It suggestion.
+        await startDebugging(Uri.file(targetPath), false, false, true);
+        return;
+    }
+    if (runTerminal) {
+        runTerminal.dispose();
+        runTerminal = undefined;
+    }
+    TracerMachine.startServer();
+    // Wrap as Uri so the RUN handler avoids Uri.parse, which mishandles Windows paths.
+    await commands.executeCommand(PALETTE_COMMANDS.RUN, Uri.file(targetPath));
+}
+
+export function activateIntegrationRunnerState(): void {
+    extension.context.subscriptions.push(
+        window.onDidCloseTerminal((terminal) => {
+            if (terminal === runTerminal) {
+                runTerminal = undefined;
+            }
+        }),
+        debug.onDidStartDebugSession((session) => {
+            if (isIntegrationRunDebugSession(session)) {
+                runDebugSession = session;
+                const script = (session.configuration as { script?: string })?.script;
+                if (script) {
+                    lastRunPath = script;
+                }
+            }
+        }),
+        debug.onDidTerminateDebugSession((session) => {
+            if (session === runDebugSession) {
+                runDebugSession = undefined;
+            }
+        })
+    );
+}

--- a/workspaces/ballerina/ballerina-extension/src/features/tracing/activate.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/tracing/activate.ts
@@ -28,6 +28,8 @@ import { executeTraceServerTask } from './trace-server-task';
 import { getCurrentProjectRoot, tryGetCurrentBallerinaFile } from '../../utils/project-utils';
 import { findBallerinaPackageRoot } from '../../utils';
 import { requiresPackageSelection, selectPackageOrPrompt } from '../../utils/command-utils';
+import { sendTracingStatusChangedNotification } from '../../RPCLayer';
+import { isIntegrationRunningAt, restartIntegration } from '../project/integration-runner-state';
 
 export const TRACE_WINDOW_COMMAND = 'ballerina.showTraceWindow';
 export const ENABLE_TRACING_COMMAND = 'ballerina.enableTracing';
@@ -93,6 +95,9 @@ export function activateTracing(ballerinaExtInstance: BallerinaExtension) {
         } else if (prevEnabled && !isEnabled) {
             disposeTraceAnimation();
         }
+        if (prevEnabled !== isEnabled) {
+            sendTracingStatusChangedNotification({ enabled: isEnabled });
+        }
         prevEnabled = isEnabled;
     });
 
@@ -112,7 +117,7 @@ export function activateTracing(ballerinaExtInstance: BallerinaExtension) {
         }
 
         TracerMachine.enable(targetPath);
-        vscode.window.showInformationMessage('Tracing enabled.');
+        await notifyTracingToggle(true, targetPath);
     });
 
     const disableTracingCommand = vscode.commands.registerCommand(DISABLE_TRACING_COMMAND, async () => {
@@ -121,7 +126,7 @@ export function activateTracing(ballerinaExtInstance: BallerinaExtension) {
             return;
         }
         TracerMachine.disable(targetPath);
-        vscode.window.showInformationMessage('Tracing disabled.');
+        await notifyTracingToggle(false, targetPath);
     });
 
     const clearTracesCommand = vscode.commands.registerCommand(CLEAR_TRACES_COMMAND, () => {
@@ -273,5 +278,21 @@ function showTraceDetails(trace: Trace, focusSpanId?: string, isAgentChat?: bool
     } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         vscode.window.showErrorMessage(`Failed to show trace details: ${message}`);
+    }
+}
+
+async function notifyTracingToggle(enabled: boolean, targetPath: string): Promise<void> {
+    if (!isIntegrationRunningAt(targetPath)) {
+        vscode.window.showInformationMessage(enabled ? 'Tracing enabled.' : 'Tracing disabled.');
+        return;
+    }
+    const restartAction = "Restart Integration";
+    const selection = await vscode.window.showWarningMessage(
+        "Tracing changes only take effect on a new run. Restart the integration to apply.",
+        restartAction,
+        "Dismiss"
+    );
+    if (selection === restartAction) {
+        await restartIntegration(targetPath);
     }
 }

--- a/workspaces/ballerina/ballerina-extension/src/features/tracing/activate.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/tracing/activate.ts
@@ -95,9 +95,7 @@ export function activateTracing(ballerinaExtInstance: BallerinaExtension) {
         } else if (prevEnabled && !isEnabled) {
             disposeTraceAnimation();
         }
-        if (prevEnabled !== isEnabled) {
-            sendTracingStatusChangedNotification({ enabled: isEnabled });
-        }
+        sendTracingStatusChangedNotification({ enabled: isEnabled });
         prevEnabled = isEnabled;
     });
 

--- a/workspaces/ballerina/ballerina-extension/src/features/tracing/trace-server-task.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/tracing/trace-server-task.ts
@@ -110,7 +110,7 @@ class TraceServerPseudoterminal implements vscode.Pseudoterminal {
         if (this.serverStarted) {
             this.writeLine('');
             this.writeLine('👋 Shutting down trace server...');
-            
+
             TraceServer.stop()
                 .then(() => {
                     this.writeLine('✅ Trace server stopped');

--- a/workspaces/ballerina/ballerina-extension/src/features/tracing/tracer-machine.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/tracing/tracer-machine.ts
@@ -89,10 +89,7 @@ function isTraceEnabledInProject(context: TracerMachineContext): Promise<{ isTra
 }
 
 function enableTracingInProject(context: TracerMachineContext, event?: any): void {
-    console.log('enableTracingInProject called with project path:', event?.projectPath);
-
     if (!event?.projectPath) {
-        console.error('enableTracingInProject: No project path provided');
         return;
     }
 
@@ -106,10 +103,7 @@ function enableTracingInProject(context: TracerMachineContext, event?: any): voi
 }
 
 function disableTracingInProject(context: TracerMachineContext, event?: any): void {
-    console.log('disableTracingInProject called with project path:', event?.projectPath);
-
     if (!event?.projectPath) {
-        console.error('disableTracingInProject: No project path provided');
         return;
     }
 
@@ -130,7 +124,19 @@ function startServer(context: TracerMachineContext, event?: any): Thenable<vscod
 }
 
 function stopServer(context: TracerMachineContext, event?: any): Promise<void> {
-    return TraceServer.stop();
+    const taskExecution = context.taskExecution;
+    if (!taskExecution || !vscode.tasks.taskExecutions.includes(taskExecution)) {
+        return TraceServer.stop();
+    }
+    return new Promise<void>((resolve, reject) => {
+        const subscription = vscode.tasks.onDidEndTask((endEvent) => {
+            if (endEvent.execution === taskExecution) {
+                subscription.dispose();
+                TraceServer.stop().then(resolve, reject);
+            }
+        });
+        taskExecution.terminate();
+    });
 }
 
 
@@ -205,6 +211,10 @@ function createTracerMachine(projectPath?: string, childProjectPaths?: string[])
                         },
                     ],
                     on: {
+                        // ENABLE while already enabled: write trace_enabled.bal for the new project, stay in enabled.
+                        ENABLE: {
+                            actions: [enableTracingInProject],
+                        },
                         DISABLE: [
                             {
                                 target: 'enabled.serverStopping',
@@ -213,6 +223,9 @@ function createTracerMachine(projectPath?: string, childProjectPaths?: string[])
                                     return TraceServer.isRunning();
                                 },
                                 actions: [
+                                    // Remove the file here while event.projectPath is still available;
+                                    // serverStopping.onDone receives a different event and would lose it.
+                                    disableTracingInProject,
                                     assign({
                                         isDisabling: true,
                                     }),
@@ -346,10 +359,10 @@ function createTracerMachine(projectPath?: string, childProjectPaths?: string[])
                                 src: stopServer,
                                 onDone: [
                                     {
+                                        // File was already removed when DISABLE was received in `enabled`.
                                         target: "#tracerMachine.disabled",
                                         cond: (context) => context.isDisabling === true,
                                         actions: [
-                                            disableTracingInProject,
                                             assign({
                                                 isDisabling: false,
                                             }),
@@ -406,6 +419,10 @@ function createTracerMachine(projectPath?: string, childProjectPaths?: string[])
                                     currentProjectPath: (context, event) => (event as any).projectPath,
                                 })
                             ]
+                        },
+                        // DISABLE while already disabled: another project still has trace_enabled.bal — remove that file. Stay in disabled.
+                        DISABLE: {
+                            actions: [disableTracingInProject],
                         },
                         REFRESH: {
                             target: 'init',

--- a/workspaces/ballerina/ballerina-extension/src/features/tracing/tracer-machine.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/tracing/tracer-machine.ts
@@ -118,6 +118,26 @@ function disableTracingInProject(context: TracerMachineContext, event?: any): vo
     }
 }
 
+// True when a known project other than the one being disabled still has trace_enabled.bal.
+function hasOtherEnabledProjects(context: TracerMachineContext, event?: any): boolean {
+    const targetPath = event?.projectPath;
+    if (!targetPath) {
+        return false;
+    }
+    const candidates = new Set<string>();
+    if (context.currentProjectPath) {
+        candidates.add(context.currentProjectPath);
+    }
+    context.childProjectPaths?.forEach(p => candidates.add(p));
+    candidates.delete(targetPath);
+    for (const projectPath of candidates) {
+        if (fs.existsSync(path.join(projectPath, 'trace_enabled.bal'))) {
+            return true;
+        }
+    }
+    return false;
+}
+
 function startServer(context: TracerMachineContext, event?: any): Thenable<vscode.TaskExecution> {
     const task = createTraceServerTask();
     return vscode.tasks.executeTask(task);
@@ -216,6 +236,11 @@ function createTracerMachine(projectPath?: string, childProjectPaths?: string[])
                             actions: [enableTracingInProject],
                         },
                         DISABLE: [
+                            // Other projects still have trace_enabled.bal — remove this project's file and stay in enabled.
+                            {
+                                cond: hasOtherEnabledProjects,
+                                actions: [disableTracingInProject],
+                            },
                             {
                                 target: 'enabled.serverStopping',
                                 cond: () => {

--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/agent-chat/rpc-handler.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/agent-chat/rpc-handler.ts
@@ -41,7 +41,7 @@ export function registerAgentChatRpcHandlers(messenger: Messenger) {
     const rpcManger = new AgentChatRpcManager();
     messenger.onRequest(getChatMessage, (args: ChatReqMessage) => rpcManger.getChatMessage(args));
     messenger.onNotification(abortChatRequest, () => rpcManger.abortChatRequest());
-    messenger.onRequest(getTracingStatus, () => rpcManger.getTracingStatus());
+    messenger.onRequest(getTracingStatus, (params) => rpcManger.getTracingStatus(params));
     messenger.onNotification(showTraceView, (args: TraceInput) => rpcManger.showTraceView(args));
     messenger.onNotification(showSessionOverview, (args: SessionInput) => rpcManger.showSessionOverview(args));
     messenger.onRequest(getChatHistory, () => rpcManger.getChatHistory());

--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/agent-chat/rpc-manager.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/agent-chat/rpc-manager.ts
@@ -23,6 +23,7 @@ import {
     ExecutionStep,
     TraceInput,
     TraceStatus,
+    TraceStatusRequest,
     ChatHistoryMessage,
     ChatHistoryResponse,
     AgentStatusResponse,
@@ -34,6 +35,8 @@ import {
     SwitchAgentResponse
 } from "@wso2/ballerina-core";
 import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
 import { extension } from '../../BalExtensionContext';
 import { TracerMachine, TraceServer } from "../../features/tracing";
 import { TraceDetailsWebview } from "../../features/tracing/trace-details-webview";
@@ -215,13 +218,12 @@ export class AgentChatRpcManager implements AgentChatAPI {
         }
     }
 
-    async getTracingStatus(): Promise<TraceStatus> {
-        return new Promise(async (resolve) => {
-            const isEnabled = TracerMachine.isEnabled();
-            resolve({
-                enabled: isEnabled
-            });
-        });
+    async getTracingStatus(params?: TraceStatusRequest): Promise<TraceStatus> {
+        if (params?.projectPath) {
+            const enabled = fs.existsSync(path.join(params.projectPath, 'trace_enabled.bal'));
+            return { enabled };
+        }
+        return { enabled: TracerMachine.isEnabled() };
     }
 
 

--- a/workspaces/ballerina/ballerina-rpc-client/src/rpc-clients/agent-chat/rpc-client.ts
+++ b/workspaces/ballerina/ballerina-rpc-client/src/rpc-clients/agent-chat/rpc-client.ts
@@ -29,6 +29,7 @@ import {
     TraceInput,
     SessionInput,
     TraceStatus,
+    TraceStatusRequest,
     ChatHistoryResponse,
     AgentStatusResponse,
     ClearChatResponse,
@@ -42,7 +43,8 @@ import {
     SwitchAgentResponse,
     getAvailableChatAgents,
     switchChatAgent,
-    activeAgentChanged
+    activeAgentChanged,
+    tracingStatusChanged
 } from "@wso2/ballerina-core";
 import { HOST_EXTENSION } from "vscode-messenger-common";
 import { Messenger } from "vscode-messenger-webview";
@@ -62,8 +64,8 @@ export class AgentChatRpcClient implements AgentChatAPI {
         return this._messenger.sendNotification(abortChatRequest, HOST_EXTENSION);
     }
 
-    getTracingStatus(): Promise<TraceStatus> {
-        return this._messenger.sendRequest(getTracingStatus, HOST_EXTENSION);
+    getTracingStatus(params: TraceStatusRequest = {}): Promise<TraceStatus> {
+        return this._messenger.sendRequest(getTracingStatus, HOST_EXTENSION, params);
     }
 
     showTraceView(params: TraceInput): Promise<void> {
@@ -100,5 +102,9 @@ export class AgentChatRpcClient implements AgentChatAPI {
 
     onActiveAgentChanged(handler: (agentName: string) => void): void {
         this._messenger.onNotification(activeAgentChanged, handler);
+    }
+
+    onTracingStatusChanged(handler: (status: TraceStatus) => void): void {
+        this._messenger.onNotification(tracingStatusChanged, handler);
     }
 }

--- a/workspaces/ballerina/ballerina-visualizer/src/views/AgentChatPanel/Components/ChatInterface.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/AgentChatPanel/Components/ChatInterface.tsx
@@ -578,6 +578,13 @@ const ChatInterface: React.FC = () => {
         loadAvailableAgents();
     }, [rpcClient]);
 
+    // Listen for tracing status changes pushed from the extension (toggled from the diagram)
+    useEffect(() => {
+        rpcClient.getAgentChatRpcClient().onTracingStatusChanged((status) => {
+            setIsTracingEnabled(status.enabled);
+        });
+    }, [rpcClient]);
+
     // Listen for active agent changes from the extension host (e.g. when user clicks Chat on a different agent)
     useEffect(() => {
         rpcClient.getAgentChatRpcClient().onActiveAgentChanged(async (agentName: string) => {

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/DiagramWrapper/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/DiagramWrapper/index.tsx
@@ -608,7 +608,11 @@ export function DiagramWrapper(param: DiagramWrapperProps) {
             {loadingDiagram && !hasLoadedTitleBar ? (
                 <TitleBarSkeleton />
             ) : (
-                <TitleBar title={getTitle()} subtitleElement={getSubtitleElement} actions={getActions()} />
+                <TitleBar
+                    title={getTitle()}
+                    subtitleElement={getSubtitleElement}
+                    actions={loadingDiagram ? null : getActions()}
+                />
             )}
             {enableSequenceDiagram && !isAgent &&
                 (

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/DiagramWrapper/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/DiagramWrapper/index.tsx
@@ -123,6 +123,7 @@ export function DiagramWrapper(param: DiagramWrapperProps) {
     const [showSequenceDiagram, setShowSequenceDiagram] = useState(false);
     const [enableSequenceDiagram, setEnableSequenceDiagram] = useState(false);
     const [loadingDiagram, setLoadingDiagram] = useState(true);
+    const [hasLoadedTitleBar, setHasLoadedTitleBar] = useState(false);
     const [fileName, setFileName] = useState("");
     const [serviceType, setServiceType] = useState("");
     const [serviceName, setServiceName] = useState("");
@@ -226,9 +227,17 @@ export function DiagramWrapper(param: DiagramWrapperProps) {
         checkTracingStatus();
     }, []);
 
+    // Re-query on every change so the button reflects this project's file,
+    // not whatever project triggered the broadcast.
+    useEffect(() => {
+        rpcClient.getAgentChatRpcClient().onTracingStatusChanged(() => {
+            checkTracingStatus();
+        });
+    }, [rpcClient]);
+
     const checkTracingStatus = async () => {
         try {
-            const status = await rpcClient.getAgentChatRpcClient().getTracingStatus();
+            const status = await rpcClient.getAgentChatRpcClient().getTracingStatus({ projectPath });
             setIsTracingEnabled(status.enabled);
         } catch (error) {
             setIsTracingEnabled(false);
@@ -267,6 +276,7 @@ export function DiagramWrapper(param: DiagramWrapperProps) {
 
     const handleReadyDiagram = (fileName?: string, parentMetadata?: ParentMetadata, position?: NodePosition, parentCodedata?: CodeData) => {
         setLoadingDiagram(false);
+        setHasLoadedTitleBar(true);
         if (fileName) {
             setFileName(fileName);
         }
@@ -595,7 +605,7 @@ export function DiagramWrapper(param: DiagramWrapperProps) {
     return (
         <View>
             <TopNavigationBar projectPath={projectPath} />
-            {loadingDiagram ? (
+            {loadingDiagram && !hasLoadedTitleBar ? (
                 <TitleBarSkeleton />
             ) : (
                 <TitleBar title={getTitle()} subtitleElement={getSubtitleElement} actions={getActions()} />

--- a/workspaces/ballerina/trace-visualizer/src/components/SpanDetails.tsx
+++ b/workspaces/ballerina/trace-visualizer/src/components/SpanDetails.tsx
@@ -878,7 +878,7 @@ export function SpanDetails({ spanData, spanName, totalInputTokens, totalOutputT
                                             value={inputData.messages}
                                             title={inputData.messagesLabel}
                                             searchQuery={searchQuery}
-                                            expandLastOnly={true}
+                                            expandLastOnly={inputData.messagesLabel === 'Messages'}
                                         />
                                     </SubSection>
                                 )}
@@ -970,7 +970,7 @@ export function SpanDetails({ spanData, spanName, totalInputTokens, totalOutputT
                                             value={outputData.messages}
                                             title={outputData.messagesLabel}
                                             searchQuery={searchQuery}
-                                            expandLastOnly={true}
+                                            expandLastOnly={outputData.messagesLabel === 'Messages'}
                                         />
                                     </SubSection>
                                 )}


### PR DESCRIPTION
## Purpose

Fixes https://github.com/wso2/product-integrator/issues/1136, https://github.com/wso2/product-integrator/issues/1135

This PR includes the following changes:
- Support for showing a notification prompting user to restart integration when toggling the tracing button
- Terminate the trace server when disabling tracing (The trace store would still contain the traces, and have to be manually cleared)
- Fixes the tracing button's state in the flow diagram header not being in sync when toggling tracing using VS Code command pallette commands.
- Support for automatically starting the trace server in debug runs when tracing is enabled.

https://github.com/user-attachments/assets/078876f7-b4ea-4bc5-ba58-dc21a40113c5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time tracing status notifications added and broadcast to chat and visualizer; clients can subscribe for immediate UI updates.
  * Tracing status queries now support optional project-scoped requests.

* **Improvements**
  * Optional "Restart Integration" prompt when toggling tracing during active runs.
  * Better tracking, restart and restart-on-toggle flows for terminal/debug runs.
  * JSON viewer refines payload expansion behavior.
  * Title bar rendering decoupled from diagram loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->