### PR TITLE
Configure Ballerina daily build notifications

### DIFF
--- a/.github/actions/dailyBuildNotification/action.yml
+++ b/.github/actions/dailyBuildNotification/action.yml
@@ -10,6 +10,10 @@ inputs:
   chatAPI:
     description: 'Google chat API'
     required: true
+  prUrl:
+    description: 'Optional product-integrator pull request URL'
+    required: false
+    default: ''
 
 runs:
   using: "composite"
@@ -37,12 +41,35 @@ runs:
     - name: "Release Notification"
       shell: bash
       run: |
+          pr_widget=''
+          if [ -n "${{ inputs.prUrl }}" ]; then
+            pr_widget=$(cat << EOF
+                      ,
+                      {
+                      "keyValue": {
+                          "topLabel": "Product Integrator PR",
+                          "content": "${{ inputs.prUrl }}",
+                          "button": {
+                          "textButton": {
+                              "text": "View PR",
+                              "onClick": {
+                              "openLink": {
+                                  "url": "${{ inputs.prUrl }}"
+                              }
+                              }
+                          }
+                          }
+                      }
+                      }
+          EOF
+          )
+          fi
           body=$(cat << EOF
           {
           "cards": [
               { 
               "header": {
-                  "title": "Daily Build",
+                  "title": "Daily Build"
               },
               "sections": [
                   {
@@ -69,6 +96,7 @@ runs:
                           }
                       }
                       }
+                      ${pr_widget}
                   ]
                   }
               ]

--- a/.github/daily-build/release.properties
+++ b/.github/daily-build/release.properties
@@ -1,5 +1,9 @@
-# Per-branch config for the Ballerina daily-build workflow.
-# Read by .github/workflows/daily-build-ballerina.yml after checking out this branch.
+# Config for the Ballerina daily-build workflow.
+
+# Workflow-level config. Read from the workflow/default branch before matrix expansion.
+vscodeBranches=main,release/bi-1.8.x
+
+# Per-branch config. Read by .github/workflows/daily-build-ballerina.yml after checking out each target branch.
 
 # Artifact name prefix on ballerina-platform/ballerina-language-server daily-build.yml runs.
 lsArtifactPrefix=ballerina-language-server-1.8.0

