### PR TITLE
Clean up modifiedFiles accumulation across review continuations

### DIFF
--- a/workspaces/ballerina/ballerina-core/src/rpc-types/ai-panel/index.ts
+++ b/workspaces/ballerina/ballerina-core/src/rpc-types/ai-panel/index.ts
@@ -94,7 +94,6 @@ export interface AIPanelAPI {
     openAIPanel: (params: AIPanelPrompt) => Promise<void>;
     // AI schema related functions
     getSemanticDiff: (params: SemanticDiffRequest) => Promise<SemanticDiffResponse>;
-    getAffectedPackages: () => Promise<string[]>;
     isWorkspaceProject: () => Promise<boolean>;
     acceptChanges: () => Promise<void>;
     declineChanges: () => Promise<void>;

--- a/workspaces/ballerina/ballerina-core/src/rpc-types/ai-panel/rpc-type.ts
+++ b/workspaces/ballerina/ballerina-core/src/rpc-types/ai-panel/rpc-type.ts
@@ -89,7 +89,6 @@ export const addFilesToProject: RequestType<AddFilesToProjectRequest, boolean> =
 export const isUserAuthenticated: RequestType<void, boolean> = { method: `${_preFix}/isUserAuthenticated` };
 export const openAIPanel: RequestType<AIPanelPrompt, void> = { method: `${_preFix}/openAIPanel` };
 export const getSemanticDiff: RequestType<SemanticDiffRequest, SemanticDiffResponse> = { method: `${_preFix}/getSemanticDiff` };
-export const getAffectedPackages: NotificationType<void> = { method: `${_preFix}/getAffectedPackages` };
 export const isWorkspaceProject: RequestType<void, boolean> = { method: `${_preFix}/isWorkspaceProject` };
 export const acceptChanges: RequestType<void, void> = { method: `${_preFix}/acceptChanges` };
 export const declineChanges: RequestType<void, void> = { method: `${_preFix}/declineChanges` };

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
@@ -870,6 +870,9 @@ Generation stopped by user. The last in-progress task was not saved. Files have 
         // Skip review mode if no files were modified
         if (generationModifiedFiles.length === 0) {
             console.log("[AgentExecutor] No modified files - skipping review mode");
+            chatStateStorage.updateReviewState(projectRootPath, threadId, context.messageId, {
+                status: 'accepted',
+            });
             return;
         }
 

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
@@ -824,13 +824,12 @@ Generation stopped by user. The last in-progress task was not saved. Files have 
             !!workspaceRoot &&
             path.resolve(tempProjectPath) === path.resolve(workspaceRoot);
         if (!isInPlaceEditing) {
-            const workspaceId = workspaceRoot;
-            const pendingReview = chatStateStorage.getPendingReviewGeneration(workspaceId, 'default');
-            if (pendingReview && pendingReview.reviewState.modifiedFiles.length > 0) {
+            const generationFiles = new Set([...context.allModifiedFiles, ...context.modifiedFiles]);
+            if (generationFiles.size > 0) {
                 const integrationCtx = { ...context.ctx };
                 // In workspace mode, resolve project path from modified files if not set
-                if (!integrationCtx.projectPath && integrationCtx.workspacePath && pendingReview.reviewState.modifiedFiles.length > 0) {
-                    const firstBalFile = pendingReview.reviewState.modifiedFiles.find(f => f.endsWith('.bal'));
+                if (!integrationCtx.projectPath && integrationCtx.workspacePath) {
+                    const firstBalFile = Array.from(generationFiles).find(f => f.endsWith('.bal'));
                     if (firstBalFile) {
                         const packageName = firstBalFile.split('/')[0];
                         if (packageName) {
@@ -839,11 +838,7 @@ Generation stopped by user. The last in-progress task was not saved. Files have 
                         }
                     }
                 }
-                await integrateCodeToWorkspace(
-                    pendingReview.reviewState.tempProjectPath!,
-                    new Set(pendingReview.reviewState.modifiedFiles),
-                    integrationCtx
-                );
+                await integrateCodeToWorkspace(tempProjectPath, generationFiles, integrationCtx);
             }
         }
 
@@ -853,7 +848,6 @@ Generation stopped by user. The last in-progress task was not saved. Files have 
 
     /**
      * Updates chat state storage with generation results.
-     * Includes accumulated modified files tracking across review continuations.
      */
     private async updateChatState(
         context: StreamContext,
@@ -863,16 +857,7 @@ Generation stopped by user. The last in-progress task was not saved. Files have 
         const projectRootPath = context.ctx.workspacePath || context.ctx.projectPath || '';
         const threadId = 'default';
 
-        // Check if we're updating an existing review context
-        const existingReview = chatStateStorage.getPendingReviewGeneration(projectRootPath, threadId);
         const generationModifiedFiles = Array.from(new Set([...context.allModifiedFiles, ...context.modifiedFiles]));
-        let accumulatedModifiedFiles = generationModifiedFiles;
-
-        if (existingReview && existingReview.reviewState.tempProjectPath === tempProjectPath) {
-            const existingFiles = new Set(existingReview.reviewState.modifiedFiles || []);
-            accumulatedModifiedFiles = Array.from(new Set([...existingFiles, ...generationModifiedFiles]));
-            console.log(`[AgentExecutor] Accumulated modified files: ${accumulatedModifiedFiles.length} total (${existingReview.reviewState.modifiedFiles?.length || 0} existing + ${generationModifiedFiles.length} new)`);
-        }
 
         // Update chat state storage with user message + assistant messages
         chatStateStorage.updateGeneration(projectRootPath, threadId, context.messageId, {
@@ -883,7 +868,7 @@ Generation stopped by user. The last in-progress task was not saved. Files have 
         });
 
         // Skip review mode if no files were modified
-        if (accumulatedModifiedFiles.length === 0) {
+        if (generationModifiedFiles.length === 0) {
             console.log("[AgentExecutor] No modified files - skipping review mode");
             return;
         }
@@ -891,17 +876,17 @@ Generation stopped by user. The last in-progress task was not saved. Files have 
         // Determine which packages have been affected by the changes
         // This returns temp package paths for use with Language Server APIs
         const affectedPackagePaths = await determineAffectedPackages(
-            accumulatedModifiedFiles,
+            generationModifiedFiles,
             context.projects,
             context.ctx,
             tempProjectPath
         );
 
-        // Update review state and open review mode
+        // Update review state — modifiedFiles is per-generation only
         chatStateStorage.updateReviewState(projectRootPath, threadId, context.messageId, {
             status: 'under_review',
             tempProjectPath,
-            modifiedFiles: accumulatedModifiedFiles,
+            modifiedFiles: generationModifiedFiles,
             affectedPackagePaths: affectedPackagePaths,
         });
 
@@ -912,14 +897,20 @@ Generation stopped by user. The last in-progress task was not saved. Files have 
      * Emits review actions and chat save events to UI.
      */
     private async emitReviewActions(context: StreamContext): Promise<void> {
-        // Use accumulated modifiedFiles from chatStateStorage (merged across review continuations)
         const workspaceId = context.ctx.workspacePath || context.ctx.projectPath;
         const threadId = 'default';
-        const pendingReview = chatStateStorage.getPendingReviewGeneration(workspaceId, threadId);
-        const generationModifiedFiles = Array.from(new Set([...context.allModifiedFiles, ...context.modifiedFiles]));
-        const accumulatedModifiedFiles = pendingReview
-            ? Array.from(new Set([...pendingReview.reviewState.modifiedFiles, ...generationModifiedFiles]))
-            : generationModifiedFiles;
+
+        // Union modifiedFiles and affectedPackagePaths across all under-review generations at read
+        // time — each generation stores only its own files, the cumulative view is derived here.
+        const underReviewGenerations = chatStateStorage
+            .getOrCreateThread(workspaceId, threadId)
+            .generations.filter(g => g.reviewState.status === 'under_review');
+        const accumulatedModifiedFiles = Array.from(
+            new Set(underReviewGenerations.flatMap(g => g.reviewState.modifiedFiles))
+        );
+        const cachedAffectedPackages = Array.from(
+            new Set(underReviewGenerations.flatMap(g => g.reviewState.affectedPackagePaths ?? []))
+        );
 
         if (accumulatedModifiedFiles.length > 0) {
             const semanticDiffs: SemanticDiff[] = [];
@@ -928,8 +919,8 @@ Generation stopped by user. The last in-progress task was not saved. Files have 
             const diffPackageMap: string[] = [];
             const langClient = StateMachine.context().langClient;
             const tempDir = context.ctx.tempProjectPath!;
-            affectedPackages = pendingReview?.reviewState.affectedPackagePaths?.length
-                ? pendingReview.reviewState.affectedPackagePaths
+            affectedPackages = cachedAffectedPackages.length > 0
+                ? cachedAffectedPackages
                 : await determineAffectedPackages(accumulatedModifiedFiles, context.projects, context.ctx, tempDir);
             const isWorkspace = StateMachine.context().projectInfo?.projectKind === PROJECT_KIND.WORKSPACE_PROJECT;
             for (const pkg of affectedPackages) {
@@ -963,9 +954,6 @@ Generation stopped by user. The last in-progress task was not saved. Files have 
                 isWorkspace,
             };
 
-            const hasSemanticResults = loadDesignDiagrams || semanticDiffs.length > 0;
-            const isBI = StateMachine.context().isBI;
-            const autoOpen = !!(isBI && hasSemanticResults);
             approvalViewManager.openReviewMode(reviewData, false);
 
             context.eventHandler({

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
@@ -909,7 +909,7 @@ Generation stopped by user. The last in-progress task was not saved. Files have 
             .getOrCreateThread(workspaceId, threadId)
             .generations.filter(g => g.reviewState.status === 'under_review');
         const accumulatedModifiedFiles = Array.from(
-            new Set(underReviewGenerations.flatMap(g => g.reviewState.modifiedFiles))
+            new Set(underReviewGenerations.flatMap(g => g.reviewState.modifiedFiles ?? []))
         );
         const cachedAffectedPackages = Array.from(
             new Set(underReviewGenerations.flatMap(g => g.reviewState.affectedPackagePaths ?? []))

--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/ai-panel/rpc-handler.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/ai-panel/rpc-handler.ts
@@ -49,7 +49,6 @@ import {
     generateOpenAPI,
     GenerateOpenAPIRequest,
     getActiveTempDir,
-    getAffectedPackages,
     getAIMachineSnapshot,
     getChatMessages,
     getCheckpoints,
@@ -144,7 +143,6 @@ export function registerAiPanelRpcHandlers(messenger: Messenger) {
     messenger.onRequest(isUserAuthenticated, () => rpcManger.isUserAuthenticated());
     messenger.onRequest(openAIPanel, (args: AIPanelPrompt) => rpcManger.openAIPanel(args));
     messenger.onRequest(getSemanticDiff, (args: SemanticDiffRequest) => rpcManger.getSemanticDiff(args));
-    messenger.onRequest(getAffectedPackages, () => rpcManger.getAffectedPackages());
     messenger.onRequest(isWorkspaceProject, () => rpcManger.isWorkspaceProject());
     messenger.onRequest(acceptChanges, () => rpcManger.acceptChanges());
     messenger.onRequest(declineChanges, () => rpcManger.declineChanges());

--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
@@ -421,29 +421,6 @@ export class AiPanelRpcManager implements AIPanelAPI {
         }
     }
 
-    async getAffectedPackages(): Promise<string[]> {
-        // Get project root path and thread ID
-        const projectRootPath = resolveProjectRootPath();
-        const threadId = 'default';
-
-        // Get the LATEST under_review generation (not the first one)
-        const thread = chatStateStorage.getOrCreateThread(projectRootPath, threadId);
-        const underReviewGenerations = thread.generations.filter(
-            g => g.reviewState.status === 'under_review'
-        );
-
-        if (underReviewGenerations.length === 0) {
-            console.log(">>> No pending review generation, returning empty affected packages");
-            return [];
-        }
-
-        // Return packages from the LATEST under_review generation
-        const latestReview = underReviewGenerations[underReviewGenerations.length - 1];
-        const affectedPackages = latestReview.reviewState.affectedPackagePaths || [];
-        console.log(`>>> Returning ${affectedPackages.length} affected packages from generation ${latestReview.id}:`, affectedPackages);
-        return affectedPackages;
-    }
-
     async isWorkspaceProject(): Promise<boolean> {
         const context = StateMachine.context();
         const isWorkspace = context.projectInfo?.projectKind === 'WORKSPACE_PROJECT';

--- a/workspaces/ballerina/ballerina-rpc-client/src/rpc-clients/ai-panel/rpc-client.ts
+++ b/workspaces/ballerina/ballerina-rpc-client/src/rpc-clients/ai-panel/rpc-client.ts
@@ -79,7 +79,6 @@ import {
     generateOpenAPI,
     getAIMachineSnapshot,
     getActiveTempDir,
-    getAffectedPackages,
     getChatMessages,
     getCheckpoints,
     getDefaultPrompt,
@@ -236,10 +235,6 @@ export class AiPanelRpcClient implements AIPanelAPI {
 
     getSemanticDiff(params: SemanticDiffRequest): Promise<SemanticDiffResponse> {
         return this._messenger.sendRequest(getSemanticDiff, HOST_EXTENSION, params);
-    }
-
-    getAffectedPackages(): Promise<string[]> {
-        return this._messenger.sendRequest(getAffectedPackages, HOST_EXTENSION);
     }
 
     isWorkspaceProject(): Promise<boolean> {


### PR DESCRIPTION
Fixes https://github.com/wso2/product-integrator/issues/1257

- Each generation now tracks only the files it modified, not an accumulated union across all under-review generations
- End-of-gen workspace integration uses the current generation's in-memory file set directly
- Review UI still shows the cumulative file list across all under-review generations, computed at emit time
- Remove unused `getAffectedPackages` RPC left behind since review data was switched to a push model

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Review workflow now tracks modified files per-generation and aggregates review actions on demand, improving review-state consistency.
  * The AI Panel’s affected-packages lookup has been removed and is no longer exposed or returned.
  * RPC and client access for fetching affected packages have been removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->