### PR TITLE
Expose multi-provider AI sign-in for migration wizard

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/extension.ts
+++ b/workspaces/ballerina/ballerina-extension/src/extension.ts
@@ -52,7 +52,7 @@ import { activate as activateNPFeatures } from './features/natural-programming/a
 import { activateAgentChatPanel } from './views/agent-chat/activate';
 import { activateTracing } from './features/tracing';
 import { activateICP } from './features/icp';
-import { onWizardChatNotify, setWizardProjectRoot, runWizardMigrationEnhancement, abortMigrationAgent, openMigratedProject, isAIAuthenticated, signInForAI } from './features/ai/migration/orchestrator';
+import { onWizardChatNotify, setWizardProjectRoot, runWizardMigrationEnhancement, abortMigrationAgent, openMigratedProject, isAIAuthenticated, signInForAI, signInWithAnthropicKey, signInWithAwsBedrock, signInWithVertexAI } from './features/ai/migration/orchestrator';
 
 let langClient: ExtendedLangClient;
 export let isPluginStartup = true;
@@ -147,6 +147,9 @@ export async function activate(context: ExtensionContext) {
             onChatNotify: onWizardChatNotify,
             isAIAuthenticated,
             signInForAI,
+            signInWithAnthropicKey,
+            signInWithAwsBedrock,
+            signInWithVertexAI,
         },
         onDownloadProgress: extension.ballerinaExtInstance.onDownloadProgress,
     };

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/migration/orchestrator.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/migration/orchestrator.ts
@@ -1046,15 +1046,48 @@ export async function signInForAI(): Promise<{ success: boolean; error?: string 
 }
 
 /**
+ * Waits until the AI state machine leaves the `Initialize` state, settling on
+ * `Authenticated`, `Unauthenticated`, or `Disabled`. Returns `"timeout"` if the
+ * machine has not settled within `timeoutMs` milliseconds.
+ */
+async function waitForAuthStateToSettle(
+    timeoutMs: number
+): Promise<"Authenticated" | "Unauthenticated" | "Disabled" | "timeout"> {
+    return new Promise((resolve) => {
+        let sub: { unsubscribe: () => void } | undefined;
+        const timer = setTimeout(() => {
+            sub?.unsubscribe();
+            resolve("timeout");
+        }, timeoutMs);
+
+        sub = AIStateMachine.service().subscribe((snapshot) => {
+            const s = snapshot.value as string;
+            if (s === "Authenticated" || s === "Unauthenticated" || s === "Disabled") {
+                clearTimeout(timer);
+                sub?.unsubscribe();
+                resolve(s as "Authenticated" | "Unauthenticated" | "Disabled");
+            }
+        });
+    });
+}
+
+/**
  * Authenticates with Anthropic using an API key and waits until the state machine
  * reaches Authenticated (or fails), with a 2-minute timeout.
  */
 export async function signInWithAnthropicKey(apiKey: string): Promise<{ success: boolean; error?: string }> {
     const AUTH_TIMEOUT_MS = 120_000;
 
-    const state = AIStateMachine.state();
+    let state = AIStateMachine.state();
     if (state === "Authenticated") { return { success: true }; }
     if (state === "Disabled") { return { success: false, error: "AI features are disabled." }; }
+    if (state === "Initialize") {
+        const settled = await waitForAuthStateToSettle(AUTH_TIMEOUT_MS);
+        if (settled === "Authenticated") { return { success: true }; }
+        if (settled === "Disabled") { return { success: false, error: "AI features are disabled." }; }
+        if (settled === "timeout") { return { success: false, error: "Sign-in timed out. Please try again." }; }
+        state = settled;
+    }
 
     AIStateMachine.sendEvent(AIMachineEventType.AUTH_WITH_API_KEY);
     AIStateMachine.sendEvent({ type: AIMachineEventType.SUBMIT_API_KEY, payload: { apiKey } } as any);
@@ -1092,9 +1125,16 @@ export async function signInWithAwsBedrock(creds: {
 }): Promise<{ success: boolean; error?: string }> {
     const AUTH_TIMEOUT_MS = 120_000;
 
-    const state = AIStateMachine.state();
+    let state = AIStateMachine.state();
     if (state === "Authenticated") { return { success: true }; }
     if (state === "Disabled") { return { success: false, error: "AI features are disabled." }; }
+    if (state === "Initialize") {
+        const settled = await waitForAuthStateToSettle(AUTH_TIMEOUT_MS);
+        if (settled === "Authenticated") { return { success: true }; }
+        if (settled === "Disabled") { return { success: false, error: "AI features are disabled." }; }
+        if (settled === "timeout") { return { success: false, error: "Sign-in timed out. Please try again." }; }
+        state = settled;
+    }
 
     AIStateMachine.sendEvent(AIMachineEventType.AUTH_WITH_AWS_BEDROCK);
     AIStateMachine.sendEvent({ type: AIMachineEventType.SUBMIT_AWS_CREDENTIALS, payload: creds } as any);
@@ -1132,9 +1172,16 @@ export async function signInWithVertexAI(creds: {
 }): Promise<{ success: boolean; error?: string }> {
     const AUTH_TIMEOUT_MS = 120_000;
 
-    const state = AIStateMachine.state();
+    let state = AIStateMachine.state();
     if (state === "Authenticated") { return { success: true }; }
     if (state === "Disabled") { return { success: false, error: "AI features are disabled." }; }
+    if (state === "Initialize") {
+        const settled = await waitForAuthStateToSettle(AUTH_TIMEOUT_MS);
+        if (settled === "Authenticated") { return { success: true }; }
+        if (settled === "Disabled") { return { success: false, error: "AI features are disabled." }; }
+        if (settled === "timeout") { return { success: false, error: "Sign-in timed out. Please try again." }; }
+        state = settled;
+    }
 
     AIStateMachine.sendEvent(AIMachineEventType.AUTH_WITH_VERTEX_AI);
     AIStateMachine.sendEvent({ type: AIMachineEventType.SUBMIT_VERTEX_AI_CREDENTIALS, payload: creds } as any);

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/migration/orchestrator.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/migration/orchestrator.ts
@@ -1045,6 +1045,122 @@ export async function signInForAI(): Promise<{ success: boolean; error?: string 
     });
 }
 
+/**
+ * Authenticates with Anthropic using an API key and waits until the state machine
+ * reaches Authenticated (or fails), with a 2-minute timeout.
+ */
+export async function signInWithAnthropicKey(apiKey: string): Promise<{ success: boolean; error?: string }> {
+    const AUTH_TIMEOUT_MS = 120_000;
+
+    const state = AIStateMachine.state();
+    if (state === "Authenticated") { return { success: true }; }
+    if (state === "Disabled") { return { success: false, error: "AI features are disabled." }; }
+
+    AIStateMachine.sendEvent(AIMachineEventType.AUTH_WITH_API_KEY);
+    AIStateMachine.sendEvent({ type: AIMachineEventType.SUBMIT_API_KEY, payload: { apiKey } } as any);
+
+    return new Promise<{ success: boolean; error?: string }>((resolve) => {
+        let settled = false;
+        const finish = (result: { success: boolean; error?: string }) => {
+            if (settled) { return; }
+            settled = true;
+            clearTimeout(timeout);
+            sub.unsubscribe();
+            resolve(result);
+        };
+        const timeout = setTimeout(() => finish({ success: false, error: "Sign-in timed out. Please try again." }), AUTH_TIMEOUT_MS);
+        const sub = AIStateMachine.service().subscribe((snapshot) => {
+            const s = snapshot.value;
+            if (s === "Authenticated") {
+                finish({ success: true });
+            } else if (s === "Unauthenticated" || s === "Disabled") {
+                const ctx = AIStateMachine.context();
+                finish({ success: false, error: ctx?.errorMessage || "Authentication failed. Please check your API key." });
+            }
+        });
+    });
+}
+
+/**
+ * Authenticates with AWS Bedrock using access key credentials.
+ */
+export async function signInWithAwsBedrock(creds: {
+    accessKeyId: string;
+    secretAccessKey: string;
+    region: string;
+    sessionToken?: string;
+}): Promise<{ success: boolean; error?: string }> {
+    const AUTH_TIMEOUT_MS = 120_000;
+
+    const state = AIStateMachine.state();
+    if (state === "Authenticated") { return { success: true }; }
+    if (state === "Disabled") { return { success: false, error: "AI features are disabled." }; }
+
+    AIStateMachine.sendEvent(AIMachineEventType.AUTH_WITH_AWS_BEDROCK);
+    AIStateMachine.sendEvent({ type: AIMachineEventType.SUBMIT_AWS_CREDENTIALS, payload: creds } as any);
+
+    return new Promise<{ success: boolean; error?: string }>((resolve) => {
+        let settled = false;
+        const finish = (result: { success: boolean; error?: string }) => {
+            if (settled) { return; }
+            settled = true;
+            clearTimeout(timeout);
+            sub.unsubscribe();
+            resolve(result);
+        };
+        const timeout = setTimeout(() => finish({ success: false, error: "Sign-in timed out. Please try again." }), AUTH_TIMEOUT_MS);
+        const sub = AIStateMachine.service().subscribe((snapshot) => {
+            const s = snapshot.value;
+            if (s === "Authenticated") {
+                finish({ success: true });
+            } else if (s === "Unauthenticated" || s === "Disabled") {
+                const ctx = AIStateMachine.context();
+                finish({ success: false, error: ctx?.errorMessage || "Authentication failed. Please check your AWS credentials." });
+            }
+        });
+    });
+}
+
+/**
+ * Authenticates with Google Vertex AI using service account credentials.
+ */
+export async function signInWithVertexAI(creds: {
+    projectId: string;
+    location: string;
+    clientEmail: string;
+    privateKey: string;
+}): Promise<{ success: boolean; error?: string }> {
+    const AUTH_TIMEOUT_MS = 120_000;
+
+    const state = AIStateMachine.state();
+    if (state === "Authenticated") { return { success: true }; }
+    if (state === "Disabled") { return { success: false, error: "AI features are disabled." }; }
+
+    AIStateMachine.sendEvent(AIMachineEventType.AUTH_WITH_VERTEX_AI);
+    AIStateMachine.sendEvent({ type: AIMachineEventType.SUBMIT_VERTEX_AI_CREDENTIALS, payload: creds } as any);
+
+    return new Promise<{ success: boolean; error?: string }>((resolve) => {
+        let settled = false;
+        const finish = (result: { success: boolean; error?: string }) => {
+            if (settled) { return; }
+            settled = true;
+            clearTimeout(timeout);
+            sub.unsubscribe();
+            resolve(result);
+        };
+        const timeout = setTimeout(() => finish({ success: false, error: "Sign-in timed out. Please try again." }), AUTH_TIMEOUT_MS);
+        const sub = AIStateMachine.service().subscribe((snapshot) => {
+            const s = snapshot.value;
+            if (s === "Authenticated") {
+                finish({ success: true });
+            } else if (s === "Unauthenticated" || s === "Disabled") {
+                const ctx = AIStateMachine.context();
+                finish({ success: false, error: ctx?.errorMessage || "Authentication failed. Please check your Google Vertex AI credentials." });
+            }
+        });
+    });
+}
+
 export async function runWizardMigrationEnhancement(): Promise<void> {
     console.log('[orchestrator] runWizardMigrationEnhancement called. _wizardProjectRoot:', _wizardProjectRoot);
     const projectRoot = _wizardProjectRoot;


### PR DESCRIPTION
## Purpose
$subject. This is needed for https://github.com/wso2/product-integrator/pull/1270.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Extended authentication support to three new AI providers: Anthropic, AWS Bedrock, and Vertex AI. Users can now securely configure and authenticate with these additional AI service providers, enabling seamless access to their capabilities for enhanced code migration and analysis workflows within the extension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->