### PR TITLE
Fix value not get flushed when switching modes while having incompatible types

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/ModeSwitcher/index.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/ModeSwitcher/index.tsx
@@ -77,8 +77,8 @@ const ModeSwitcher: React.FC<ModeSwitcherProps> = ({ value, isRecordTypeField, o
 
     const handleConfirmSwitch = () => {
         if (pendingMode) {
+            setValue(fieldKey, "", { shouldDirty: true });
             onChange(pendingMode);
-            setValue(fieldKey, undefined);
             setPendingMode(null);
         }
         setShowWarning(false);

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/FieldFactory.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/FieldFactory.tsx
@@ -242,7 +242,7 @@ export const FieldFactory = (props: FieldFactoryProps) => {
                 props.handleFormValidation?.(currentValues);
             }
         } else {
-            props.handleFormValidation?.();
+            props.handleFormValidation?.({ ...currentValues, [props.field.key]: "" });
         }
     }, [props.handleFormValidation, form, props.field.key]);
 

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/utils.ts
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/utils.ts
@@ -312,7 +312,7 @@ function pushPair(
 export function buildStringArray(elements: FormField[]): string {
     if (typeof elements === "string") return elements;
     const parts = elements.map(el => {
-        return (el.value as string).trim();
+        return ((el.value as string) ?? "").trim();
     });
     return `[${parts.join(", ")}]`;
 }
@@ -321,8 +321,8 @@ export function buildStringMap(elements: FormField[][] | string): string {
     if (typeof elements === "string") return elements;
     let finalString = "{";
     elements.forEach((el, index) => {
-        let processedValue = (el[1].value as string).trim();
-        const keyValue = (el[0].value as string).trim();
+        let processedValue = ((el[1].value as string) ?? "").trim();
+        const keyValue = ((el[0].value as string) ?? "").trim();
         
         if (index !== 0) {
             finalString += `, ${keyValue}: ${processedValue}`;


### PR DESCRIPTION
## Purpose
> This PR will fix some issues in expression Editor mode switcher where it does not clear the incompatible values from the expression when switching modes. This resulted in bugs like https://github.com/wso2/product-integrator/issues/1276

Resolves: https://github.com/wso2/product-integrator/issues/1276

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form field handling during mode switches to ensure better data consistency and validation
  * Enhanced form validation to properly process and handle cleared field values
  * Added safeguards against runtime errors when form fields have missing or undefined values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->