### PR TITLE
fix: use correct icons for workflow and activity tree items

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/utils/project-artifacts.ts
+++ b/workspaces/ballerina/ballerina-extension/src/utils/project-artifacts.ts
@@ -179,8 +179,8 @@ async function traverseComponents(artifacts: Artifacts, projectPath: string, res
     response.directoryMap[DIRECTORY_MAP.SERVICE].push(...await getComponents(artifacts[ARTIFACT_TYPE.EntryPoints], projectPath, DIRECTORY_MAP.SERVICE, "http-service"));
     response.directoryMap[DIRECTORY_MAP.LISTENER].push(...await getComponents(artifacts[ARTIFACT_TYPE.Listeners], projectPath, DIRECTORY_MAP.LISTENER, "http-service"));
     response.directoryMap[DIRECTORY_MAP.FUNCTION].push(...await getComponents(artifacts[ARTIFACT_TYPE.Functions], projectPath, DIRECTORY_MAP.FUNCTION, "function"));
-    response.directoryMap[DIRECTORY_MAP.WORKFLOW].push(...await getComponents(artifacts[ARTIFACT_TYPE.Workflows], projectPath, DIRECTORY_MAP.WORKFLOW, "function"));
-    response.directoryMap[DIRECTORY_MAP.ACTIVITY].push(...await getComponents(artifacts[ARTIFACT_TYPE.Workflows], projectPath, DIRECTORY_MAP.ACTIVITY, "function"));
+    response.directoryMap[DIRECTORY_MAP.WORKFLOW].push(...await getComponents(artifacts[ARTIFACT_TYPE.Workflows], projectPath, DIRECTORY_MAP.WORKFLOW, "workflow"));
+    response.directoryMap[DIRECTORY_MAP.ACTIVITY].push(...await getComponents(artifacts[ARTIFACT_TYPE.Workflows], projectPath, DIRECTORY_MAP.ACTIVITY, "task"));
     response.directoryMap[DIRECTORY_MAP.DATA_MAPPER].push(...await getComponents(artifacts[ARTIFACT_TYPE.DataMappers], projectPath, DIRECTORY_MAP.DATA_MAPPER, "dataMapper"));
     response.directoryMap[DIRECTORY_MAP.CONNECTION].push(...await getComponents(artifacts[ARTIFACT_TYPE.Connections], projectPath, DIRECTORY_MAP.CONNECTION, "connection"));
     response.directoryMap[DIRECTORY_MAP.TYPE].push(...await getComponents(artifacts[ARTIFACT_TYPE.Types], projectPath, DIRECTORY_MAP.TYPE, "type"));
@@ -347,9 +347,9 @@ function getDirectoryMapKeyAndIcon(artifact: BaseArtifact, artifactCategoryKey: 
             return { mapKey: DIRECTORY_MAP.FUNCTION, icon: "function" };
         case ARTIFACT_TYPE.Workflows:
             if (artifact.type === DIRECTORY_MAP.ACTIVITY) {
-                return { mapKey: DIRECTORY_MAP.ACTIVITY, icon: "function" };
+                return { mapKey: DIRECTORY_MAP.ACTIVITY, icon: "task" };
             }
-            return { mapKey: DIRECTORY_MAP.WORKFLOW, icon: "function" };
+            return { mapKey: DIRECTORY_MAP.WORKFLOW, icon: "workflow" };
         case ARTIFACT_TYPE.DataMappers:
             return { mapKey: DIRECTORY_MAP.DATA_MAPPER, icon: "dataMapper" };
         case ARTIFACT_TYPE.Connections:


### PR DESCRIPTION
## Summary
- Change workflow icon from 'function' to 'workflow' in tree view
- Change activity icon from 'function' to 'task' in tree view
- Update getDirectoryMapKeyAndIcon() to return correct icons for workflow and activity types

## Changes
- `workspaces/ballerina/ballerina-extension/src/utils/project-artifacts.ts`
  - Line 182: WORKFLOW icon: `"function"` → `"workflow"`
  - Line 183: ACTIVITY icon: `"function"` → `"task"`
  - Line 350: ACTIVITY icon in getDirectoryMapKeyAndIcon: `"function"` → `"task"`
  - Line 352: WORKFLOW icon in getDirectoryMapKeyAndIcon: `"function"` → `"workflow"`

## Impact
Workflow items and workflow activities in the tree view now display appropriate icons instead of the generic function icon.