### PR TITLE
Fix MCP Inspector styling issues by updating theme color handling

### DIFF
--- a/workspaces/mcp-inspector/mcp-inspector-extension/scripts/inject-theme.js
+++ b/workspaces/mcp-inspector/mcp-inspector-extension/scripts/inject-theme.js
@@ -76,6 +76,12 @@ const CUSTOM_CSS = `    <!-- Dynamic Theme Injection Placeholder -->
       window.addEventListener('message', (event) => {
         const message = event.data;
         if (message.type === 'vscode-theme-colors') {
+          // Sync the inspector's dark-mode class with VSCode's theme so its
+          // own theme tokens (:root for light, .dark for dark) align with our overrides.
+          if (typeof message.isDark === 'boolean') {
+            document.documentElement.classList.toggle('dark', message.isDark);
+          }
+
           // Remove old theme style if exists
           if (themeStyleElement) {
             themeStyleElement.remove();
@@ -145,6 +151,9 @@ const CUSTOM_CSS = `    <!-- Dynamic Theme Injection Placeholder -->
                 background-color: \${message.colors.bodyBg} !important;
               }
             }
+
+            /* Hide the inspector's theme switcher — VSCode owns the theme. */
+            #theme-select { display: none !important; }
           \`;
           document.head.appendChild(themeStyleElement);
         }
@@ -164,10 +173,11 @@ function injectTheme() {
   // Read index.html
   let html = fs.readFileSync(INDEX_HTML_PATH, 'utf8');
 
-  // Check if theme is already injected (avoid duplicate injection)
-  if (html.includes('Dynamic Theme Injection Placeholder')) {
-    console.log('   ℹ️  Theme already injected, skipping...');
-    return;
+  // If a previous injection exists, strip it so we can replace with the latest version.
+  const existing = /\s*<!-- Dynamic Theme Injection Placeholder -->[\s\S]*?<\/script>\s*/;
+  if (existing.test(html)) {
+    html = html.replace(existing, '\n    ');
+    console.log('   ♻️  Replacing existing theme injection...');
   }
 
   // Inject custom CSS before </head> tag

--- a/workspaces/mcp-inspector/mcp-inspector-extension/scripts/inject-theme.js
+++ b/workspaces/mcp-inspector/mcp-inspector-extension/scripts/inject-theme.js
@@ -74,8 +74,9 @@ const CUSTOM_CSS = `    <!-- Dynamic Theme Injection Placeholder -->
 
       // Listen for theme color messages from parent
       window.addEventListener('message', (event) => {
+        if (event.source !== window.parent) return;
         const message = event.data;
-        if (message.type === 'vscode-theme-colors') {
+        if (message && message.type === 'vscode-theme-colors') {
           // Sync the inspector's dark-mode class with VSCode's theme so its
           // own theme tokens (:root for light, .dark for dark) align with our overrides.
           if (typeof message.isDark === 'boolean') {

--- a/workspaces/mcp-inspector/mcp-inspector-extension/src/MCPInspectorViewProvider.ts
+++ b/workspaces/mcp-inspector/mcp-inspector-extension/src/MCPInspectorViewProvider.ts
@@ -213,11 +213,42 @@ export class MCPInspectorViewProvider implements vscode.WebviewViewProvider {
         const computedStyle = getComputedStyle(document.documentElement);
         const editorBg = computedStyle.getPropertyValue('--vscode-editor-background').trim();
         const editorFg = computedStyle.getPropertyValue('--vscode-editor-foreground').trim();
-        const buttonBg = computedStyle.getPropertyValue('--vscode-button-secondaryBackground').trim();
-        const border = computedStyle.getPropertyValue('--vscode-activityBar-border').trim();
+        const fg = computedStyle.getPropertyValue('--vscode-foreground').trim() || editorFg;
+        const buttonBg = computedStyle.getPropertyValue('--vscode-button-background').trim();
+        const buttonFg = computedStyle.getPropertyValue('--vscode-button-foreground').trim() || fg;
+        const buttonSecBg = computedStyle.getPropertyValue('--vscode-button-secondaryBackground').trim();
+        const buttonSecFg = computedStyle.getPropertyValue('--vscode-button-secondaryForeground').trim() || fg;
+        const descriptionFg = computedStyle.getPropertyValue('--vscode-descriptionForeground').trim() || fg;
+        const panelBorder = computedStyle.getPropertyValue('--vscode-panel-border').trim();
+        const widgetBorder = computedStyle.getPropertyValue('--vscode-widget-border').trim();
+        const contrastBorder = computedStyle.getPropertyValue('--vscode-contrastBorder').trim();
+        const activityBarBorder = computedStyle.getPropertyValue('--vscode-activityBar-border').trim();
+        const inputBorder = computedStyle.getPropertyValue('--vscode-input-border').trim();
+        const border = panelBorder || widgetBorder || contrastBorder || activityBarBorder;
+        const inputBorderResolved = inputBorder || border;
         const errorBg = computedStyle.getPropertyValue('--vscode-inputValidation-errorBackground').trim();
-        const activityBarBg = computedStyle.getPropertyValue('--vscode-activityBar-background').trim();
+        const errorFg = computedStyle.getPropertyValue('--vscode-inputValidation-errorForeground').trim() || fg;
         const inactiveTabBg = computedStyle.getPropertyValue('--vscode-tab-inactiveBackground').trim();
+        // Drop fully-transparent or low-alpha values; alpha is dropped by colorToHsl
+        // and would collapse rgba(white, 0.1)-style overlays to bright HSL.
+        const opaque = (c) => {
+          if (!c) return '';
+          if (/rgba\\([^)]*,\\s*0(\\.0*)?\\s*\\)$/.test(c)) return '';
+          const m = c.match(/rgba\\(\\s*\\d+\\s*,\\s*\\d+\\s*,\\s*\\d+\\s*,\\s*([\\d.]+)\\s*\\)$/);
+          if (m && parseFloat(m[1]) < 0.5) return '';
+          return c;
+        };
+        const widgetBg = opaque(computedStyle.getPropertyValue('--vscode-editorWidget-background').trim());
+        const listHoverBg = opaque(computedStyle.getPropertyValue('--vscode-list-hoverBackground').trim());
+
+        const bodyClass = document.body.className || '';
+        const isHighContrast = bodyClass.includes('vscode-high-contrast');
+        const isDark = bodyClass.includes('vscode-dark') || (isHighContrast && !bodyClass.includes('vscode-high-contrast-light'));
+
+        // In HC themes, surfaces should blend with the editor and rely on borders (contrastBorder)
+        // for differentiation — coloured fills wash out or render invisible.
+        const subtleSurface = isHighContrast ? editorBg : (widgetBg || listHoverBg || buttonSecBg || inactiveTabBg);
+        const subtleSurfaceMuted = isHighContrast ? editorBg : (widgetBg || listHoverBg || inactiveTabBg);
 
         // Send all theme colors (in same order as inject-theme.js uses them)
         const themeColors = {
@@ -234,28 +265,28 @@ export class MCPInspectorViewProvider implements vscode.WebviewViewProvider {
           popoverForeground: editorFg,
 
           // Primary colors
-          primary: activityBarBg,
-          primaryForeground: inactiveTabBg,
+          primary: buttonBg,
+          primaryForeground: buttonFg,
 
           // Secondary colors
-          secondary: inactiveTabBg,
-          secondaryForeground: activityBarBg,
+          secondary: subtleSurface,
+          secondaryForeground: fg,
 
           // Muted colors
-          muted: inactiveTabBg,
-          mutedForeground: activityBarBg,
+          muted: subtleSurfaceMuted,
+          mutedForeground: descriptionFg,
 
           // Accent colors
-          accent: inactiveTabBg,
-          accentForeground: activityBarBg,
+          accent: subtleSurface,
+          accentForeground: fg,
 
           // Destructive colors
           destructive: errorBg,
-          destructiveForeground: inactiveTabBg,
+          destructiveForeground: errorFg,
 
           // Input/Border/Ring
           border: border,
-          input: border,
+          input: inputBorderResolved,
           ring: editorFg,
 
           // Body styles
@@ -263,11 +294,11 @@ export class MCPInspectorViewProvider implements vscode.WebviewViewProvider {
           bodyColor: editorFg
         };
 
-
         if (iframe.contentWindow) {
           iframe.contentWindow.postMessage({
             type: 'vscode-theme-colors',
-            colors: themeColors
+            colors: themeColors,
+            isDark: isDark
           }, '*');
         }
       }

--- a/workspaces/mcp-inspector/mcp-inspector-extension/src/MCPInspectorViewProvider.ts
+++ b/workspaces/mcp-inspector/mcp-inspector-extension/src/MCPInspectorViewProvider.ts
@@ -224,30 +224,50 @@ export class MCPInspectorViewProvider implements vscode.WebviewViewProvider {
         const contrastBorder = computedStyle.getPropertyValue('--vscode-contrastBorder').trim();
         const activityBarBorder = computedStyle.getPropertyValue('--vscode-activityBar-border').trim();
         const inputBorder = computedStyle.getPropertyValue('--vscode-input-border').trim();
-        const border = panelBorder || widgetBorder || contrastBorder || activityBarBorder;
+
+        const bodyClass = document.body.className || '';
+        const isHighContrast = bodyClass.includes('vscode-high-contrast');
+        const isDark = bodyClass.includes('vscode-dark') || (isHighContrast && !bodyClass.includes('vscode-high-contrast-light'));
+
+        // Prefer contrastBorder in HC: surfaces blend with body there, so the border carries differentiation.
+        const border = isHighContrast
+          ? (contrastBorder || panelBorder || widgetBorder || activityBarBorder)
+          : (panelBorder || widgetBorder || contrastBorder || activityBarBorder);
         const inputBorderResolved = inputBorder || border;
         const errorBg = computedStyle.getPropertyValue('--vscode-inputValidation-errorBackground').trim();
         const errorFg = computedStyle.getPropertyValue('--vscode-inputValidation-errorForeground').trim() || fg;
         const inactiveTabBg = computedStyle.getPropertyValue('--vscode-tab-inactiveBackground').trim();
-        // Drop fully-transparent or low-alpha values; alpha is dropped by colorToHsl
-        // and would collapse rgba(white, 0.1)-style overlays to bright HSL.
+        // Drop transparent / low-alpha values so they don't degrade to gray in colorToHsl.
         const opaque = (c) => {
           if (!c) return '';
-          if (/rgba\\([^)]*,\\s*0(\\.0*)?\\s*\\)$/.test(c)) return '';
-          const m = c.match(/rgba\\(\\s*\\d+\\s*,\\s*\\d+\\s*,\\s*\\d+\\s*,\\s*([\\d.]+)\\s*\\)$/);
+          if (/^\\s*transparent\\s*$/i.test(c)) return '';
+          let m = c.match(/^#[0-9a-f]{6}([0-9a-f]{2})$/i);
+          if (m && parseInt(m[1], 16) < 128) return '';
+          m = c.match(/^[a-z]+\\(\\s*[\\d.]+%?\\s*,\\s*[\\d.]+%?\\s*,\\s*[\\d.]+%?\\s*,\\s*([\\d.]+)\\s*\\)\\s*$/i);
+          if (m && parseFloat(m[1]) < 0.5) return '';
+          m = c.match(/^[a-z]+\\([^)]*\\/\\s*([\\d.]+)\\s*\\)\\s*$/i);
           if (m && parseFloat(m[1]) < 0.5) return '';
           return c;
         };
         const widgetBg = opaque(computedStyle.getPropertyValue('--vscode-editorWidget-background').trim());
         const listHoverBg = opaque(computedStyle.getPropertyValue('--vscode-list-hoverBackground').trim());
 
-        const bodyClass = document.body.className || '';
-        const isHighContrast = bodyClass.includes('vscode-high-contrast');
-        const isDark = bodyClass.includes('vscode-dark') || (isHighContrast && !bodyClass.includes('vscode-high-contrast-light'));
-
         // In HC themes, surfaces should blend with the editor and rely on borders (contrastBorder)
         // for differentiation — coloured fills wash out or render invisible.
-        const subtleSurface = isHighContrast ? editorBg : (widgetBg || listHoverBg || buttonSecBg || inactiveTabBg);
+        let subtleSurface;
+        let subtleSurfaceFg = fg;
+        if (isHighContrast) {
+          subtleSurface = editorBg;
+        } else if (widgetBg) {
+          subtleSurface = widgetBg;
+        } else if (listHoverBg) {
+          subtleSurface = listHoverBg;
+        } else if (buttonSecBg) {
+          subtleSurface = buttonSecBg;
+          subtleSurfaceFg = buttonSecFg;
+        } else {
+          subtleSurface = inactiveTabBg;
+        }
         const subtleSurfaceMuted = isHighContrast ? editorBg : (widgetBg || listHoverBg || inactiveTabBg);
 
         // Send all theme colors (in same order as inject-theme.js uses them)
@@ -270,7 +290,7 @@ export class MCPInspectorViewProvider implements vscode.WebviewViewProvider {
 
           // Secondary colors
           secondary: subtleSurface,
-          secondaryForeground: fg,
+          secondaryForeground: subtleSurfaceFg,
 
           // Muted colors
           muted: subtleSurfaceMuted,
@@ -278,7 +298,7 @@ export class MCPInspectorViewProvider implements vscode.WebviewViewProvider {
 
           // Accent colors
           accent: subtleSurface,
-          accentForeground: fg,
+          accentForeground: subtleSurfaceFg,
 
           // Destructive colors
           destructive: errorBg,
@@ -299,7 +319,7 @@ export class MCPInspectorViewProvider implements vscode.WebviewViewProvider {
             type: 'vscode-theme-colors',
             colors: themeColors,
             isDark: isDark
-          }, '*');
+          }, 'http://localhost:${Ports.CLIENT}');
         }
       }
 
@@ -329,11 +349,17 @@ export class MCPInspectorViewProvider implements vscode.WebviewViewProvider {
         sendThemeColors();
       });
 
-      // Observe changes to the document element's style attribute
+      // Observe both <html> (CSS variable updates) and <body> (theme class flips).
       observer.observe(document.documentElement, {
         attributes: true,
         attributeFilter: ['style', 'class']
       });
+      if (document.body) {
+        observer.observe(document.body, {
+          attributes: true,
+          attributeFilter: ['class']
+        });
+      }
 
     })();
   </script>


### PR DESCRIPTION
## Purpose

This PR fixes MCP Inspector styling issues where certain text elements were not visible in dark mode.

Fixes https://github.com/wso2/product-integrator/issues/1253

**Dark Mode:**

https://github.com/user-attachments/assets/2a1312a5-2800-4a69-bd8d-2453b0acf4d9

**Light Mode:**

https://github.com/user-attachments/assets/3e871c78-eaa1-4209-bbe3-1b99e8b546e3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inspector theme now automatically synchronizes with VSCode's theme preference
  * Improved support for dark and high-contrast VS Code themes

* **Bug Fixes**
  * Enhanced visual consistency and color contrast across different theme modes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->