### PR TITLE
Fix clipboard issues in MCP Inspector extension

### DIFF
--- a/workspaces/mcp-inspector/mcp-inspector-extension/CHANGELOG.md
+++ b/workspaces/mcp-inspector/mcp-inspector-extension/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Theme and Accessibility Improvements** — Fixed MCP Inspector styling issues by improving VS Code theme color mapping, synchronizing dark/high-contrast mode behavior, and addressing text visibility problems in the Try It editor
+- **Clipboard Support** — Fixed copy, cut, and paste in the MCP Inspector by bridging clipboard access through the extension host so cross-origin iframe inputs and the Server Files / Server Entries copy buttons work reliably
 
 ## [0.7.3] - 2026-04-23
 

--- a/workspaces/mcp-inspector/mcp-inspector-extension/scripts/inject-theme.js
+++ b/workspaces/mcp-inspector/mcp-inspector-extension/scripts/inject-theme.js
@@ -75,12 +75,57 @@ const CUSTOM_CSS = `    <!-- Dynamic Theme Injection Placeholder -->
           }
         }
 
+        function getSelectionContext() {
+          var ae = document.activeElement;
+          if (ae && (ae.tagName === 'INPUT' || ae.tagName === 'TEXTAREA')) {
+            var s = ae.selectionStart;
+            var en = ae.selectionEnd;
+            if (s != null && en != null && s !== en) {
+              return { text: ae.value.slice(s, en), inInput: true, el: ae, start: s, end: en };
+            }
+          }
+          var sel = window.getSelection();
+          var selText = sel ? sel.toString() : '';
+          if (selText) return { text: selText, inInput: false };
+          return null;
+        }
+
+        function deleteSelection(ctx) {
+          if (!ctx) return;
+          if (ctx.inInput && ctx.el && !ctx.el.disabled && !ctx.el.readOnly) {
+            var nativeSetter = Object.getOwnPropertyDescriptor(
+              ctx.el.tagName === 'TEXTAREA' ? window.HTMLTextAreaElement.prototype : window.HTMLInputElement.prototype,
+              'value'
+            ).set;
+            nativeSetter.call(ctx.el, ctx.el.value.slice(0, ctx.start) + ctx.el.value.slice(ctx.end));
+            ctx.el.setSelectionRange(ctx.start, ctx.start);
+            ctx.el.dispatchEvent(new Event('input', { bubbles: true }));
+          } else {
+            try { document.execCommand('delete'); } catch (_) { /* ignore */ }
+          }
+        }
+
         document.addEventListener('keydown', function (e) {
           if (!(e.metaKey || e.ctrlKey)) return;
           if (e.shiftKey || e.altKey) return;
+          var k = e.key && e.key.toLowerCase();
+
+          // Copy / Cut: work on any selection in the document (form field or UI text).
+          if (k === 'c' || k === 'x') {
+            var ctx = getSelectionContext();
+            if (!ctx || !ctx.text) return;
+            e.preventDefault();
+            e.stopPropagation();
+            if (typeof window.__mcpInspectorWriteClipboard === 'function') {
+              window.__mcpInspectorWriteClipboard(ctx.text).catch(function () { /* swallow */ });
+            }
+            if (k === 'x') deleteSelection(ctx);
+            return;
+          }
+
+          // Paste / Select-all: only meaningful when a paste-capable field is focused.
           var ae = document.activeElement;
           if (!isPasteableInput(ae)) return;
-          var k = e.key && e.key.toLowerCase();
           if (k === 'v') {
             // Prevent the (broken) native paste path; do our own via the parent webview.
             e.preventDefault();
@@ -96,12 +141,43 @@ const CUSTOM_CSS = `    <!-- Dynamic Theme Injection Placeholder -->
           }
         }, true);
 
