### PR TITLE
Add download Ballerina distribution option to the MI Extension

### DIFF
--- a/workspaces/mi/mi-extension/.env.example
+++ b/workspaces/mi/mi-extension/.env.example
@@ -26,5 +26,7 @@ MI_SAMPLE_ICONS_GITHUB_URL=https://raw.githubusercontent.com/wso2/integration-st
 MI_UPDATE_VERSION_CHECK_URL=https://mi-distribution.wso2.com/versions.json
 # Adoptium API base URL for JDK release metadata.
 ADOPTIUM_API_BASE_URL=https://api.adoptium.net/v3/assets/feature_releases
+# Base URL for Ballerina distribution GitHub releases downloads.
+BALLERINA_DIST_BASE_URL=https://github.com/ballerina-platform/ballerina-distribution/releases/download
 # Copilot backend root URL for non-model API operations.
 COPILOT_ROOT_URL=https://7eff1239-64bb-4663-b256-30a00d187a5c-prod.e1-us-east-azure.choreoapis.dev/copilot

--- a/workspaces/mi/mi-extension/src/constants/index.ts
+++ b/workspaces/mi/mi-extension/src/constants/index.ts
@@ -118,8 +118,6 @@ export const COMMANDS = {
     MANAGE_REGISTRY_PROPERTIES_COMMAND: 'MI.manage-registry-property',
     CONFIGURE_DEFAULT_MODEL: 'MI.configureDefaultModelProvider',
 
-    BI_EXTENSION: 'WSO2.ballerina-integrator',
-    BI_OPEN_COMMAND: 'ballerina.open.bi.welcome',
     INSTALL_EXTENSION_COMMAND: 'workbench.extensions.installExtension',
     RELOAD_WINDOW: 'workbench.action.reloadWindow'
 };
@@ -136,6 +134,8 @@ export const MVN_COMMANDS = {
 }
 
 export const DEFAULT_PROJECT_VERSION = "1.0.0";
+
+export const BALLERINA_VERSION = "2201.13.3";
 
 export const READONLY_MAPPING_FUNCTION_NAME = "mapFunction";
 

--- a/workspaces/mi/mi-extension/src/test/e2e-playwright-tests/components/ArtifactTest/BallerinaModule.ts
+++ b/workspaces/mi/mi-extension/src/test/e2e-playwright-tests/components/ArtifactTest/BallerinaModule.ts
@@ -21,7 +21,7 @@ import { switchToIFrame } from "@wso2/playwright-vscode-tester";
 import { ProjectExplorer } from "../ProjectExplorer";
 import { AddArtifact } from "../AddArtifact";
 import { Overview } from "../Overview";
-import { clearNotificationAlerts, page, showNotifications } from "../../Utils";
+import { clearNotificationAlerts, page } from "../../Utils";
 import { ServiceDesigner } from "../ServiceDesigner";
 import { Form } from '../Form';
 import { Diagram } from '../Diagram';
