### PR TITLE
Fix  cursor being disabled when hovering over text area editor

### DIFF
--- a/workspaces/common-libs/ui-toolkit/src/components/TextArea/TextArea.tsx
+++ b/workspaces/common-libs/ui-toolkit/src/components/TextArea/TextArea.tsx
@@ -37,6 +37,8 @@ export interface TextAreaProps extends ComponentProps<"textarea"> {
     autoFocus?: boolean;
     icon?: IconProps;
     required?: boolean;
+    readOnly?: boolean;
+    readonly?: boolean;
     errorMsg?: string;
     placeholder?: string;
     cols?: number;
@@ -71,8 +73,10 @@ const LabelContainer = styled.div<ContainerProps>`
 export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
     function TextArea(props: TextAreaProps, ref: React.ForwardedRef<HTMLTextAreaElement>) {
         const { label, id, className, autoFocus, required, validationMessage, cols = 40,
-            rows, resize, errorMsg, sx, onTextChange, labelAdornment, icon, "aria-label": ariaLabel, disabled, ...rest
+            rows, resize, errorMsg, sx, onTextChange, labelAdornment, icon, "aria-label": ariaLabel, disabled,
+            readOnly, readonly, ...rest
         } = props;
+        const resolvedReadOnly = readOnly ?? readonly;
 
         const { iconComponent, onClick: iconClick } = icon || {};
 
@@ -93,6 +97,7 @@ export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
                     ref={ref}
                     autoFocus={autoFocus}
                     disabled={disabled || undefined}
+                    readonly={resolvedReadOnly || undefined}
                     validationMessage={validationMessage}
                     cols={cols}
                     rows={rows}


### PR DESCRIPTION
## Purpose

Fixes https://github.com/wso2/product-integrator/issues/1301

This PR fixes the cursor showing up as disabled when hovering over a text area editor.

Before:

https://github.com/user-attachments/assets/021175cf-aaa8-4a1c-b7c5-323514f24aec

After:

https://github.com/user-attachments/assets/be70f017-c541-4afd-b9f5-cb6fe37b2903


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TextArea component now supports read-only mode via `readOnly` or `readonly` props to prevent editing while maintaining content visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->