### PR TITLE
Add responsive tracing button label for smaller screens

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/DiagramWrapper/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/DiagramWrapper/index.tsx
@@ -525,6 +525,7 @@ export function DiagramWrapper(param: DiagramWrapperProps) {
                 appearance={isTracingEnabled ? "primary" : "secondary"}
                 onClick={handleToggleTracing}
                 disabled={isToggling}
+                tooltip={isTracingEnabled ? "Disable tracing" : "Enable tracing"}
             >
                 <Icon
                     name={isTracingEnabled ? "telescope" : "circle-slash"}

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/DiagramWrapper/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/DiagramWrapper/index.tsx
@@ -525,7 +525,7 @@ export function DiagramWrapper(param: DiagramWrapperProps) {
                 appearance={isTracingEnabled ? "primary" : "secondary"}
                 onClick={handleToggleTracing}
                 disabled={isToggling}
-                tooltip={isTracingEnabled ? "Disable tracing" : "Enable tracing"}
+                tooltip={isTracingEnabled ? "Tracing is on. Click to disable." : "Tracing is off. Click to enable."}
             >
                 <Icon
                     name={isTracingEnabled ? "telescope" : "circle-slash"}

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/DiagramWrapper/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/DiagramWrapper/index.tsx
@@ -43,6 +43,8 @@ const ActionButton = styled(Button)`
     gap: 4px;
 `;
 
+const TRACING_LABEL_BREAKPOINT = 600;
+
 const SubTitleWrapper = styled.div`
     display: flex;
     align-items: center;
@@ -138,6 +140,9 @@ export function DiagramWrapper(param: DiagramWrapperProps) {
     const [isSaving, setIsSaving] = useState(false);
     const [isTracingEnabled, setIsTracingEnabled] = useState(false);
     const [isToggling, setIsToggling] = useState(false);
+    const [isNarrowViewport, setIsNarrowViewport] = useState(
+        typeof window !== "undefined" && window.innerWidth < TRACING_LABEL_BREAKPOINT
+    );
     const [selectedTryItOption, setSelectedTryItOption] = useState<TryItOptionValue>(TryItOptionValue.TRY_IT);
     const [isTryItInProgress, setIsTryItInProgress] = useState(false);
     const isMountedRef = useRef(true);
@@ -147,6 +152,14 @@ export function DiagramWrapper(param: DiagramWrapperProps) {
         return () => {
             isMountedRef.current = false;
         };
+    }, []);
+
+    useEffect(() => {
+        const handleResize = () => {
+            setIsNarrowViewport(window.innerWidth < TRACING_LABEL_BREAKPOINT);
+        };
+        window.addEventListener("resize", handleResize);
+        return () => window.removeEventListener("resize", handleResize);
     }, []);
 
     useEffect(() => {
@@ -518,7 +531,7 @@ export function DiagramWrapper(param: DiagramWrapperProps) {
                     isCodicon={true}
                     sx={{ marginRight: 5, width: 16, height: 16, fontSize: 14 }}
                 />
-                {isTracingEnabled ? "Tracing: On" : "Tracing: Off"}
+                {isNarrowViewport ? "Tracing" : isTracingEnabled ? "Tracing: On" : "Tracing: Off"}
             </ActionButton>
         );
 


### PR DESCRIPTION
## Purpose

Fixes https://github.com/wso2/product-integrator/issues/1037

This PR makes the label in the tracing toggle button responsive, so that it doesn't break into 2 lines when the window size is too small.

https://github.com/user-attachments/assets/83f15c29-9ac8-47d6-baf6-47ba24a8b927


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved responsive design for better mobile and narrow viewport support. The tracing button label now adapts dynamically based on screen width, displaying a compact label on narrow viewports while maintaining the full label on wider screens for enhanced usability and optimal space utilization across all device sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->