### PR TITLE
add loader for expression editor

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/components/ChipExpressionEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/components/ChipExpressionEditor.tsx
@@ -46,9 +46,9 @@ import {
 import { correctTokenStreamPositions, normalizeEditorValue } from "../utils";
 import { history } from "@codemirror/commands";
 import { autocompletion } from "@codemirror/autocomplete";
-import { FloatingButtonContainer, FloatingToggleButton, ChipEditorContainer } from "../styles";
+import { FloatingButtonContainer, FloatingToggleButton, ChipEditorContainer, LoadingOverlay, LoadingPlaceholder } from "../styles";
 import { HelperpaneOnChangeOptions } from "../../../../Form/types";
-import { CompletionItem, FnSignatureDocumentation, HelperPaneHeight } from "@wso2/ui-toolkit";
+import { CompletionItem, FnSignatureDocumentation, HelperPaneHeight, ProgressRing } from "@wso2/ui-toolkit";
 import { CloseHelperIcon, ExpandIcon, MinimizeIcon, OpenHelperIcon } from "./FloatingButtonIcons";
 import { LineRange } from "@wso2/ballerina-core";
 import { HelperPaneToggleButton } from "./HelperPaneToggleButton";
@@ -104,6 +104,15 @@ export type ChipExpressionEditorComponentProps = {
     placeholder?: string;
 }
 
+function resolveInitialValueResolving(
+    value: string | undefined,
+    configuration: ChipExpressionEditorDefaultConfiguration
+): boolean {
+    if (!value) return false;
+    const deserialized = configuration.deserializeValue(value);
+    return normalizeEditorValue(deserialized) !== normalizeEditorValue(value);
+}
+
 export const ChipExpressionEditorComponent = (props: ChipExpressionEditorComponentProps) => {
     const { configuration = new ChipExpressionEditorConfig() } = props;
     const editorRef = useRef<HTMLDivElement>(null);
@@ -111,6 +120,9 @@ export const ChipExpressionEditorComponent = (props: ChipExpressionEditorCompone
     const fieldContainerRef = useRef<HTMLDivElement>(null);
     const viewRef = useRef<EditorView | null>(null);
     const [isTokenUpdateScheduled, setIsTokenUpdateScheduled] = useState(true);
+    const [isValueResolving, setIsValueResolving] = useState(
+        () => resolveInitialValueResolving(props.value, configuration)
+    );
     const completionsRef = useRef<CompletionItem[]>(props.completions);
     const helperPaneToggleButtonRef = useRef<HTMLButtonElement>(null);
     const completionsFetchScheduledRef = useRef<boolean>(false);
@@ -393,7 +405,10 @@ export const ChipExpressionEditorComponent = (props: ChipExpressionEditorCompone
             const currentDoc = viewRef.current!.state.doc.toString();
             const isExternalUpdate = serializedValue !== currentDoc;
 
-            if (!isTokenUpdateScheduled && !isExternalUpdate) return;
+            if (!isTokenUpdateScheduled && !isExternalUpdate) {
+                setIsValueResolving(false);
+                return;
+            }
 
             const startLine = props.targetLineRange?.startLine;
             const tokenStream = await expressionEditorRpcManager?.getExpressionTokens(
@@ -423,7 +438,7 @@ export const ChipExpressionEditorComponent = (props: ChipExpressionEditorCompone
                 ...(changes && { changes }),
                 ...(annotations.length > 0 && { annotations }),
             });
-
+            setIsValueResolving(false);
         };
         updateEditorState();
     }, [props.value, props.fileName, props.targetLineRange?.startLine, isTokenUpdateScheduled]);
@@ -487,6 +502,12 @@ export const ChipExpressionEditorComponent = (props: ChipExpressionEditorCompone
                         width: '100%',
                         height: '100%'
                     }} />
+                    {isValueResolving && (
+                        <LoadingOverlay>
+                            <ProgressRing sx={{ height: 16, width: 16 }} color="var(--vscode-input-placeholderForeground)" />
+                            <LoadingPlaceholder>Loading...</LoadingPlaceholder>
+                        </LoadingOverlay>
+                    )}
                     {helperPaneState.isOpen && configuration.showHelperPane() &&
                         <HelperPane
                             ref={helperPaneRef}

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/styles.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/styles.tsx
@@ -355,3 +355,24 @@ export const SkeletonLoader = styled.div`
     pointer-events: none;
     animation: ${loading} 1s infinite alternate;
 `;
+
+export const LoadingOverlay = styled.div`
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 0 8px;
+    background: var(--vscode-input-background);
+    border: 1px solid var(--vscode-dropdown-border);
+    z-index: 1000;
+    pointer-events: none;
+`;
+
+export const LoadingPlaceholder = styled.span`
+    color: var(--vscode-input-placeholderForeground);
+    font-size: 13px;
+`;


### PR DESCRIPTION
## Purpose
>  Expression editors in text mode briefly flash double quotes (e.g., "hello") when a form panel is opened. This occurs because the raw Ballerina string literal value is written directly into the CodeMirror editor
  on initialization, and the value normalization cycle that strips the quotes runs asynchronously — creating a visible flash before the correct display value is rendered.
  
  Resolves: https://github.com/wso2/product-integrator/issues/688

## Goals
  > Eliminate the double-quote flash in text mode expression editors when a panel is opened.
  > Show a loading indicator while the editor value is being resolved, consistent with the loading pattern used in ConnectionSelectEditor.
  > Ensure the loading indicator is only dismissed after the editor displays the correctly resolved value.Ï
  
## Approach
>  A isValueResolving state is added to ChipExpressionEditorComponent, initialized lazily on mount: if the incoming value requires normalization (i.e., deserializeValue(value) !== value), the state starts as true.
  While resolving, a LoadingOverlay — containing a ProgressRing spinner and "Loading..." text — is rendered as an absolute overlay on top of the CodeMirror editor. The overlay style and pattern match the existing
  loader in ConnectionSelectEditor (ProgressRing + placeholder-colored text).
  
  

https://github.com/user-attachments/assets/61b87047-1c92-4182-89a8-d02b49730242



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a loading overlay with a progress indicator in the expression editor that displays during value resolution, showing "Loading..." feedback while processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->