### PR TITLE
Fix review mode old/new toggle not showing original content

### DIFF
--- a/workspaces/ballerina/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
+++ b/workspaces/ballerina/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
@@ -519,6 +519,7 @@ export interface UsageResponse {
 
 export interface OpenFileDiffRequest {
     relativePath: string;
+    generationId: string;
 }
 
 // ==================================

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
@@ -903,17 +903,11 @@ Generation stopped by user. The last in-progress task was not saved. Files have 
         const workspaceId = context.ctx.workspacePath || context.ctx.projectPath;
         const threadId = 'default';
 
-        // Union modifiedFiles and affectedPackagePaths across all under-review generations at read
-        // time — each generation stores only its own files, the cumulative view is derived here.
-        const underReviewGenerations = chatStateStorage
-            .getOrCreateThread(workspaceId, threadId)
-            .generations.filter(g => g.reviewState.status === 'under_review');
-        const accumulatedModifiedFiles = Array.from(
-            new Set(underReviewGenerations.flatMap(g => g.reviewState.modifiedFiles ?? []))
-        );
-        const cachedAffectedPackages = Array.from(
-            new Set(underReviewGenerations.flatMap(g => g.reviewState.affectedPackagePaths ?? []))
-        );
+        // Show review for the current generation only; older under-review ones are treated as accepted.
+        // TODO: refactor generation review state so older generations are explicitly marked accepted.
+        const currentGeneration = chatStateStorage.getGeneration(workspaceId, threadId, context.messageId);
+        const accumulatedModifiedFiles = currentGeneration?.reviewState.modifiedFiles ?? [];
+        const cachedAffectedPackages = currentGeneration?.reviewState.affectedPackagePaths ?? [];
 
         if (accumulatedModifiedFiles.length > 0) {
             const semanticDiffs: SemanticDiff[] = [];

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
@@ -956,7 +956,7 @@ Generation stopped by user. The last in-progress task was not saved. Files have 
             context.eventHandler({
                 type: "chat_component",
                 componentType: "review",
-                data: { modifiedFiles: accumulatedModifiedFiles, semanticDiffs, loadDesignDiagrams, affectedPackages, isWorkspace, diffPackageMap }
+                data: { modifiedFiles: accumulatedModifiedFiles, semanticDiffs, loadDesignDiagrams, affectedPackages, isWorkspace, diffPackageMap, generationId: context.messageId }
             });
         }
 

--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
@@ -775,11 +775,11 @@ User reverted the last made changes. The files have been restored to the state b
         const context = StateMachine.context();
         const workspaceId = context.workspacePath || context.projectPath;
         const threadId = 'default';
-        const pendingReview = chatStateStorage.getPendingReviewGeneration(workspaceId, threadId);
-        const tempProjectPath = pendingReview?.reviewState.tempProjectPath;
+        const generation = chatStateStorage.getGeneration(workspaceId, threadId, params.generationId);
+        const tempProjectPath = generation?.reviewState.tempProjectPath;
 
         if (!tempProjectPath) {
-            console.error("[openFileDiff] No active review with temp project path");
+            console.error("[openFileDiff] No generation or temp project path for generationId:", params.generationId);
             return;
         }
 
@@ -794,7 +794,7 @@ User reverted the last made changes. The files have been restored to the state b
         AiPanelRpcManager.diffContentMap.clear();
 
         // Read original content from checkpoint snapshot — workspace already has generated code
-        const originalContent = pendingReview?.checkpoint?.workspaceSnapshot[params.relativePath] ?? '';
+        const originalContent = generation?.checkpoint?.workspaceSnapshot[params.relativePath] ?? '';
 
         let modifiedContent = '';
         try {

--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
@@ -794,7 +794,8 @@ User reverted the last made changes. The files have been restored to the state b
         AiPanelRpcManager.diffContentMap.clear();
 
         // Read original content from checkpoint snapshot — workspace already has generated code
-        const originalContent = generation?.checkpoint?.workspaceSnapshot?.[params.relativePath] ?? '';
+        const snapshotKey = params.relativePath.split(path.sep).join('/');
+        const originalContent = generation?.checkpoint?.workspaceSnapshot?.[snapshotKey] ?? '';
 
         let modifiedContent = '';
         try {

--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
@@ -794,7 +794,7 @@ User reverted the last made changes. The files have been restored to the state b
         AiPanelRpcManager.diffContentMap.clear();
 
         // Read original content from checkpoint snapshot — workspace already has generated code
-        const originalContent = generation?.checkpoint?.workspaceSnapshot[params.relativePath] ?? '';
+        const originalContent = generation?.checkpoint?.workspaceSnapshot?.[params.relativePath] ?? '';
 
         let modifiedContent = '';
         try {

--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/bi-diagram/rpc-manager.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/bi-diagram/rpc-manager.ts
@@ -274,6 +274,13 @@ export class BiDiagramRpcManager implements BIDiagramAPI {
         return input;
     }
 
+    private convertAiToFileScheme(uri: string): string {
+        if (uri.startsWith('ai://')) {
+            return 'file://' + uri.substring(5);
+        }
+        return uri;
+    }
+
     private mapTempPathToOriginal(tempFilePath: string): string {
         const rawPath = this.toRawPath(tempFilePath);
         const context = StateMachine.context();
@@ -301,9 +308,9 @@ export class BiDiagramRpcManager implements BIDiagramAPI {
             if (params?.filePath && params?.startLine && params?.endLine) {
                 console.log(">>> using params to create request");
                 let filePath = params.filePath;
-                // When useFileSchema is set, map temp path to original project path
+                // When useFileSchema is set, use file:// scheme to show original content
                 if (params.useFileSchema) {
-                    filePath = this.mapTempPathToOriginal(filePath);
+                    filePath = this.convertAiToFileScheme(filePath);
                 }
                 request = {
                     filePath,
@@ -1739,10 +1746,10 @@ export class BiDiagramRpcManager implements BIDiagramAPI {
 
     async getEnclosedFunction(params: BIGetEnclosedFunctionRequest): Promise<BIGetEnclosedFunctionResponse> {
         console.log(">>> requesting parent functin definition", params);
-        // When useFileSchema is set, map temp path to original project path
+        // When useFileSchema is set, use file:// scheme to show original content
         let filePath = params.filePath;
         if (params.useFileSchema) {
-            filePath = this.mapTempPathToOriginal(filePath);
+            filePath = this.convertAiToFileScheme(filePath);
         }
         const request = { filePath, position: params.position, findClass: params.findClass };
         return new Promise((resolve) => {
@@ -1828,8 +1835,8 @@ export class BiDiagramRpcManager implements BIDiagramAPI {
             let projectPath: string;
             if (params?.projectPath) {
                 if (params.useFileSchema) {
-                    // Map temp project path to original project raw path
-                    projectPath = this.mapTempPathToOriginal(params.projectPath);
+                    // Use file:// scheme to show original content
+                    projectPath = Uri.file(params.projectPath).toString();
                 } else {
                     const uri = Uri.file(params.projectPath);
                     projectPath = uri.with({ scheme: 'ai' }).toString();
@@ -1870,9 +1877,9 @@ export class BiDiagramRpcManager implements BIDiagramAPI {
             });
         }
 
-        // When useFileSchema is set, map temp path to original project path
+        // When useFileSchema is set, use file:// scheme to show original content
         if (params.useFileSchema) {
-            filePath = this.mapTempPathToOriginal(filePath);
+            filePath = this.convertAiToFileScheme(filePath);
         }
 
         return new Promise((resolve, reject) => {

--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/bi-diagram/rpc-manager.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/bi-diagram/rpc-manager.ts
@@ -267,13 +267,6 @@ function setTomlSectionField(filePath: string, section: string, field: string, v
 export class BiDiagramRpcManager implements BIDiagramAPI {
     OpenConfigTomlRequest: (params: OpenConfigTomlRequest) => Promise<void>;
 
-    private toRawPath(input: string): string {
-        if (input.includes('://')) {
-            return Uri.parse(input).fsPath;
-        }
-        return input;
-    }
-
     private convertAiToFileScheme(uri: string): string {
         if (uri.startsWith('ai://')) {
             return 'file://' + uri.substring(5);
@@ -281,23 +274,6 @@ export class BiDiagramRpcManager implements BIDiagramAPI {
         return uri;
     }
 
-    private mapTempPathToOriginal(tempFilePath: string): string {
-        const rawPath = this.toRawPath(tempFilePath);
-        const context = StateMachine.context();
-        const originalRoot = context.workspacePath || context.projectPath;
-        const workspaceId = context.workspacePath || context.projectPath;
-        const threadId = 'default';
-        const pendingReview = chatStateStorage.getPendingReviewGeneration(workspaceId, threadId);
-        if (pendingReview?.reviewState?.tempProjectPath && originalRoot) {
-            const normalizedTempRoot = pendingReview.reviewState.tempProjectPath.replace(/\\/g, '/');
-            const normalizedFilePath = rawPath.replace(/\\/g, '/');
-            if (normalizedFilePath.startsWith(normalizedTempRoot)) {
-                const relativePath = normalizedFilePath.substring(normalizedTempRoot.length);
-                return originalRoot + relativePath;
-            }
-        }
-        return rawPath;
-    }
 
     async getFlowModel(params: BIFlowModelRequest): Promise<BIFlowModelResponse> {
         console.log(">>> requesting bi flow model from ls", params);

--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/bi-diagram/rpc-manager.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/bi-diagram/rpc-manager.ts
@@ -269,7 +269,8 @@ export class BiDiagramRpcManager implements BIDiagramAPI {
 
     private convertAiToFileScheme(uri: string): string {
         if (uri.startsWith('ai://')) {
-            return 'file://' + uri.substring(5);
+            const fileUri = Uri.parse(uri).with({ scheme: 'file' }).toString();
+            return fileUri;
         }
         return uri;
     }

--- a/workspaces/ballerina/ballerina-extension/src/views/ai-panel/checkpoint/checkpointUtils.ts
+++ b/workspaces/ballerina/ballerina-extension/src/views/ai-panel/checkpoint/checkpointUtils.ts
@@ -57,7 +57,7 @@ export async function captureWorkspaceSnapshot(messageId: string): Promise<Check
             try {
                 const fileContent = await vscode.workspace.fs.readFile(fileUri);
                 const content = Buffer.from(fileContent).toString('utf8');
-                const relativePath = path.relative(workspaceRoot.fsPath, fileUri.fsPath);
+                const relativePath = path.relative(workspaceRoot.fsPath, fileUri.fsPath).split(path.sep).join('/');
 
                 workspaceSnapshot[relativePath] = content;
                 fileList.push(relativePath);
@@ -112,7 +112,7 @@ export async function restoreWorkspaceSnapshot(checkpoint: Checkpoint, skipArtif
             const config = getCheckpointConfig();
             const currentFiles = await getAllWorkspaceFiles(workspaceRoot, config.ignorePatterns);
             const currentFilePaths = new Set(
-                currentFiles.map(uri => path.relative(workspaceRoot.fsPath, uri.fsPath))
+                currentFiles.map(uri => path.relative(workspaceRoot.fsPath, uri.fsPath).split(path.sep).join('/'))
             );
 
             const snapshotFilePaths = new Set(checkpoint.fileList);

--- a/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -1890,6 +1890,7 @@ const AIChat: React.FC = () => {
                                                                 loadDesignDiagrams={(reviewItem as any).data.loadDesignDiagrams}
                                                                 isWorkspace={(reviewItem as any).data.isWorkspace}
                                                                 diffPackageMap={(reviewItem as any).data.diffPackageMap}
+                                                                generationId={(reviewItem as any).data.generationId}
                                                                 isDiscarded={(reviewItem as any)?.data?.status === "discarded"}
                                                                 rpcClient={isLatestAssistantMessage ? rpcClient : undefined}
                                                                 isActive={isLatestAssistantMessage && !isLoading && hasActiveReview}

--- a/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/ReviewBar/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/ReviewBar/index.tsx
@@ -331,6 +331,7 @@ interface ReviewBarProps {
     rpcClient?: any;
     isActive?: boolean;
     onDiscarded?: () => void;
+    generationId: string;
 }
 
 function getFileName(filePath: string): string {
@@ -674,6 +675,7 @@ export const ReviewBar: React.FC<ReviewBarProps> = ({
     rpcClient,
     isActive = false,
     onDiscarded,
+    generationId,
 }) => {
     const status = isDiscarded ? "discarded" : isActive ? "pending" : "accepted";
     const [isProcessing, setIsProcessing] = useState(false);
@@ -723,7 +725,7 @@ export const ReviewBar: React.FC<ReviewBarProps> = ({
 
     const openFileDiff = (relativePath: string) => {
         if (!rpcClient) return;
-        rpcClient.getAiPanelRpcClient().openFileDiff({ relativePath });
+        rpcClient.getAiPanelRpcClient().openFileDiff({ relativePath, generationId });
     };
 
     const handleDiscard = async () => {

--- a/workspaces/ballerina/ballerina-visualizer/src/views/ReviewMode/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/ReviewMode/index.tsx
@@ -206,7 +206,7 @@ function convertToReviewView(diff: SemanticDiff, projectPath: string, packageNam
 
 // Helper to extract package name from path
 function getPackageName(path: string): string {
-    const parts = path.split("/");
+    const parts = path.replace(/\\/g, "/").split("/");
     const lastPart = parts[parts.length - 1];
 
     // If the last part is a .bal file, the package name is the directory before it


### PR DESCRIPTION
Fixes https://github.com/wso2/product-integrator/issues/1351
Fixes https://github.com/wso2/product-integrator/issues/1370
Related to https://github.com/wso2/product-integrator/issues/1380 (partial fix - code diff side)

 - Show the original (pre-generation) version correctly when toggling old/new in review mode                                                       
 - Show the correct package name in the review mode Design Diagram label on Windows
 - Limit the review to the current generation's changes only                                        
 - Make the file diff work correctly on Windows by aligning path separators

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced AI panel review functionality to properly track and identify file changes across different code generations, improving review navigation and organization.

* **Bug Fixes**
  * Fixed path handling inconsistencies across Windows, Mac, and Linux to ensure reliable file diff display in reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->