### PR TITLE
Add HTTP Header Type Suggestions

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/ResourceForm/Parameters/ParamEditor.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/ResourceForm/Parameters/ParamEditor.tsx
@@ -28,6 +28,7 @@ import ArtifactForm from '../../../../Forms/ArtifactForm';
 import { useRpcContext } from '@wso2/ballerina-rpc-client';
 import { URI, Utils } from 'vscode-uri';
 import { getImportsForProperty } from '../../../../../../utils/bi';
+import { HTTP_HEADER_TYPES } from '../../../utils';
 
 const options = [{ id: "0", value: "QUERY" }, { id: "1", value: "Header" }];
 
@@ -249,7 +250,7 @@ export function ParamEditor(props: ParamProps) {
                 fields.push({
                     key: `type`,
                     label: 'Type',
-                    type: "ENUM",
+                    type: "AUTOCOMPLETE",
                     advanced: isNew,
                     optional: false,
                     editable: true,
@@ -257,8 +258,8 @@ export function ParamEditor(props: ParamProps) {
                     enabled: true,
                     defaultValue: "string",
                     value: param.type.value,
-                    items: ["string", "int", "float", "decimal", "boolean"],
-                    types: [{ fieldType: getPrimaryInputType(param.type.types)?.fieldType, selected: false }]
+                    items: HTTP_HEADER_TYPES,
+                    types: [{ fieldType: "AUTOCOMPLETE", selected: false }]
                 });
                 break;
             case "PAYLOAD":

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/ResourceForm/ResourceResponse/ResponseEditor.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/ServiceDesigner/Forms/ResourceForm/ResourceResponse/ResponseEditor.tsx
@@ -23,7 +23,7 @@ import { Divider, OptionProps, Typography } from '@wso2/ui-toolkit';
 import { EditorContainer, EditorContent } from '../../../styles';
 import { getPrimaryInputType, LineRange, PropertyModel, StatusCodeResponse, VisibleTypeItem, VisibleTypesResponse } from '@wso2/ballerina-core';
 import { TypeHelperContext } from '../../../../../../constants';
-import { getDefaultResponse, getTitleFromStatusCodeAndType, HTTP_METHOD } from '../../../utils';
+import { getDefaultResponse, getTitleFromStatusCodeAndType, HTTP_HEADER_TYPES, HTTP_METHOD } from '../../../utils';
 import { FormField, FormImports, FormValues } from '@wso2/ballerina-side-panel';
 import ArtifactForm from '../../../../Forms/ArtifactForm';
 import { useRpcContext } from '@wso2/ballerina-rpc-client';
@@ -85,14 +85,7 @@ export function ResponseEditor(props: ParamProps) {
 
     const updateNewFields = (res: StatusCodeResponse, hasBody: boolean = true) => {
         const NO_BODY_TYPES = ["http:Response", "http:NoContent", "error"];
-        const defaultItems = [
-            "string",
-            "int",
-            "boolean",
-            "string[]",
-            "int[]",
-            "boolean[]"
-        ];
+        const defaultItems = HTTP_HEADER_TYPES;
 
         // Special Condition to check http:Response to re-direct to Dynamic Status code
         if (NO_BODY_TYPES.includes(res.type.value)) {

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/ServiceDesigner/utils.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/ServiceDesigner/utils.tsx
@@ -27,6 +27,19 @@ export enum HTTP_METHOD {
     "PATCH" = "PATCH"
 }
 
+export const HTTP_HEADER_TYPES = [
+    "string",
+    "int",
+    "boolean",
+    "float",
+    "decimal",
+    "string[]",
+    "int[]",
+    "boolean[]",
+    "float[]",
+    "decimal[]"
+];
+
 export function getDefaultResponse(httpMethod: HTTP_METHOD): string {
     switch (httpMethod.toUpperCase()) {
         case HTTP_METHOD.GET:


### PR DESCRIPTION
## Purpose

Fixes: [966](https://github.com/wso2/product-integrator/issues/966)

> With this, for header types it shows the list of pre-defined types as follows.

<img width="354" height="398" alt="Screenshot 2026-04-28 at 11 02 30 AM" src="https://github.com/user-attachments/assets/ae4c37b6-08ee-46cd-903c-6faa3b61f7b3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced header parameter editor with autocomplete functionality for improved usability when editing request headers.

* **Refactor**
  * Standardized HTTP header type definitions across request and response editors for consistent header type handling throughout the service designer interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->