### PR TITLE
Fix form diagnostics for incomplete required fields

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/package.json
+++ b/workspaces/ballerina/ballerina-side-panel/package.json
@@ -9,7 +9,7 @@
     "types": "lib/index.d.ts",
     "scripts": {
         "build": "tsc --pretty && npm run copy:assets",
-        "test": "npm run build && node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test test/typeCompletionUtils.test.mjs",
+        "test": "npm run build && node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test test/typeCompletionUtils.test.mjs test/formValidationUtils.test.mjs",
         "storybook": "start-storybook -p 6006",
         "watch": "tsc --pretty --watch",
         "build-storybook": "build-storybook",

--- a/workspaces/ballerina/ballerina-side-panel/src/components/Form/index.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/Form/index.tsx
@@ -62,6 +62,7 @@ import {
     formatJSONLikeString,
     stripHtmlTags,
     updateFormFieldWithImports,
+    hasIncompleteRequiredFormFields,
     shouldRunExternalFormValidation,
     isPrioritizedField,
     hasRequiredParameters,
@@ -622,7 +623,11 @@ export const Form = forwardRef((props: FormProps, _ref) => {
         onSubmit && onSubmit(data, dirtyFields);
     };
 
-    const canRunExternalFormValidation = () => shouldRunExternalFormValidation({ formStateIsValid, errors });
+    const canRunExternalFormValidation = (values: FormValues) => shouldRunExternalFormValidation({
+        formStateIsValid,
+        errors,
+        hasIncompleteRequiredFields: hasIncompleteRequiredFormFields(formFields, values),
+    });
 
     const runExternalFormValidation = async (data: FormValues): Promise<boolean> => {
         if (!onFormValidation) {
@@ -640,18 +645,20 @@ export const Form = forwardRef((props: FormProps, _ref) => {
     }
 
     const handleFormValidation = async (formData?: FormValues): Promise<boolean> => {
-        if (!onFormValidation || !canRunExternalFormValidation()) {
+        const data = formData ?? getValues();
+        if (!onFormValidation || !canRunExternalFormValidation(data)) {
             return true;
         }
 
-        return runExternalFormValidation(formData ?? getValues());
+        return runExternalFormValidation(data);
     }
 
     const handleOnBlur = async () => {
-        if (!canRunExternalFormValidation()) {
+        const values = getValues();
+        if (!canRunExternalFormValidation(values)) {
             return;
         }
-        onBlur?.(getValues(), dirtyFields);
+        onBlur?.(values, dirtyFields);
     };
 
     const handleOpenRecordEditor = (open: boolean, typeField?: FormField, newType?: string | NodeProperties) => {
@@ -885,15 +892,19 @@ export const Form = forwardRef((props: FormProps, _ref) => {
         return !hasDiagnostics;
     }, [diagnosticsInfo, formFields]);
 
+    const prevValuesRef = useRef<FormValues>({});
+    const watchedValues = watch();
+    const hasIncompleteRequiredFields = hasIncompleteRequiredFormFields(formFields, watchedValues);
+
     // Call onValidityChange when form validity changes
     useEffect(() => {
         if (onValidityChange) {
             // formStateIsValid captures errors from PathEditor and other validators (setError)
-            const formIsValid = isValid && formStateIsValid && !isValidating && Object.keys(errors).length === 0 &&
+            const formIsValid = isValid && formStateIsValid && !isValidating && Object.keys(errors).length === 0 && !hasIncompleteRequiredFields &&
                 (!concertMessage || !concertRequired || isUserConcert) && !isIdentifierEditing && !isSubComponentEnabled;
             onValidityChange(formIsValid);
         }
-    }, [isValid, formStateIsValid, isValidating, errors, concertMessage, concertRequired, isUserConcert, isIdentifierEditing, isSubComponentEnabled, onValidityChange]);
+    }, [isValid, formStateIsValid, isValidating, errors, hasIncompleteRequiredFields, concertMessage, concertRequired, isUserConcert, isIdentifierEditing, isSubComponentEnabled, onValidityChange]);
 
     const handleIdentifierEditingStateChange = (isEditing: boolean) => {
         setIsIdentifierEditing(isEditing);
@@ -905,7 +916,8 @@ export const Form = forwardRef((props: FormProps, _ref) => {
 
     const disableSaveButton =
         isValidating || props.disableSaveButton || (concertMessage && concertRequired && !isUserConcert) ||
-        isIdentifierEditing || isSubComponentEnabled || isValidatingForm || !formStateIsValid || Object.keys(errors).length > 0;
+        isIdentifierEditing || isSubComponentEnabled || isValidatingForm || hasIncompleteRequiredFields ||
+        !formStateIsValid || Object.keys(errors).length > 0;
 
     const handleShowMoreClick = () => {
         setIsMarkdownExpanded(!isMarkdownExpanded);
@@ -916,8 +928,6 @@ export const Form = forwardRef((props: FormProps, _ref) => {
         }
     };
 
-    const prevValuesRef = useRef<FormValues>({});
-    const watchedValues = watch();
     useEffect(() => {
         if (props.onChange) {
             const prevValues = prevValuesRef.current;

--- a/workspaces/ballerina/ballerina-side-panel/src/components/Form/index.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/Form/index.tsx
@@ -62,6 +62,7 @@ import {
     formatJSONLikeString,
     stripHtmlTags,
     updateFormFieldWithImports,
+    shouldRunExternalFormValidation,
     isPrioritizedField,
     hasRequiredParameters,
     hasOptionalParameters,
@@ -621,13 +622,14 @@ export const Form = forwardRef((props: FormProps, _ref) => {
         onSubmit && onSubmit(data, dirtyFields);
     };
 
-    const handleFormValidation = async (formData?: FormValues): Promise<boolean> => {
+    const canRunExternalFormValidation = () => shouldRunExternalFormValidation({ formStateIsValid, errors });
+
+    const runExternalFormValidation = async (data: FormValues): Promise<boolean> => {
         if (!onFormValidation) {
             return true;
         }
 
         setIsValidatingForm(true);
-        const data = formData ?? getValues();
 
         try {
             const validationResult = await onFormValidation(data, dirtyFields);
@@ -637,7 +639,18 @@ export const Form = forwardRef((props: FormProps, _ref) => {
         }
     }
 
+    const handleFormValidation = async (formData?: FormValues): Promise<boolean> => {
+        if (!onFormValidation || !canRunExternalFormValidation()) {
+            return true;
+        }
+
+        return runExternalFormValidation(formData ?? getValues());
+    }
+
     const handleOnBlur = async () => {
+        if (!canRunExternalFormValidation()) {
+            return;
+        }
         onBlur?.(getValues(), dirtyFields);
     };
 
@@ -1001,7 +1014,7 @@ export const Form = forwardRef((props: FormProps, _ref) => {
         handleSubmit(
             async (data) => {
                 try {
-                    const isValidForm = await handleFormValidation(data);
+                    const isValidForm = await runExternalFormValidation(data);
                     if (!isValidForm) {
                         setSavingButton(null);
                         return;

--- a/workspaces/ballerina/ballerina-side-panel/src/components/Form/index.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/Form/index.tsx
@@ -490,6 +490,7 @@ export const Form = forwardRef((props: FormProps, _ref) => {
         setValue,
         setError,
         clearErrors,
+        trigger,
         formState: { isValidating, isValid: formStateIsValid, errors, dirtyFields, isDirty },
     } = useForm<FormValues>();
 
@@ -860,6 +861,9 @@ export const Form = forwardRef((props: FormProps, _ref) => {
                     // not errors set by other validators (e.g., PathEditor)
                     if (errors[key]?.type === "expression_diagnostic") {
                         clearErrors(key);
+                        // clearErrors removes the entry but does not refresh formState.isValid;
+                        // trigger a revalidation so Save re-enables once diagnostics go clean.
+                        trigger(key);
                     }
                     continue;
                 } else {

--- a/workspaces/ballerina/ballerina-side-panel/src/components/Form/index.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/Form/index.tsx
@@ -655,7 +655,7 @@ export const Form = forwardRef((props: FormProps, _ref) => {
 
     const handleOnBlur = async () => {
         const values = getValues();
-        if (!canRunExternalFormValidation(values)) {
+        if (onFormValidation && !canRunExternalFormValidation(values)) {
             return;
         }
         onBlur?.(values, dirtyFields);
@@ -894,7 +894,8 @@ export const Form = forwardRef((props: FormProps, _ref) => {
 
     const prevValuesRef = useRef<FormValues>({});
     const watchedValues = watch();
-    const hasIncompleteRequiredFields = hasIncompleteRequiredFormFields(formFields, watchedValues);
+    const hasIncompleteRequiredFields = !!onFormValidation &&
+        hasIncompleteRequiredFormFields(formFields, watchedValues);
 
     // Call onValidityChange when form validity changes
     useEffect(() => {

--- a/workspaces/ballerina/ballerina-side-panel/src/components/Form/utils.ts
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/Form/utils.ts
@@ -50,6 +50,16 @@ export function updateFormFieldWithImports(formField: FormField, fieldImports: F
     return formField;
 }
 
+export function shouldRunExternalFormValidation({
+    formStateIsValid,
+    errors,
+}: {
+    formStateIsValid: boolean;
+    errors?: Record<string, unknown>;
+}): boolean {
+    return formStateIsValid && Object.keys(errors ?? {}).length === 0;
+}
+
 export function isPrioritizedField(field: FormField): boolean {
     return field.key === "variable" || getPrimaryInputType(field.types)?.fieldType === "TYPE" || field.codedata?.kind === "PARAM_FOR_TYPE_INFER";
 }

--- a/workspaces/ballerina/ballerina-side-panel/src/components/Form/utils.ts
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/Form/utils.ts
@@ -50,14 +50,39 @@ export function updateFormFieldWithImports(formField: FormField, fieldImports: F
     return formField;
 }
 
+export function hasIncompleteRequiredFormFields(
+    formFields: Pick<FormField, "key" | "optional" | "hidden" | "enabled">[] = [],
+    values: Record<string, unknown> = {}
+): boolean {
+    return formFields.some((field) => {
+        if (field.optional || field.hidden || field.enabled === false) {
+            return false;
+        }
+
+        const value = values[field.key];
+        if (value === undefined || value === null) {
+            return true;
+        }
+        if (typeof value === "string") {
+            return value.trim() === "";
+        }
+        if (Array.isArray(value)) {
+            return value.length === 0;
+        }
+        return false;
+    });
+}
+
 export function shouldRunExternalFormValidation({
     formStateIsValid,
     errors,
+    hasIncompleteRequiredFields = false,
 }: {
     formStateIsValid: boolean;
     errors?: Record<string, unknown>;
+    hasIncompleteRequiredFields?: boolean;
 }): boolean {
-    return formStateIsValid && Object.keys(errors ?? {}).length === 0;
+    return formStateIsValid && Object.keys(errors ?? {}).length === 0 && !hasIncompleteRequiredFields;
 }
 
 export function isPrioritizedField(field: FormField): boolean {

--- a/workspaces/ballerina/ballerina-side-panel/src/components/Form/utils.ts
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/Form/utils.ts
@@ -55,18 +55,21 @@ export function hasIncompleteRequiredFormFields(
     values: Record<string, unknown> = {}
 ): boolean {
     const checkField = (field: FormField): boolean => {
-        if (field.optional || field.hidden || field.enabled === false) {
+        if (field.hidden || field.enabled === false) {
             return false;
         }
 
         const value = values[field.key];
-        if (value === undefined || value === null) {
+        const hasValue = value !== undefined && value !== null && !(typeof value === "string" && value.trim() === "");
+
+        if (field.optional && !hasValue) {
+            return false;
+        }
+
+        if (!hasValue) {
             return true;
         }
         if (typeof value === "string") {
-            if (value.trim() === "") {
-                return true;
-            }
             if (field.dynamicFormFields?.[value]) {
                 if (field.dynamicFormFields[value].some(checkField)) {
                     return true;

--- a/workspaces/ballerina/ballerina-side-panel/src/components/Form/utils.ts
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/Form/utils.ts
@@ -51,10 +51,10 @@ export function updateFormFieldWithImports(formField: FormField, fieldImports: F
 }
 
 export function hasIncompleteRequiredFormFields(
-    formFields: Pick<FormField, "key" | "optional" | "hidden" | "enabled">[] = [],
+    formFields: FormField[] = [],
     values: Record<string, unknown> = {}
 ): boolean {
-    return formFields.some((field) => {
+    const checkField = (field: FormField): boolean => {
         if (field.optional || field.hidden || field.enabled === false) {
             return false;
         }
@@ -64,13 +64,22 @@ export function hasIncompleteRequiredFormFields(
             return true;
         }
         if (typeof value === "string") {
-            return value.trim() === "";
+            if (value.trim() === "") {
+                return true;
+            }
+            if (field.dynamicFormFields?.[value]) {
+                if (field.dynamicFormFields[value].some(checkField)) {
+                    return true;
+                }
+            }
         }
         if (Array.isArray(value)) {
             return value.length === 0;
         }
         return false;
-    });
+    };
+
+    return formFields.some(checkField);
 }
 
 export function shouldRunExternalFormValidation({

--- a/workspaces/ballerina/ballerina-side-panel/src/components/Form/utils.ts
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/Form/utils.ts
@@ -60,7 +60,9 @@ export function hasIncompleteRequiredFormFields(
         }
 
         const value = values[field.key];
-        const hasValue = value !== undefined && value !== null && !(typeof value === "string" && value.trim() === "");
+        const isEmptyString = typeof value === "string" && value.trim() === "";
+        const isEmptyArray = Array.isArray(value) && value.length === 0;
+        const hasValue = value !== undefined && value !== null && !isEmptyString && !isEmptyArray;
 
         if (field.optional && !hasValue) {
             return false;
@@ -75,9 +77,6 @@ export function hasIncompleteRequiredFormFields(
                     return true;
                 }
             }
-        }
-        if (Array.isArray(value)) {
-            return value.length === 0;
         }
         return false;
     };

--- a/workspaces/ballerina/ballerina-side-panel/test/formValidationUtils.test.mjs
+++ b/workspaces/ballerina/ballerina-side-panel/test/formValidationUtils.test.mjs
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { shouldRunExternalFormValidation } from "../lib/components/Form/utils.js";
+import { hasIncompleteRequiredFormFields, shouldRunExternalFormValidation } from "../lib/components/Form/utils.js";
 
 test("shouldRunExternalFormValidation blocks external validation when local form state is invalid", () => {
     assert.equal(
@@ -40,5 +40,117 @@ test("shouldRunExternalFormValidation permits external validation when local val
             errors: {},
         }),
         true
+    );
+});
+
+test("shouldRunExternalFormValidation blocks external validation when required fields are incomplete", () => {
+    assert.equal(
+        shouldRunExternalFormValidation({
+            formStateIsValid: true,
+            errors: {},
+            hasIncompleteRequiredFields: true,
+        }),
+        false
+    );
+});
+
+test("hasIncompleteRequiredFormFields returns true when a required string field is empty", () => {
+    assert.equal(
+        hasIncompleteRequiredFormFields(
+            [
+                {
+                    key: "variable",
+                    optional: false,
+                    hidden: false,
+                    enabled: true,
+                },
+            ],
+            { variable: "" }
+        ),
+        true
+    );
+});
+
+test("hasIncompleteRequiredFormFields returns true when a required string field is whitespace", () => {
+    assert.equal(
+        hasIncompleteRequiredFormFields(
+            [
+                {
+                    key: "expression",
+                    optional: false,
+                    hidden: false,
+                    enabled: true,
+                },
+            ],
+            { expression: "   " }
+        ),
+        true
+    );
+});
+
+test("hasIncompleteRequiredFormFields returns true when a required array field is empty", () => {
+    assert.equal(
+        hasIncompleteRequiredFormFields(
+            [
+                {
+                    key: "items",
+                    optional: false,
+                    hidden: false,
+                    enabled: true,
+                },
+            ],
+            { items: [] }
+        ),
+        true
+    );
+});
+
+test("hasIncompleteRequiredFormFields ignores optional, hidden, and disabled empty fields", () => {
+    assert.equal(
+        hasIncompleteRequiredFormFields(
+            [
+                {
+                    key: "optionalValue",
+                    optional: true,
+                    hidden: false,
+                    enabled: true,
+                },
+                {
+                    key: "hiddenValue",
+                    optional: false,
+                    hidden: true,
+                    enabled: true,
+                },
+                {
+                    key: "disabledValue",
+                    optional: false,
+                    hidden: false,
+                    enabled: false,
+                },
+            ],
+            {
+                optionalValue: "",
+                hiddenValue: "",
+                disabledValue: "",
+            }
+        ),
+        false
+    );
+});
+
+test("hasIncompleteRequiredFormFields returns false when required visible fields are filled", () => {
+    assert.equal(
+        hasIncompleteRequiredFormFields(
+            [
+                {
+                    key: "variable",
+                    optional: false,
+                    hidden: false,
+                    enabled: true,
+                },
+            ],
+            { variable: "var1" }
+        ),
+        false
     );
 });

--- a/workspaces/ballerina/ballerina-side-panel/test/formValidationUtils.test.mjs
+++ b/workspaces/ballerina/ballerina-side-panel/test/formValidationUtils.test.mjs
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { shouldRunExternalFormValidation } from "../lib/components/Form/utils.js";
+
+test("shouldRunExternalFormValidation blocks external validation when local form state is invalid", () => {
+    assert.equal(
+        shouldRunExternalFormValidation({
+            formStateIsValid: false,
+            errors: {
+                name: {
+                    type: "required",
+                    message: "Name is required",
+                },
+            },
+        }),
+        false
+    );
+});
+
+test("shouldRunExternalFormValidation blocks external validation when local errors exist", () => {
+    assert.equal(
+        shouldRunExternalFormValidation({
+            formStateIsValid: true,
+            errors: {
+                path: {
+                    type: "pattern",
+                    message: "Invalid path",
+                },
+            },
+        }),
+        false
+    );
+});
+
+test("shouldRunExternalFormValidation permits external validation when local validation is clean", () => {
+    assert.equal(
+        shouldRunExternalFormValidation({
+            formStateIsValid: true,
+            errors: {},
+        }),
+        true
+    );
+});

--- a/workspaces/ballerina/ballerina-side-panel/test/formValidationUtils.test.mjs
+++ b/workspaces/ballerina/ballerina-side-panel/test/formValidationUtils.test.mjs
@@ -336,3 +336,57 @@ test("hasIncompleteRequiredFormFields returns false when nested dynamic child fi
         false
     );
 });
+
+test("hasIncompleteRequiredFormFields validates dynamic child fields when optional parent has a value", () => {
+    assert.equal(
+        hasIncompleteRequiredFormFields(
+            [
+                {
+                    key: "optionalSelector",
+                    optional: true,
+                    hidden: false,
+                    enabled: true,
+                    dynamicFormFields: {
+                        selected: [
+                            {
+                                key: "requiredChild",
+                                optional: false,
+                                hidden: false,
+                                enabled: true,
+                            },
+                        ],
+                    },
+                },
+            ],
+            { optionalSelector: "selected", requiredChild: "" }
+        ),
+        true
+    );
+});
+
+test("hasIncompleteRequiredFormFields skips optional parent with no value even if dynamic child fields exist", () => {
+    assert.equal(
+        hasIncompleteRequiredFormFields(
+            [
+                {
+                    key: "optionalSelector",
+                    optional: true,
+                    hidden: false,
+                    enabled: true,
+                    dynamicFormFields: {
+                        selected: [
+                            {
+                                key: "requiredChild",
+                                optional: false,
+                                hidden: false,
+                                enabled: true,
+                            },
+                        ],
+                    },
+                },
+            ],
+            { optionalSelector: "", requiredChild: "" }
+        ),
+        false
+    );
+});

--- a/workspaces/ballerina/ballerina-side-panel/test/formValidationUtils.test.mjs
+++ b/workspaces/ballerina/ballerina-side-panel/test/formValidationUtils.test.mjs
@@ -154,3 +154,185 @@ test("hasIncompleteRequiredFormFields returns false when required visible fields
         false
     );
 });
+
+test("hasIncompleteRequiredFormFields returns true when dynamic child field is empty", () => {
+    assert.equal(
+        hasIncompleteRequiredFormFields(
+            [
+                {
+                    key: "connectionType",
+                    optional: false,
+                    hidden: false,
+                    enabled: true,
+                    dynamicFormFields: {
+                        HTTP: [
+                            {
+                                key: "url",
+                                optional: false,
+                                hidden: false,
+                                enabled: true,
+                            },
+                        ],
+                    },
+                },
+            ],
+            { connectionType: "HTTP", url: "" }
+        ),
+        true
+    );
+});
+
+test("hasIncompleteRequiredFormFields returns false when dynamic child fields are filled", () => {
+    assert.equal(
+        hasIncompleteRequiredFormFields(
+            [
+                {
+                    key: "connectionType",
+                    optional: false,
+                    hidden: false,
+                    enabled: true,
+                    dynamicFormFields: {
+                        HTTP: [
+                            {
+                                key: "url",
+                                optional: false,
+                                hidden: false,
+                                enabled: true,
+                            },
+                        ],
+                    },
+                },
+            ],
+            { connectionType: "HTTP", url: "https://example.com" }
+        ),
+        false
+    );
+});
+
+test("hasIncompleteRequiredFormFields ignores dynamic child fields when parent is empty", () => {
+    assert.equal(
+        hasIncompleteRequiredFormFields(
+            [
+                {
+                    key: "connectionType",
+                    optional: false,
+                    hidden: false,
+                    enabled: true,
+                    dynamicFormFields: {
+                        HTTP: [
+                            {
+                                key: "url",
+                                optional: false,
+                                hidden: false,
+                                enabled: true,
+                            },
+                        ],
+                    },
+                },
+            ],
+            { connectionType: "", url: "" }
+        ),
+        true
+    );
+});
+
+test("hasIncompleteRequiredFormFields ignores dynamic child fields when parent selection has no dynamic fields", () => {
+    assert.equal(
+        hasIncompleteRequiredFormFields(
+            [
+                {
+                    key: "connectionType",
+                    optional: false,
+                    hidden: false,
+                    enabled: true,
+                    dynamicFormFields: {
+                        HTTP: [
+                            {
+                                key: "url",
+                                optional: false,
+                                hidden: false,
+                                enabled: true,
+                            },
+                        ],
+                    },
+                },
+            ],
+            { connectionType: "FILE", url: "" }
+        ),
+        false
+    );
+});
+
+test("hasIncompleteRequiredFormFields returns true when nested dynamic child field is empty", () => {
+    assert.equal(
+        hasIncompleteRequiredFormFields(
+            [
+                {
+                    key: "connectionType",
+                    optional: false,
+                    hidden: false,
+                    enabled: true,
+                    dynamicFormFields: {
+                        HTTP: [
+                            {
+                                key: "authType",
+                                optional: false,
+                                hidden: false,
+                                enabled: true,
+                                dynamicFormFields: {
+                                    OAuth: [
+                                        {
+                                            key: "token",
+                                            optional: false,
+                                            hidden: false,
+                                            enabled: true,
+                                        },
+                                    ],
+                                },
+                            },
+                        ],
+                    },
+                },
+            ],
+            { connectionType: "HTTP", authType: "OAuth", token: "" }
+        ),
+        true
+    );
+});
+
+test("hasIncompleteRequiredFormFields returns false when nested dynamic child fields are filled", () => {
+    assert.equal(
+        hasIncompleteRequiredFormFields(
+            [
+                {
+                    key: "connectionType",
+                    optional: false,
+                    hidden: false,
+                    enabled: true,
+                    dynamicFormFields: {
+                        HTTP: [
+                            {
+                                key: "authType",
+                                optional: false,
+                                hidden: false,
+                                enabled: true,
+                                dynamicFormFields: {
+                                    OAuth: [
+                                        {
+                                            key: "token",
+                                            optional: false,
+                                            hidden: false,
+                                            enabled: true,
+                                        },
+                                    ],
+                                },
+                            },
+                        ],
+                    },
+                },
+            ],
+            { connectionType: "HTTP", authType: "OAuth", token: "abc123" }
+        ),
+        false
+    );
+});

--- a/workspaces/ballerina/ballerina-side-panel/test/formValidationUtils.test.mjs
+++ b/workspaces/ballerina/ballerina-side-panel/test/formValidationUtils.test.mjs
@@ -105,6 +105,23 @@ test("hasIncompleteRequiredFormFields returns true when a required array field i
     );
 });
 
+test("hasIncompleteRequiredFormFields ignores optional empty array fields", () => {
+    assert.equal(
+        hasIncompleteRequiredFormFields(
+            [
+                {
+                    key: "items",
+                    optional: true,
+                    hidden: false,
+                    enabled: true,
+                },
+            ],
+            { items: [] }
+        ),
+        false
+    );
+});
+
 test("hasIncompleteRequiredFormFields ignores optional, hidden, and disabled empty fields", () => {
     assert.equal(
         hasIncompleteRequiredFormFields(

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FlowNodeForm/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FlowNodeForm/index.tsx
@@ -1008,15 +1008,32 @@ export const FlowNodeForm = forwardRef<FormExpressionEditorRef, FlowNodeFormProp
     };
 
     const getFormWithDiagnostics = async (node: FlowNode): Promise<FlowNode | null> => {
-        try {
-            // Update node with new line range only for creation forms (not edit forms)
-            const nodeToProcess = props.editForm
-                ? node
-                : createNodeWithUpdatedLineRange(node, targetLineRange);
-            const response = await rpcClient.getBIDiagramRpcClient().getFormDiagnostics({
+        // Update node with new line range only for creation forms (not edit forms)
+        const nodeToProcess = props.editForm
+            ? node
+            : createNodeWithUpdatedLineRange(node, targetLineRange);
+
+        const issueRequest = () =>
+            rpcClient.getBIDiagramRpcClient().getFormDiagnostics({
                 flowNode: nodeToProcess,
                 filePath: fileName
             });
+
+        const isDebounceCancellation = (resp: any) =>
+            !resp?.flowNode &&
+            typeof resp?.errorMsg === "string" &&
+            resp.errorMsg.includes("Debounced");
+
+        try {
+            let response = await issueRequest();
+            // The backend debounces concurrent diagnostics requests; the older one resolves
+            // with a cancellation envelope. Retry past the debounce window so save sees the
+            // real verdict instead of treating cancellation as "no diagnostics".
+            let retries = 2;
+            while (isDebounceCancellation(response) && retries-- > 0) {
+                await new Promise(resolve => setTimeout(resolve, 300));
+                response = await issueRequest();
+            }
 
             if (response.flowNode) {
                 return response.flowNode as FlowNode;


### PR DESCRIPTION
## Summary
- Prevent full form diagnostics from running while required fields are incomplete.
- Keep top-level form diagnostics clearing on user input.
- Add regression coverage for the local validation gate.
- **Fix form validation race conditions**: Handle concurrent diagnostics requests and RHF state sync

Fixes wso2/product-integrator#1297, wso2/product-integrator#1150

https://github.com/user-attachments/assets/07c9d2e8-31b3-45f6-8051-07349742bdf2

## Technical Details

### Race Condition Fixes
Two validation race conditions were discovered and fixed during testing:

1. **Diagnostics Request Cancellation (FlowNodeForm)**
   - When blur and submit events fire simultaneously, the backend's `DiagnosticsDebouncer` cancels the first request with a `CancellationException: Debounced by a new diagnostics request` envelope
   - The frontend was treating this cancellation response as "no diagnostics", allowing invalid input (e.g., `123` for a string field) to be saved despite type mismatch
   - **Fix**: Detect cancellation envelopes and retry after 300ms to retrieve the real diagnostics verdict past the debounce window

2. **RHF formState Sync After Error Clearing (Form)**
   - `clearErrors()` removes error entries from RHF's errors object but does not recompute `formState.isValid`
   - After expression diagnostics clear (e.g., fixing `123` → `"123"`), the errors array becomes empty but `formState.isValid` remained false, keeping Save disabled
   - **Fix**: Call `trigger(key)` immediately after `clearErrors(key)` to force RHF validation and sync `formState.isValid`

## Test plan
- pnpm --dir workspaces/ballerina/ballerina-side-panel test
- rush build -o @wso2/ballerina-side-panel

## Notes
The visualizer build is currently blocked by unrelated TypeScript errors in existing files outside this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * External form validation and blur callbacks are now blocked until required fields are complete and local validation is clean; validity reporting and Save enablement respect incomplete required fields.
  * Form diagnostics are now debounce-cancellation aware with retries to reduce validation race conditions; expression-diagnostic clearing keeps Save accuracy in sync.
* **Tests**
  * Added comprehensive tests for required-field completeness and external-validation gating.
* **Chores**
  * Test script updated to run the new validation tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->