+        // Bridge for writing to the system clipboard (copy direction).
+        // Cross-origin iframes can't use navigator.clipboard.writeText() either,
+        // so we ask the extension host to do it via vscode.env.clipboard.writeText().
+        var copyRequestId = 0;
+        var pendingCopyRequests = new Map();
+        window.__mcpInspectorWriteClipboard = function (text) {
+          return new Promise(function (resolve, reject) {
+            var id = ++copyRequestId;
+            pendingCopyRequests.set(id, { resolve: resolve, reject: reject });
+            window.parent.postMessage({
+              type: 'mcp-inspector-request-clipboard-write',
+              requestId: id,
+              text: text == null ? '' : String(text)
+            }, '*');
+            setTimeout(function () {
+              if (pendingCopyRequests.has(id)) {
+                pendingCopyRequests.delete(id);
+                reject(new Error('Clipboard write timed out'));
+              }
+            }, 5000);
+          });
+        };
+
         window.addEventListener('message', function (e) {
           var msg = e.data;
-          if (!msg || msg.type !== 'mcp-inspector-paste-response') return;
-          var target = pendingPasteRequests.get(msg.requestId);
-          pendingPasteRequests.delete(msg.requestId);
-          if (target && msg.text) insertTextAt(target, msg.text);
+          if (!msg) return;
+          if (msg.type === 'mcp-inspector-paste-response') {
+            var target = pendingPasteRequests.get(msg.requestId);
+            pendingPasteRequests.delete(msg.requestId);
+            if (target && msg.text) insertTextAt(target, msg.text);
+          } else if (msg.type === 'mcp-inspector-clipboard-write-result') {
+            var pending = pendingCopyRequests.get(msg.requestId);
+            if (!pending) return;
+            pendingCopyRequests.delete(msg.requestId);
+            if (msg.ok) pending.resolve();
+            else pending.reject(new Error(msg.error || 'Clipboard write failed'));
+          }
         });
       })();
 