@@ -93,37 +93,31 @@ export class BallerinaModule {
         const currentPage = this._page;
         await currentPage.getByLabel('Build Ballerina Module').click();
         console.log("Clicked on Build Ballerina Module button");
-        const successNotification = currentPage.getByText('Ballerina module build successful', { exact: true })
-        const errorNotification = currentPage.getByText('Ballerina not found. Please download Ballerina and try again.', { exact: true })
-        await Promise.race([
-            successNotification.waitFor({ state: 'visible', timeout: 40000 }),
-            errorNotification.waitFor({ state: 'visible', timeout: 40000 })
+
+        const successNotification = currentPage.getByText('Ballerina module build successful', { exact: true });
+        const downloadButton = currentPage.getByRole('button', { name: 'Download Now' });
+
+        const result = await Promise.race([
+            successNotification.waitFor({ state: 'visible', timeout: 40000 }).then(() => 'success'),
+            downloadButton.waitFor({ state: 'visible', timeout: 40000 }).then(() => 'download')
         ]);
 
-        if (await errorNotification.isVisible()) {
-            await showNotifications();
-            await currentPage.getByRole('button', { name: 'Install Now' }).click();
-            console.log("Clicked on Install Now button to install Ballerina");
-            await clearNotificationAlerts();
-            console.log("Waiting for Ballerina download to complete");
-            const webview = await switchToIFrame('WSO2 Integrator: BI', this._page, 120000);
-            console.log("Switching to WSO2 Integrator: BI iframe");
-            if (!webview) {
-                throw new Error("Failed to switch to the Ballerina Module Form iframe");
-            }
-            await webview.locator('vscode-button').locator('div:has-text("Set up Ballerina distribution")').click();
-            console.log("Downloading Ballerina");
-            const restartButton = webview.locator('vscode-button').locator('div:has-text("Restart VS Code")');
-            await expect(restartButton).toBeVisible({ timeout: 600000 });
-            console.log("Ballerina download completed");
-            await currentPage.getByRole('tab', { name: 'WSO2 Integrator: BI', exact: true }).getByLabel('Close').click();
+        if (result === 'download') {
+            await downloadButton.click();
+            console.log("Clicked Download Now to install Ballerina");
+            const installSuccessNotification = currentPage.getByText(
+                'Ballerina has been installed successfully. Please retrigger the build to continue.',
+                { exact: true }
+            );
+            await expect(installSuccessNotification).toBeVisible({ timeout: 600000 });
+            console.log("Ballerina installed successfully");
             await clearNotificationAlerts();
             await currentPage.getByLabel('Build Ballerina Module').click();
-            console.log("Clicked on Build Ballerina Module button after installing Ballerina");
-            const updatedNotification = currentPage.getByText('Ballerina module build successful', { exact: true });
-            await expect(updatedNotification).toBeVisible({ timeout: 120000 });
-            console.log("Ballerina module build successful");
+            console.log("Retriggering build after Ballerina installation");
+            await expect(successNotification).toBeVisible({ timeout: 120000 });
         }
+
+        console.log("Ballerina module build successful");
         await clearNotificationAlerts();
 
         await currentPage.getByRole('tab', { name: `${moduleName}-module.bal` }).getByLabel('Close').click();
@@ -167,7 +161,7 @@ export class BallerinaModule {
         const diagram = new Diagram(page.page, 'Resource');
         await diagram.init();
         await diagram.refreshBallerinaModule(moduleName);
-        const notificationAlert = await page.page.getByText('Ballerina module build successful', { exact: true })
+        const notificationAlert = page.page.getByText('Ballerina module build successful', { exact: true })
         await expect(notificationAlert).toBeVisible({ timeout: 40000 });
     }
 

--- a/workspaces/mi/mi-extension/src/util/onboardingUtils.ts
+++ b/workspaces/mi/mi-extension/src/util/onboardingUtils.ts
@@ -25,7 +25,7 @@ import { downloadWithProgress, extractWithProgress, selectFolderDialog } from '.
 import { extension } from '../MIExtensionContext';
 import { copyMavenWrapper } from '.';
 import { SELECTED_JAVA_HOME, SELECTED_SERVER_PATH } from '../debugger/constants';
-import { COMMANDS } from '../constants';
+import { COMMANDS, BALLERINA_VERSION } from '../constants';
 import { SetPathRequest, PathDetailsResponse, SetupDetails } from '@wso2/mi-core';
 import { parseStringPromise } from 'xml2js';
 import { LATEST_CAR_PLUGIN_VERSION } from './templates';
@@ -55,6 +55,7 @@ const miDownloadUrls: { [key: string]: string } = {
 
 export const miUpdateVersionCheckUrl: string = process.env.MI_UPDATE_VERSION_CHECK_URL as string;
 export const ADOPTIUM_API_BASE_URL: string = process.env.ADOPTIUM_API_BASE_URL as string;
+export const BALLERINA_DIST_BASE_URL: string = process.env.BALLERINA_DIST_BASE_URL as string;
 
 export const CACHED_FOLDER = path.join(os.homedir(), '.wso2-mi');
 export const INTEGRATION_PROJECT_DEPENDENCIES_DIR = 'integration-project-dependencies';
@@ -1089,6 +1090,25 @@ export function getDefaultProjectPath(): string {
 
 export async function buildBallerinaModule(projectPath: string) {
     const MIN_REQUIRED_UPDATE = 13;
+
+    // Try the bundled Ballerina distribution first when running inside the WSO2 Integrator IDE.
+    if (process.env.WSO2_INTEGRATOR_RUNTIME === 'true') {
+        const wiBalHome = process.env.WSO2_INTEGRATOR_BALLERINA_HOME;
+        if (wiBalHome) {
+            const balExecutable = process.platform === 'win32' ? 'bal.bat' : 'bal';
+            const balBin = path.join(wiBalHome, 'bin', balExecutable);
+            if (fs.existsSync(balBin)) {
+                console.log('Attempting to use bundled Ballerina distribution at:', balBin);
+                try {
+                    await runBallerinaBuildsWithProgress(projectPath, false, wiBalHome);
+                    return;
+                } catch {
+                    // Fall through to the standard resolution below.
+                }
+            }
+        }
+    }
+
     const isBallerinaInstalled = await isBallerinaAvailableGlobally();
     const isLocalBallerina = fs.existsSync(path.join(os.homedir(), '.ballerina', 'ballerina-home', 'bin', process.platform === 'win32' ? 'bal.bat' : 'bal'));
 
@@ -1123,12 +1143,11 @@ export async function buildBallerinaModule(projectPath: string) {
 
         await runBallerinaBuildsWithProgress(projectPath, isBallerinaInstalled);
     } else {
-        vscode.window.showErrorMessage('Ballerina not found. Please download Ballerina and try again.');
-        showExtensionPrompt();
+        await downloadAndInstallBallerina();
     }
 }
 
-async function runBallerinaBuildsWithProgress(projectPath: string, isBallerinaInstalled: boolean = false) {
+async function runBallerinaBuildsWithProgress(projectPath: string, isBallerinaInstalled: boolean = false, inbuiltBalHome?: string) {
     await vscode.window.withProgress(
         {
             location: vscode.ProgressLocation.Notification,
@@ -1141,9 +1160,9 @@ async function runBallerinaBuildsWithProgress(projectPath: string, isBallerinaIn
             // Handle paths for different OS
             const isWindows = process.platform === 'win32';
             console.debug('[Ballerina Build] OS Platform:', process.platform);
-            
-            // Normalize paths for proper handling
-            const balHome = path.normalize(path.join(os.homedir(), '.ballerina', 'ballerina-home', 'bin'));
+
+            // Use inbuilt ballerina home if provided (WI runtime), otherwise fall back to the local installation.
+            const balHome = path.normalize(path.join(inbuiltBalHome ?? path.join(os.homedir(), '.ballerina', 'ballerina-home'), 'bin'));
             console.debug('[Ballerina Build] Ballerina Home:', balHome);
             
             // Use appropriate executable for the platform
@@ -1159,7 +1178,7 @@ async function runBallerinaBuildsWithProgress(projectPath: string, isBallerinaIn
                 return;
             }
 
-            // Properly quote paths for Windows, ensuring spaces are handled correctly
+            // Quote paths on all platforms to handle spaces in directory names
             const quotedProjectPath = isWindows ? `"${projectPath.replace(/"/g, '""')}"` : projectPath;
             const quotedBalCommand = isWindows ? `"${balCommand.replace(/"/g, '""')}"` : balCommand;
             console.debug('[Ballerina Build] Quoted Project Path:', quotedProjectPath);
@@ -1193,7 +1212,7 @@ async function runBallerinaBuildsWithProgress(projectPath: string, isBallerinaIn
                 }
             }
 
-            function onError(data: any) {
+            async function onError(data: any) {
                 if (data) {
                     // Convert data to string with simplified logic
                     const errorMessage: string = data?.toString?.() ?? String(data);
@@ -1225,8 +1244,7 @@ async function runBallerinaBuildsWithProgress(projectPath: string, isBallerinaIn
                         if (errorMessage.includes('EPERM') || errorMessage.includes('EACCES')) {
                             vscode.window.showErrorMessage("Permission error. Please run VS Code with administrator privileges.");
                         } else {
-                            vscode.window.showErrorMessage("Ballerina not found. Please install and setup the Ballerina Extension and try again.");
-                            showExtensionPrompt();
+                            await downloadAndInstallBallerina();
                         }
                     } else {
                         console.error('[Ballerina Build] Unexpected error:', errorMessage);
@@ -1251,7 +1269,7 @@ async function runBallerinaBuildsWithProgress(projectPath: string, isBallerinaIn
                 const isWindows = process.platform === 'win32';
                 const moduleGenCommand = isBallerinaInstalled
                     ? (isWindows ? 'bal.bat migen module' : 'bal migen module')
-                    : `${path.join(balHome, isWindows ? 'bal.bat' : 'bal')} migen module`;
+                    : `"${path.join(balHome, isWindows ? 'bal.bat' : 'bal').replace(/"/g, isWindows ? '""' : '\\"')}" migen module`;
 
                 console.debug('Running module gen command:', moduleGenCommand, 'in directory:', projectPath);
                 runBasicCommand(moduleGenCommand, projectPath,
@@ -1337,16 +1355,83 @@ async function runBallerinaBuildsWithProgress(projectPath: string, isBallerinaIn
     );
 }
 
-async function showExtensionPrompt() {
-    vscode.window.showInformationMessage(
-        'Ballerina distribution is required to build the Ballerina module. Install and setup the Ballerina Extension from the Visual Studio Code Marketplace.',
-        'Install Now'
-    ).then(async (selection) => {
-        if (selection === 'Install Now') {
-            await vscode.commands.executeCommand(COMMANDS.INSTALL_EXTENSION_COMMAND, COMMANDS.BI_EXTENSION);
-            await vscode.commands.executeCommand(COMMANDS.BI_OPEN_COMMAND);
+
+function getBallerinaOsSuffix(): string {
+    const platform = os.platform();
+    const arch = os.arch();
+    if (platform === 'darwin') {
+        return arch === 'arm64' ? 'macos-arm' : 'macos';
+    } else if (platform === 'linux') {
+        return arch === 'arm64' ? 'linux-arm' : 'linux';
+    } else if (platform === 'win32') {
+        return 'windows';
+    }
+    throw new Error(`Unsupported platform: ${platform} (${arch})`);
+}
+
+async function downloadAndInstallBallerina() {
+    const osSuffix = getBallerinaOsSuffix();
+    const ballerinaZipName = `ballerina-${BALLERINA_VERSION}-swan-lake-${osSuffix}.zip`;
+    const ballerinaDownloadUrl = `${BALLERINA_DIST_BASE_URL}/v${BALLERINA_VERSION}/${ballerinaZipName}`;
+    const ballerinaDir = path.join(os.homedir(), '.ballerina');
+    const ballerinaZipPath = path.join(ballerinaDir, ballerinaZipName);
+    const ballerinaHomePath = path.join(ballerinaDir, 'ballerina-home');
+
+    const selection = await vscode.window.showInformationMessage(
+        'Ballerina distribution is required to build the Ballerina module. Would you like to download and install Ballerina now?',
+        { modal: true },
+        'Download Now'
+    );
+
+    if (selection !== 'Download Now') {
+        return;
+    }
+
+    try {
+        if (!fs.existsSync(ballerinaDir)) {
+            fs.mkdirSync(ballerinaDir, { recursive: true });
         }
-    });
+        await downloadWithProgress('', ballerinaDownloadUrl, ballerinaZipPath, 'Downloading Ballerina');
+
+        if (!fs.existsSync(ballerinaZipPath)) {
+            vscode.window.showErrorMessage('Failed to download Ballerina. Please try again.');
+            return;
+        }
+
+        const beforeExtraction = new Set(fs.readdirSync(ballerinaDir));
+        await extractWithProgress(ballerinaZipPath, ballerinaDir, 'Extracting Ballerina');
+
+        const extractedEntry = fs.readdirSync(ballerinaDir).find(entry => {
+            if (beforeExtraction.has(entry)) {
+                return false;
+            }
+            return fs.statSync(path.join(ballerinaDir, entry)).isDirectory();
+        });
+
+        if (!extractedEntry) {
+            vscode.window.showErrorMessage('Failed to locate extracted Ballerina distribution.');
+            return;
+        }
+
+        if (fs.existsSync(ballerinaHomePath)) {
+            fs.rmSync(ballerinaHomePath, { recursive: true, force: true });
+        }
+        fs.renameSync(path.join(ballerinaDir, extractedEntry), ballerinaHomePath);
+
+        if (process.platform !== 'win32') {
+            child_process.spawnSync('chmod', ['-R', '+x', path.join(ballerinaHomePath, 'bin')]);
+            if (process.platform === 'darwin') {
+                child_process.spawnSync('xattr', ['-dr', 'com.apple.quarantine', ballerinaHomePath]);
+            }
+        }
+
+        fs.rmSync(ballerinaZipPath, { force: true });
+        vscode.window.showInformationMessage(
+            'Ballerina has been installed successfully. Please retrigger the build to continue.'
+        );
+    } catch (error) {
+        vscode.window.showErrorMessage(`Failed to install Ballerina: ${error instanceof Error ? error.message : String(error)}`);
+    }
 }
 
 async function isBallerinaAvailableGlobally(): Promise<boolean> {

--- a/workspaces/mi/mi-extension/src/util/onboardingUtils.ts
+++ b/workspaces/mi/mi-extension/src/util/onboardingUtils.ts
@@ -60,6 +60,10 @@ export const BALLERINA_DIST_BASE_URL: string = process.env.BALLERINA_DIST_BASE_U
 export const CACHED_FOLDER = path.join(os.homedir(), '.wso2-mi');
 export const INTEGRATION_PROJECT_DEPENDENCIES_DIR = 'integration-project-dependencies';
 
+export function isWso2IntegratorRuntime(): boolean {
+    return process.env.WSO2_INTEGRATOR_RUNTIME === 'true';
+}
+
 let ballerinaOutputChannel: vscode.OutputChannel | undefined;
 
 export async function setupEnvironment(projectUri: string, isOldProject: boolean): Promise<boolean> {
@@ -1092,7 +1096,7 @@ export async function buildBallerinaModule(projectPath: string) {
     const MIN_REQUIRED_UPDATE = 13;
 
     // Try the bundled Ballerina distribution first when running inside the WSO2 Integrator IDE.
-    if (process.env.WSO2_INTEGRATOR_RUNTIME === 'true') {
+    if (isWso2IntegratorRuntime()) {
         const wiBalHome = process.env.WSO2_INTEGRATOR_BALLERINA_HOME;
         if (wiBalHome) {
             const balExecutable = process.platform === 'win32' ? 'bal.bat' : 'bal';


### PR DESCRIPTION
This PR will remove the use of the BI extension and will download the Ballerina distribution within the MI extension itself. Yet the inbuilt Ballerina distribution will be used If the MI extension is opened within the WI IDE.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic Ballerina distribution download and installation capability with bundled runtime support.

* **Bug Fixes**
  * Improved Ballerina module build error handling with streamlined installation workflow.

* **Chores**
  * Removed BI extension-related commands.
  * Updated Ballerina version to 2201.13.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->