--- a/.github/workflows/daily-build-ballerina.yml
+++ b/.github/workflows/daily-build-ballerina.yml
@@ -58,7 +58,7 @@ jobs:
               branch="${branch#"${branch%%[![:space:]]*}"}"
               branch="${branch%"${branch##*[![:space:]]}"}"
               if [ -z "$branch" ]; then
-                echo "::error::vscodeBranches contains an empty branch entry"
+                echo "::error::vscodeBranches contains an empty branch entry" >&2
                 exit 1
               fi
               printf '%s\n' "$branch"
@@ -275,10 +275,13 @@ jobs:
 
       - name: Run Ballerina package tests
         continue-on-error: true
+        env:
+          PACKAGES: ballerina-visualizer ballerina-side-panel type-diagram sequence-diagram component-diagram bi-diagram
         run: |
           set +e
           mkdir -p /tmp/snapshot
-          for pkg in ballerina-visualizer ballerina-side-panel type-diagram sequence-diagram component-diagram bi-diagram; do
+          echo "$PACKAGES" > /tmp/snapshot/.packages
+          for pkg in $PACKAGES; do
             echo "::group::Package tests — $pkg"
             (cd "workspaces/ballerina/$pkg" && pnpm test) 2>&1 | tee "/tmp/snapshot/${pkg}.log"
             rc=${PIPESTATUS[0]}
@@ -352,7 +355,7 @@ jobs:
             echo ""
             echo "| Package | Test Suites | Tests | Status |"
             echo "|---|---|---|---|"
-            for pkg in ballerina-visualizer ballerina-side-panel type-diagram sequence-diagram component-diagram bi-diagram; do
+            for pkg in $(cat /tmp/snapshot/.packages); do
               log="/tmp/snapshot/${pkg}.log"
               status=$(cat "/tmp/snapshot/${pkg}.status" 2>/dev/null || echo "fail")
               suites="—"

--- a/.github/workflows/daily-build-ballerina.yml
+++ b/.github/workflows/daily-build-ballerina.yml
@@ -267,11 +267,22 @@ jobs:
             envfile="$(dirname "$example")/.env"
             cp "$example" "$envfile"
           done
+          ballerinaEnv="workspaces/ballerina/ballerina-extension/.env"
+          for key in COPILOT_ROOT_URL COPILOT_DEV_ROOT_URL APPINSIGHTS_INSTRUMENTATION_KEY; do
+            if grep -q "^${key}=" "$ballerinaEnv"; then
+              sed -i "s|^${key}=.*|${key}=|" "$ballerinaEnv"
+            else
+              echo "${key}=" >> "$ballerinaEnv"
+            fi
+          done
 
       - name: Build Ballerina extension
         run: node common/scripts/install-run-rush.js build -t ballerina --verbose
         env:
           isPreRelease: true
+          COPILOT_ROOT_URL: ${{ secrets.COPILOT_ROOT_URL }}
+          COPILOT_DEV_ROOT_URL: ${{ secrets.COPILOT_DEV_ROOT_URL }}
+          APPINSIGHTS_INSTRUMENTATION_KEY: ${{ secrets.APPINSIGHTS_INSTRUMENTATION_KEY }}
 
       - name: Run Ballerina package tests
         continue-on-error: true

--- a/.github/workflows/daily-build-ballerina.yml
+++ b/.github/workflows/daily-build-ballerina.yml
@@ -273,24 +273,41 @@ jobs:
         env:
           isPreRelease: true
 
-      - name: Run Ballerina diagram snapshot tests
+      - name: Run Ballerina package tests
         continue-on-error: true
         run: |
           set +e
           mkdir -p /tmp/snapshot
-          for pkg in ballerina-visualizer type-diagram sequence-diagram component-diagram bi-diagram; do
-            echo "::group::Snapshot tests — $pkg"
+          for pkg in ballerina-visualizer ballerina-side-panel type-diagram sequence-diagram component-diagram bi-diagram; do
+            echo "::group::Package tests — $pkg"
             (cd "workspaces/ballerina/$pkg" && pnpm test) 2>&1 | tee "/tmp/snapshot/${pkg}.log"
             rc=${PIPESTATUS[0]}
             if [ "$rc" -eq 0 ]; then
               echo pass > "/tmp/snapshot/${pkg}.status"
             else
               echo fail > "/tmp/snapshot/${pkg}.status"
-              echo "::warning::Snapshot tests failed for $pkg (non-blocking for daily build)"
+              echo "::warning::Package tests failed for $pkg (non-blocking for daily build)"
             fi
             echo "::endgroup::"
           done
           exit 0
+
+      - name: Prepare Trivy output directory
+        run: mkdir -p /tmp/trivy
+
+      - name: Run Trivy vulnerability scanner
+        id: trivy
+        continue-on-error: true
+        uses: aquasecurity/trivy-action@0.35.0
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          format: 'table'
+          output: '/tmp/trivy/trivy-results.txt'
+          exit-code: '1'
+          timeout: '10m'
+          skip-dirs: 'common/temp'
+          ignore-unfixed: true
 
       - name: Get VSIX file name
         id: vsix
@@ -331,11 +348,11 @@ jobs:
             echo "| LS JAR | \`${lsArtifact}\` |"
             echo "| LS source run | [${lsRunId}](${lsRunUrl}) |"
             echo ""
-            echo "#### Snapshot tests"
+            echo "#### Package tests"
             echo ""
             echo "| Package | Test Suites | Tests | Status |"
             echo "|---|---|---|---|"
-            for pkg in ballerina-visualizer type-diagram sequence-diagram component-diagram bi-diagram; do
+            for pkg in ballerina-visualizer ballerina-side-panel type-diagram sequence-diagram component-diagram bi-diagram; do
               log="/tmp/snapshot/${pkg}.log"
               status=$(cat "/tmp/snapshot/${pkg}.status" 2>/dev/null || echo "fail")
               suites="—"
@@ -353,6 +370,26 @@ jobs:
               fi
               echo "| ${pkg} | ${suites} | ${tests} | ${status_txt} |"
             done
+            echo ""
+            echo "#### Trivy scan"
+            echo ""
+            if [ '${{ steps.trivy.outcome }}' = "success" ]; then
+              echo "Status: passed"
+            else
+              echo "Status: failed (non-blocking)"
+            fi
+            echo ""
+            if [ -s /tmp/trivy/trivy-results.txt ]; then
+              echo "<details><summary>Trivy output excerpt</summary>"
+              echo ""
+              echo '```'
+              sed -n '1,120p' /tmp/trivy/trivy-results.txt
+              echo '```'
+              echo ""
+              echo "</details>"
+            else
+              echo "No Trivy output file was produced."
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload VSIX artifact

--- a/.github/workflows/daily-build-ballerina.yml
+++ b/.github/workflows/daily-build-ballerina.yml
@@ -2,11 +2,11 @@ name: Ballerina Daily Build
 
 on:
   schedule:
-    # 05:30 UTC = 11:00 Colombo (nominal). Actual firing drifts 0–30 min
+    # 05:00 UTC = 10:30 Colombo (nominal). Actual firing drifts 0–30 min
     # later; build completes well under an hour, so the run finishes
     # comfortably before noon Colombo. Exact timing is not achievable
     # with scheduled triggers — platform limitation.
-    - cron: '30 5 * * *'
+    - cron: '0 5 * * *'
   workflow_dispatch:
     inputs:
       sendNotification:
@@ -15,16 +15,68 @@ on:
         default: true
 
 jobs:
+  PrepareBranches:
+    name: Prepare branch matrix
+    runs-on: ubuntu-latest
+    outputs:
+      vscodeBranches: ${{ steps.branches.outputs.vscodeBranches }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Load branch matrix config
+        id: branches
+        run: |
+          set -euo pipefail
+          CONFIG=.github/daily-build/release.properties
+          if [ ! -f "$CONFIG" ]; then
+            echo "::error::Missing $CONFIG"
+            exit 1
+          fi
+
+          branches=$(awk -F= '
+            /^[[:space:]]*#/ || /^[[:space:]]*$/ { next }
+            {
+              key=$1
+              gsub(/^[[:space:]]+|[[:space:]]+$/, "", key)
+              if (key == "vscodeBranches") {
+                value=substr($0, index($0, "=") + 1)
+                gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+                print value
+                exit
+              }
+            }
+          ' "$CONFIG")
+
+          if [ -z "$branches" ]; then
+            echo "::error::Required key 'vscodeBranches' missing or blank in $CONFIG"
+            exit 1
+          fi
+
+          json=$(
+            IFS=',' read -ra branchArray <<< "$branches"
+            for branch in "${branchArray[@]}"; do
+              branch="${branch#"${branch%%[![:space:]]*}"}"
+              branch="${branch%"${branch##*[![:space:]]}"}"
+              if [ -z "$branch" ]; then
+                echo "::error::vscodeBranches contains an empty branch entry"
+                exit 1
+              fi
+              printf '%s\n' "$branch"
+            done | jq -R -s -c 'split("\n")[:-1]'
+          )
+
+          echo "vscodeBranches=$json" >> "$GITHUB_OUTPUT"
+          echo "Using Ballerina daily-build branches: $json"
+
   Build:
     name: Build Ballerina Extension (${{ matrix.vscodeBranch }})
+    needs: PrepareBranches
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
-        vscodeBranch:
-          - main
-          - release/bi-1.8.x
+        vscodeBranch: ${{ fromJson(needs.PrepareBranches.outputs.vscodeBranches) }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -338,7 +390,7 @@ jobs:
 
   Release:
     name: Release (${{ matrix.vscodeBranch }})
-    needs: Build
+    needs: [PrepareBranches, Build]
     # !cancelled() lets this job run even when a different matrix leg of Build failed —
     # per-leg isolation. The `gate` step below skips this specific leg if its own
     # Build didn't produce the metadata artifact.
@@ -347,9 +399,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        vscodeBranch:
-          - main
-          - release/bi-1.8.x
+        vscodeBranch: ${{ fromJson(needs.PrepareBranches.outputs.vscodeBranches) }}
     steps:
       - name: Slugify branch name
         id: slug
@@ -492,7 +542,7 @@ jobs:
 
   UpdateProductIntegrator:
     name: Update product-integrator (${{ matrix.vscodeBranch }})
-    needs: [Build, Release]
+    needs: [PrepareBranches, Build, Release]
     # Per-leg gating: !cancelled() allows this leg to run even when another matrix
     # leg of Build/Release failed. The `gate` step skips this specific leg if its
     # own Release didn't complete successfully (marker artifact absent).
@@ -501,9 +551,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        vscodeBranch:
-          - main
-          - release/bi-1.8.x
+        vscodeBranch: ${{ fromJson(needs.PrepareBranches.outputs.vscodeBranches) }}
     steps:
       - name: Slugify branch name
         id: slug
@@ -567,6 +615,7 @@ jobs:
           path: product-integrator
 
       - name: Update ballerina.extension.version and open PR
+        id: productIntegratorPr
         if: steps.gate.outputs.skip != 'true'
         working-directory: product-integrator
         env:
@@ -612,6 +661,7 @@ jobs:
           pr_url=$(echo "$pr_response" | jq -r '.html_url // empty')
           if [ -n "$pr_url" ] && [ "$pr_url" != "null" ]; then
             echo "Created PR: $pr_url"
+            echo "prUrl=$pr_url" >> "$GITHUB_OUTPUT"
           else
             echo "::error::Failed to create PR"
             echo "$pr_response"
@@ -625,7 +675,10 @@ jobs:
         if: steps.gate.outputs.skip != 'true'
         run: |
           mkdir -p pi-ok
-          echo "updated=required" > pi-ok/pi.env
+          {
+            echo "updated=required"
+            echo "prUrl=${{ steps.productIntegratorPr.outputs.prUrl }}"
+          } > pi-ok/pi.env
 
       - name: Upload product-integrator success marker
         if: steps.gate.outputs.skip != 'true'
@@ -637,7 +690,7 @@ jobs:
 
   NotifySuccess:
     name: Notify Success (${{ matrix.vscodeBranch }})
-    needs: [Build, Release, UpdateProductIntegrator]
+    needs: [PrepareBranches, Build, Release, UpdateProductIntegrator]
     # Per-leg gating: !cancelled() allows this leg to run even when another matrix
     # leg failed. The `gate` step skips this specific leg if its own Build didn't
     # produce the metadata artifact. Manual dispatch can opt out via
@@ -647,9 +700,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        vscodeBranch:
-          - main
-          - release/bi-1.8.x
+        vscodeBranch: ${{ fromJson(needs.PrepareBranches.outputs.vscodeBranches) }}
     steps:
       - name: Slugify branch name
         id: slug
@@ -699,6 +750,29 @@ jobs:
         with:
           name: ballerina-daily-vsix-${{ steps.slug.outputs.slug }}
 
+      - name: Download product-integrator metadata
+        if: steps.gate.outputs.skip != 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: ballerina-daily-product-integrator-ok-${{ steps.slug.outputs.slug }}
+          path: pi-ok
+
+      - name: Load product-integrator metadata
+        if: steps.gate.outputs.skip != 'true'
+        id: pi
+        run: |
+          set -euo pipefail
+          prUrl=""
+          if [ -f pi-ok/pi.env ]; then
+            while IFS='=' read -r key value; do
+              [[ -z "${key// /}" || "$key" =~ ^[[:space:]]*# ]] && continue
+              if [ "$key" = "prUrl" ]; then
+                prUrl="$value"
+              fi
+            done < pi-ok/pi.env
+          fi
+          echo "prUrl=$prUrl" >> "$GITHUB_OUTPUT"
+
       - name: Notification - Ballerina
         if: steps.gate.outputs.skip != 'true'
         uses: ./.github/actions/dailyBuildNotification
@@ -706,10 +780,11 @@ jobs:
           title: "Ballerina (${{ matrix.vscodeBranch }})"
           fileName: ballerina
           chatAPI: ${{ secrets.BI_TEAM_CHAT_API }}
+          prUrl: ${{ steps.pi.outputs.prUrl }}
 
   NotifyFailure:
     name: Notify Failure
-    needs: [Build, Release, UpdateProductIntegrator]
+    needs: [PrepareBranches, Build, Release, UpdateProductIntegrator]
     if: ${{ always() && contains(needs.*.result, 'failure') && github.repository == 'wso2/vscode-extensions' && (github.event_name != 'workflow_dispatch' || inputs.sendNotification) }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Move the Ballerina daily-build schedule to 10:30 AM Colombo.
- Read Ballerina daily-build source branches from .github/daily-build/release.properties instead of hardcoded matrices.
- Add an optional product-integrator PR link to the success Google Chat notification.
- Add Trivy scan

## Test Plan
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "OK #{f}" }' .github/workflows/daily-build-ballerina.yml .github/actions/dailyBuildNotification/action.yml
- git diff --check -- .github/daily-build/release.properties .github/workflows/daily-build-ballerina.yml .github/actions/dailyBuildNotification/action.yml
- Dry-run branch parser: confirmed ["main","release/bi-1.8.x"]
- Render notification payload with PR URL: confirmed 2 widgets and View PR button

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release notifications can include a direct pull-request link.
  * Automated security vulnerability scanning (Trivy) added to the build pipeline.

* **Improvements**
  * Daily build schedule moved 30 minutes earlier.
  * Test coverage expanded to broader package testing (including side-panel).
  * Builds now dynamically target configured branches via a prepared branch matrix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->