@@ -151,7 +227,44 @@ const CUSTOM_CSS = `    <!-- Dynamic Theme Injection Placeholder -->
         return Math.round(h * 360) + ' ' + Math.round(s * 100) + '% ' + Math.round(l * 100) + '%';
       }
 
-      // Remove existing theme styles when updating
+      // Fallback to execCommand when webview blocks navigator.clipboard.writeText.
+      (function patchClipboard() {
+        const execCopy = (text) => {
+          const ta = document.createElement('textarea');
+          ta.value = text == null ? '' : String(text);
+          ta.setAttribute('readonly', '');
+          ta.style.cssText = 'position:fixed;top:0;left:0;opacity:0;pointer-events:none';
+          document.body.appendChild(ta);
+          const sel = document.getSelection();
+          const prevRange = sel && sel.rangeCount > 0 ? sel.getRangeAt(0) : null;
+          ta.select();
+          ta.setSelectionRange(0, ta.value.length);
+          let ok = false;
+          try { ok = document.execCommand('copy'); } catch (_) { ok = false; }
+          document.body.removeChild(ta);
+          if (prevRange && sel) { sel.removeAllRanges(); sel.addRange(prevRange); }
+          return ok;
+        };
+        const native = navigator.clipboard && navigator.clipboard.writeText
+          ? navigator.clipboard.writeText.bind(navigator.clipboard)
+          : null;
+        const writeText = async (text) => {
+          if (native) {
+            try { return await native(text); } catch (_) {}
+          }
+          // VS Code webview path: ask the extension host to write the clipboard.
+          if (typeof window.__mcpInspectorWriteClipboard === 'function') {
+            try { await window.__mcpInspectorWriteClipboard(text); return; } catch (_) {}
+          }
+          if (execCopy(text)) return;
+          throw new Error('Clipboard copy failed');
+        };
+        if (!navigator.clipboard) {
+          Object.defineProperty(navigator, 'clipboard', { value: {}, configurable: true });
+        }
+        try { navigator.clipboard.writeText = writeText; } catch (_) {}
+      })();
+
       let themeStyleElement = null;
 
       // Listen for theme color messages from parent

--- a/workspaces/mcp-inspector/mcp-inspector-extension/scripts/inject-theme.js
+++ b/workspaces/mcp-inspector/mcp-inspector-extension/scripts/inject-theme.js
@@ -46,16 +46,22 @@ const CUSTOM_CSS = `    <!-- Dynamic Theme Injection Placeholder -->
         function insertTextAt(el, text) {
           if (!el || !text) return;
           if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA') {
-            var start = el.selectionStart != null ? el.selectionStart : el.value.length;
-            var end = el.selectionEnd != null ? el.selectionEnd : el.value.length;
+            // input[type="number"] (and a few others) don't support selection APIs;
+            // setSelectionRange throws InvalidStateError, which would skip the input event.
+            var canSelect = el.tagName === 'TEXTAREA' ||
+              ['text', 'search', 'url', 'email', 'password', 'tel'].indexOf((el.type || 'text').toLowerCase()) !== -1;
+            var start = canSelect && el.selectionStart != null ? el.selectionStart : el.value.length;
+            var end = canSelect && el.selectionEnd != null ? el.selectionEnd : el.value.length;
             var nativeSetter = Object.getOwnPropertyDescriptor(
               el.tagName === 'TEXTAREA' ? window.HTMLTextAreaElement.prototype : window.HTMLInputElement.prototype,
               'value'
             ).set;
             // Use the native setter so React's onChange fires (React tracks the prior value)
             nativeSetter.call(el, el.value.slice(0, start) + text + el.value.slice(end));
-            var caret = start + text.length;
-            el.setSelectionRange(caret, caret);
+            if (canSelect) {
+              var caret = start + text.length;
+              el.setSelectionRange(caret, caret);
+            }
             el.dispatchEvent(new Event('input', { bubbles: true }));
           } else if (el.isContentEditable) {
             document.execCommand('insertText', false, text);
@@ -117,9 +123,14 @@ const CUSTOM_CSS = `    <!-- Dynamic Theme Injection Placeholder -->
             e.preventDefault();
             e.stopPropagation();
             if (typeof window.__mcpInspectorWriteClipboard === 'function') {
-              window.__mcpInspectorWriteClipboard(ctx.text).catch(function () { /* swallow */ });
+              var write = window.__mcpInspectorWriteClipboard(ctx.text);
+              if (k === 'x') {
+                // Defer the delete until after the write resolves to avoid silent data loss.
+                write.then(function () { deleteSelection(ctx); }, function () { /* keep selection on failure */ });
+              } else {
+                write.catch(function () { /* swallow */ });
+              }
             }
-            if (k === 'x') deleteSelection(ctx);
             return;
           }
 
@@ -132,6 +143,9 @@ const CUSTOM_CSS = `    <!-- Dynamic Theme Injection Placeholder -->
             e.stopPropagation();
             var id = ++pasteRequestId;
             pendingPasteRequests.set(id, ae);
+            setTimeout(function () {
+              pendingPasteRequests.delete(id);
+            }, 10000);
             window.parent.postMessage({ type: 'mcp-inspector-request-paste', requestId: id }, '*');
           } else if (k === 'a') {
             // VS Code's webview swallows the native Select All; do it manually.
@@ -165,6 +179,8 @@ const CUSTOM_CSS = `    <!-- Dynamic Theme Injection Placeholder -->
         };
 
         window.addEventListener('message', function (e) {
+          // Only honour clipboard responses from the parent webview shell.
+          if (e.source !== window.parent) return;
           var msg = e.data;
           if (!msg) return;
           if (msg.type === 'mcp-inspector-paste-response') {

--- a/workspaces/mcp-inspector/mcp-inspector-extension/scripts/inject-theme.js
+++ b/workspaces/mcp-inspector/mcp-inspector-extension/scripts/inject-theme.js
@@ -23,6 +23,88 @@ const INDEX_HTML_PATH = path.join(
 // Placeholder CSS - will be replaced by dynamic theme injection at runtime
 const CUSTOM_CSS = `    <!-- Dynamic Theme Injection Placeholder -->
     <script>
+      // === Clipboard paste bridge ===
+      // Cross-origin iframes inside VS Code webviews cannot use the Clipboard API
+      // (microsoft/vscode#129178, #182642). We intercept Cmd/Ctrl+V over paste-capable
+      // fields and ask the parent webview for the clipboard text, then insert it ourselves.
+      (function () {
+        var pasteRequestId = 0;
+        var pendingPasteRequests = new Map();
+
+        function isPasteableInput(el) {
+          if (!el) return false;
+          if (el.isContentEditable) return true;
+          if (el.tagName === 'TEXTAREA') return !el.disabled && !el.readOnly;
+          if (el.tagName === 'INPUT') {
+            var t = (el.type || 'text').toLowerCase();
+            var pasteableTypes = ['text', 'search', 'url', 'email', 'password', 'tel', 'number'];
+            return pasteableTypes.indexOf(t) !== -1 && !el.disabled && !el.readOnly;
+          }
+          return false;
+        }
+
+        function insertTextAt(el, text) {
+          if (!el || !text) return;
+          if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA') {
+            var start = el.selectionStart != null ? el.selectionStart : el.value.length;
+            var end = el.selectionEnd != null ? el.selectionEnd : el.value.length;
+            var nativeSetter = Object.getOwnPropertyDescriptor(
+              el.tagName === 'TEXTAREA' ? window.HTMLTextAreaElement.prototype : window.HTMLInputElement.prototype,
+              'value'
+            ).set;
+            // Use the native setter so React's onChange fires (React tracks the prior value)
+            nativeSetter.call(el, el.value.slice(0, start) + text + el.value.slice(end));
+            var caret = start + text.length;
+            el.setSelectionRange(caret, caret);
+            el.dispatchEvent(new Event('input', { bubbles: true }));
+          } else if (el.isContentEditable) {
+            document.execCommand('insertText', false, text);
+          }
+        }
+
+        function selectAll(el) {
+          if (!el) return;
+          if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA') {
+            try { el.select(); } catch (_) { /* ignore */ }
+          } else if (el.isContentEditable) {
+            var range = document.createRange();
+            range.selectNodeContents(el);
+            var sel = window.getSelection();
+            sel.removeAllRanges();
+            sel.addRange(range);
+          }
+        }
+
+        document.addEventListener('keydown', function (e) {
+          if (!(e.metaKey || e.ctrlKey)) return;
+          if (e.shiftKey || e.altKey) return;
+          var ae = document.activeElement;
+          if (!isPasteableInput(ae)) return;
+          var k = e.key && e.key.toLowerCase();
+          if (k === 'v') {
+            // Prevent the (broken) native paste path; do our own via the parent webview.
+            e.preventDefault();
+            e.stopPropagation();
+            var id = ++pasteRequestId;
+            pendingPasteRequests.set(id, ae);
+            window.parent.postMessage({ type: 'mcp-inspector-request-paste', requestId: id }, '*');
+          } else if (k === 'a') {
+            // VS Code's webview swallows the native Select All; do it manually.
+            e.preventDefault();
+            e.stopPropagation();
+            selectAll(ae);
+          }
+        }, true);
+
+        window.addEventListener('message', function (e) {
+          var msg = e.data;
+          if (!msg || msg.type !== 'mcp-inspector-paste-response') return;
+          var target = pendingPasteRequests.get(msg.requestId);
+          pendingPasteRequests.delete(msg.requestId);
+          if (target && msg.text) insertTextAt(target, msg.text);
+        });
+      })();
+
       // Function to convert color (hex or rgb/rgba) to HSL format
       function colorToHsl(color) {
         let r, g, b;

--- a/workspaces/mcp-inspector/mcp-inspector-extension/src/MCPInspectorViewProvider.ts
+++ b/workspaces/mcp-inspector/mcp-inspector-extension/src/MCPInspectorViewProvider.ts
@@ -25,7 +25,8 @@ export class MCPInspectorViewProvider implements vscode.WebviewViewProvider {
         enableScripts: WebviewConfig.ENABLE_SCRIPTS,
       };
 
-      MCPInspectorViewProvider.attachClipboardBridge(webviewView.webview);
+      const clipboardBridge = MCPInspectorViewProvider.attachClipboardBridge(webviewView.webview);
+      webviewView.onDidDispose(() => clipboardBridge.dispose());
       webviewView.webview.html = this._getHtmlForWebview(webviewView.webview);
     } catch (error) {
       Logger.error('Failed to resolve webview view', error);
@@ -401,9 +402,9 @@ export class MCPInspectorViewProvider implements vscode.WebviewViewProvider {
         } else if (msg.type === 'mcp-inspector-request-clipboard-write' && e.source === iframe.contentWindow) {
           vscodeApi.postMessage({ type: 'mcp-inspector-request-clipboard-write', requestId: msg.requestId, text: msg.text });
         } else if (msg.type === 'mcp-inspector-clipboard-text' && iframe.contentWindow) {
-          iframe.contentWindow.postMessage({ type: 'mcp-inspector-paste-response', requestId: msg.requestId, text: msg.text }, '*');
+          iframe.contentWindow.postMessage({ type: 'mcp-inspector-paste-response', requestId: msg.requestId, text: msg.text }, 'http://localhost:${Ports.CLIENT}');
         } else if (msg.type === 'mcp-inspector-clipboard-write-result' && iframe.contentWindow) {
-          iframe.contentWindow.postMessage({ type: 'mcp-inspector-clipboard-write-result', requestId: msg.requestId, ok: msg.ok, error: msg.error }, '*');
+          iframe.contentWindow.postMessage({ type: 'mcp-inspector-clipboard-write-result', requestId: msg.requestId, ok: msg.ok, error: msg.error }, 'http://localhost:${Ports.CLIENT}');
         }
       });
 

