### PR TITLE
Improve AI chat input toggle and web search button styling

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/AIChatInput/ModeToggle.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/AIChatInput/ModeToggle.tsx
@@ -39,23 +39,20 @@ const ToggleOption = styled.button<{ active?: boolean }>`
     border: none;
     border-radius: 4px;
     background-color: ${(props: { active?: boolean }) =>
-        props.active ? "var(--vscode-button-background)" : "transparent"};
+        props.active ? "var(--vscode-editor-background)" : "transparent"};
     color: ${(props: { active?: boolean }) =>
-        props.active ? "var(--vscode-button-foreground)" : "var(--vscode-descriptionForeground)"};
-    cursor: pointer;
+        props.active ? "var(--vscode-editor-foreground)" : "var(--vscode-descriptionForeground)"};
+
+    cursor: ${(props: { active?: boolean }) => (props.active ? "default" : "pointer")};
     font-size: 11px;
     white-space: nowrap;
     transition: background-color 0.1s, color 0.1s;
 
     &:hover {
         background-color: ${(props: { active?: boolean }) =>
-            props.active
-                ? "var(--vscode-button-background)"
-                : "var(--vscode-toolbar-hoverBackground)"};
+            props.active ? "var(--vscode-editor-background)" : "var(--vscode-toolbar-hoverBackground)"};
         color: ${(props: { active?: boolean }) =>
-            props.active
-                ? "var(--vscode-button-foreground)"
-                : "var(--vscode-foreground)"};
+            props.active ? "var(--vscode-editor-foreground)" : "var(--vscode-foreground)"};
     }
 `;
 

--- a/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/AIChatInput/ModeToggle.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/AIChatInput/ModeToggle.tsx
@@ -72,7 +72,7 @@ const ModeToggle: React.FC<ModeToggleProps> = ({ mode, onChange, disabled }) => 
         <ToggleOption
             active={mode === AgentMode.Edit}
             title="Direct file edits"
-            onClick={() => onChange(AgentMode.Edit)}
+            onClick={() => mode !== AgentMode.Edit && onChange(AgentMode.Edit)}
         >
             <span className="codicon codicon-edit" style={{ fontSize: 11 }} />
             Edit
@@ -80,7 +80,7 @@ const ModeToggle: React.FC<ModeToggleProps> = ({ mode, onChange, disabled }) => 
         <ToggleOption
             active={mode === AgentMode.Plan}
             title="Design first, then build"
-            onClick={() => onChange(AgentMode.Plan)}
+            onClick={() => mode !== AgentMode.Plan && onChange(AgentMode.Plan)}
         >
             <span className="codicon codicon-list-tree" style={{ fontSize: 11 }} />
             Plan

--- a/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/AIChatInput/WebSearchToggle.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/AIChatInput/WebSearchToggle.tsx
@@ -27,19 +27,23 @@ const ToggleButton = styled.button<{ isActive: boolean }>`
     height: 24px;
     padding: 0;
     border-radius: 4px;
-    border: 1px solid ${({ isActive }: { isActive: boolean }) =>
-        isActive ? "var(--vscode-button-background)" : "transparent"};
+    border: none;
     background-color: ${({ isActive }: { isActive: boolean }) =>
-        isActive ? "var(--vscode-button-background)" : "transparent"};
+        isActive ? "var(--vscode-editor-inactiveSelectionBackground)" : "transparent"};
     color: ${({ isActive }: { isActive: boolean }) =>
-        isActive ? "var(--vscode-button-foreground)" : "var(--vscode-foreground)"};
+        isActive ? "var(--vscode-editor-foreground)" : "var(--vscode-descriptionForeground)"};
     cursor: pointer;
-    opacity: ${({ isActive }: { isActive: boolean }) => (isActive ? 1 : 0.7)};
+    opacity: ${({ isActive }: { isActive: boolean }) => (isActive ? 1 : 0.5)};
+    transition: background-color 0.1s, color 0.1s, opacity 0.1s;
 
     &:hover {
         opacity: 1;
         background-color: ${({ isActive }: { isActive: boolean }) =>
-            isActive ? "var(--vscode-button-hoverBackground)" : "var(--vscode-toolbar-hoverBackground)"};
+            isActive
+                ? "var(--vscode-editor-inactiveSelectionBackground)"
+                : "var(--vscode-toolbar-hoverBackground)"};
+        color: ${({ isActive }: { isActive: boolean }) =>
+            isActive ? "var(--vscode-editor-foreground)" : "var(--vscode-foreground)"};
     }
 `;
 

--- a/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/AIChatInput/WebSearchToggle.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/AIChatInput/WebSearchToggle.tsx
@@ -33,11 +33,9 @@ const ToggleButton = styled.button<{ isActive: boolean }>`
     color: ${({ isActive }: { isActive: boolean }) =>
         isActive ? "var(--vscode-editor-foreground)" : "var(--vscode-descriptionForeground)"};
     cursor: pointer;
-    opacity: ${({ isActive }: { isActive: boolean }) => (isActive ? 1 : 0.5)};
-    transition: background-color 0.1s, color 0.1s, opacity 0.1s;
+    transition: background-color 0.1s, color 0.1s;
 
     &:hover {
-        opacity: 1;
         background-color: ${({ isActive }: { isActive: boolean }) =>
             isActive
                 ? "var(--vscode-editor-inactiveSelectionBackground)"
@@ -56,6 +54,8 @@ const WebSearchToggle: React.FC<WebSearchToggleProps> = ({ isActive, onToggle })
     <ToggleButton
         isActive={isActive}
         onClick={onToggle}
+        aria-pressed={isActive}
+        aria-label={isActive ? "Web access enabled, click to revoke" : "Web access disabled, click to allow"}
         title={isActive ? "Web access allowed — click to revoke" : "Allow web access"}
     >
         <span className="codicon codicon-globe" style={{ fontSize: 14 }} />


### PR DESCRIPTION
Related https://github.com/wso2/product-integrator/issues/1264

- ModeToggle active pill uses `editor-background` (frosted elevation) instead of primary blue — reduces visual noise since one option is always active
- ModeToggle click handlers no-op when the already-active option is clicked, consistent with `cursor: default` on active state
- WebSearchToggle active state uses `editor-inactiveSelectionBackground`, inactive at full opacity with color-only differentiation
- WebSearchToggle gains `aria-pressed` and descriptive `aria-label` for accessibility

https://github.com/user-attachments/assets/15d5786c-861c-48c1-ba3d-ae4bfad23f90


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated AI Chat Input mode and web search toggle components to use VS Code editor theme variables for improved visual consistency with the editor interface
  * Added smooth transitions for background color, text color, and opacity changes when toggling states
  * Improved cursor feedback to show default cursor on active options and pointer cursor on inactive options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->