--- a/workspaces/mcp-inspector/mcp-inspector-extension/src/MCPInspectorViewProvider.ts
+++ b/workspaces/mcp-inspector/mcp-inspector-extension/src/MCPInspectorViewProvider.ts
@@ -25,11 +25,38 @@ export class MCPInspectorViewProvider implements vscode.WebviewViewProvider {
         enableScripts: WebviewConfig.ENABLE_SCRIPTS,
       };
 
+      MCPInspectorViewProvider.attachClipboardBridge(webviewView.webview);
       webviewView.webview.html = this._getHtmlForWebview(webviewView.webview);
     } catch (error) {
       Logger.error('Failed to resolve webview view', error);
       throw error;
     }
+  }
+
+  /**
+   * Wires up the parent-webview side of the clipboard paste bridge.
+   * The iframe cannot read the system clipboard directly because it's cross-origin
+   * to the VS Code webview shell; we relay the request through the extension host.
+   */
+  public static attachClipboardBridge(webview: vscode.Webview): vscode.Disposable {
+    return webview.onDidReceiveMessage(async (msg) => {
+      if (!msg || msg.type !== 'mcp-inspector-request-clipboard-text') return;
+      try {
+        const text = await vscode.env.clipboard.readText();
+        webview.postMessage({
+          type: 'mcp-inspector-clipboard-text',
+          requestId: msg.requestId,
+          text,
+        });
+      } catch (error) {
+        Logger.error('Failed to read clipboard for inspector paste', error);
+        webview.postMessage({
+          type: 'mcp-inspector-clipboard-text',
+          requestId: msg.requestId,
+          text: '',
+        });
+      }
+    });
   }
 
   /**
@@ -199,7 +226,7 @@ export class MCPInspectorViewProvider implements vscode.WebviewViewProvider {
   </style>
 </head>
 <body>
-  <iframe id="inspector-iframe" src="${inspectorUrl}" sandbox="allow-scripts allow-forms allow-same-origin"></iframe>
+  <iframe id="inspector-iframe" src="${inspectorUrl}" sandbox="allow-scripts allow-forms allow-same-origin" allow="clipboard-read; clipboard-write"></iframe>
   <script>
     (function() {
       const iframe = document.getElementById('inspector-iframe');
@@ -343,6 +370,19 @@ export class MCPInspectorViewProvider implements vscode.WebviewViewProvider {
         setTimeout(sendThemeColors, 50);
         setTimeout(sendThemeColors, 200);
       };
+
+      // === Clipboard paste bridge (parent webview side) ===
+      // Iframe asks us for clipboard text -> we ask the extension -> we forward back to iframe.
+      const vscodeApi = acquireVsCodeApi();
+      window.addEventListener('message', function(e) {
+        const msg = e.data;
+        if (!msg || typeof msg !== 'object') return;
+        if (msg.type === 'mcp-inspector-request-paste' && e.source === iframe.contentWindow) {
+          vscodeApi.postMessage({ type: 'mcp-inspector-request-clipboard-text', requestId: msg.requestId });
+        } else if (msg.type === 'mcp-inspector-clipboard-text' && iframe.contentWindow) {
+          iframe.contentWindow.postMessage({ type: 'mcp-inspector-paste-response', requestId: msg.requestId, text: msg.text }, '*');
+        }
+      });
 
       // Listen for VSCode theme changes
       const observer = new MutationObserver((mutations) => {

--- a/workspaces/mcp-inspector/mcp-inspector-extension/src/MCPInspectorViewProvider.ts
+++ b/workspaces/mcp-inspector/mcp-inspector-extension/src/MCPInspectorViewProvider.ts
@@ -40,21 +40,40 @@ export class MCPInspectorViewProvider implements vscode.WebviewViewProvider {
    */
   public static attachClipboardBridge(webview: vscode.Webview): vscode.Disposable {
     return webview.onDidReceiveMessage(async (msg) => {
-      if (!msg || msg.type !== 'mcp-inspector-request-clipboard-text') return;
-      try {
-        const text = await vscode.env.clipboard.readText();
-        webview.postMessage({
-          type: 'mcp-inspector-clipboard-text',
-          requestId: msg.requestId,
-          text,
-        });
-      } catch (error) {
-        Logger.error('Failed to read clipboard for inspector paste', error);
-        webview.postMessage({
-          type: 'mcp-inspector-clipboard-text',
-          requestId: msg.requestId,
-          text: '',
-        });
+      if (!msg) return;
+      if (msg.type === 'mcp-inspector-request-clipboard-text') {
+        try {
+          const text = await vscode.env.clipboard.readText();
+          webview.postMessage({
+            type: 'mcp-inspector-clipboard-text',
+            requestId: msg.requestId,
+            text,
+          });
+        } catch (error) {
+          Logger.error('Failed to read clipboard for inspector paste', error);
+          webview.postMessage({
+            type: 'mcp-inspector-clipboard-text',
+            requestId: msg.requestId,
+            text: '',
+          });
+        }
+      } else if (msg.type === 'mcp-inspector-request-clipboard-write') {
+        try {
+          await vscode.env.clipboard.writeText(typeof msg.text === 'string' ? msg.text : '');
+          webview.postMessage({
+            type: 'mcp-inspector-clipboard-write-result',
+            requestId: msg.requestId,
+            ok: true,
+          });
+        } catch (error) {
+          Logger.error('Failed to write clipboard for inspector copy', error);
+          webview.postMessage({
+            type: 'mcp-inspector-clipboard-write-result',
+            requestId: msg.requestId,
+            ok: false,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
       }
     });
   }
@@ -371,16 +390,20 @@ export class MCPInspectorViewProvider implements vscode.WebviewViewProvider {
         setTimeout(sendThemeColors, 200);
       };
 
-      // === Clipboard paste bridge (parent webview side) ===
-      // Iframe asks us for clipboard text -> we ask the extension -> we forward back to iframe.
+      // === Clipboard bridge (parent webview side) ===
+      // Iframe asks us for clipboard read/write -> we ask the extension -> we forward back to iframe.
       const vscodeApi = acquireVsCodeApi();
       window.addEventListener('message', function(e) {
         const msg = e.data;
         if (!msg || typeof msg !== 'object') return;
         if (msg.type === 'mcp-inspector-request-paste' && e.source === iframe.contentWindow) {
           vscodeApi.postMessage({ type: 'mcp-inspector-request-clipboard-text', requestId: msg.requestId });
+        } else if (msg.type === 'mcp-inspector-request-clipboard-write' && e.source === iframe.contentWindow) {
+          vscodeApi.postMessage({ type: 'mcp-inspector-request-clipboard-write', requestId: msg.requestId, text: msg.text });
         } else if (msg.type === 'mcp-inspector-clipboard-text' && iframe.contentWindow) {
           iframe.contentWindow.postMessage({ type: 'mcp-inspector-paste-response', requestId: msg.requestId, text: msg.text }, '*');
+        } else if (msg.type === 'mcp-inspector-clipboard-write-result' && iframe.contentWindow) {
+          iframe.contentWindow.postMessage({ type: 'mcp-inspector-clipboard-write-result', requestId: msg.requestId, ok: msg.ok, error: msg.error }, '*');
         }
       });
 

--- a/workspaces/mcp-inspector/mcp-inspector-extension/src/extension.ts
+++ b/workspaces/mcp-inspector/mcp-inspector-extension/src/extension.ts
@@ -119,8 +119,9 @@ function openInspectorPanel(
       dark: vscode.Uri.joinPath(context.extensionUri, 'resources', 'icon-light.svg'),
     };
 
-    // Wire up the paste bridge so iframe inputs can paste from the system clipboard
-    context.subscriptions.push(MCPInspectorViewProvider.attachClipboardBridge(currentPanel.webview));
+    // Wire up the paste bridge so iframe inputs can paste from the system clipboard.
+    // Tied to panel lifetime to avoid leaking listeners across reopen cycles.
+    const clipboardBridge = MCPInspectorViewProvider.attachClipboardBridge(currentPanel.webview);
 
     // Set initial loading content
     currentPanel.webview.html = provider.getLoadingHtml();
@@ -173,6 +174,7 @@ function openInspectorPanel(
     // Handle panel disposal
     currentPanel.onDidDispose(
       () => {
+        clipboardBridge.dispose();
         currentPanel = undefined;
 
         // Stop the MCP Inspector processes when panel is closed

--- a/workspaces/mcp-inspector/mcp-inspector-extension/src/extension.ts
+++ b/workspaces/mcp-inspector/mcp-inspector-extension/src/extension.ts
@@ -119,6 +119,9 @@ function openInspectorPanel(
       dark: vscode.Uri.joinPath(context.extensionUri, 'resources', 'icon-light.svg'),
     };
 
+    // Wire up the paste bridge so iframe inputs can paste from the system clipboard
+    context.subscriptions.push(MCPInspectorViewProvider.attachClipboardBridge(currentPanel.webview));
+
     // Set initial loading content
     currentPanel.webview.html = provider.getLoadingHtml();
 


### PR DESCRIPTION
## Purpose

Fixes https://github.com/wso2/product-integrator/issues/1325

This PR fixes clipboard issues in the MCP inspector extension, where we cannot paste values into the form fields, and use the `Server FIles` and `Server Entries` copy buttons to copy items to the clipboard.

https://github.com/user-attachments/assets/16e30cbe-4868-4edd-9cb2-5840e1e83245

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clipboard functionality (copy, paste, cut) now works reliably in the MCP Inspector webview
  * System clipboard is properly synchronized between the inspector interface and VS Code
  * Users can now seamlessly copy/paste content in input fields, text areas, and other editable content within the inspector

<!-- end of auto-generated comment: release notes by coderabbit.ai -->