### PR TITLE
[Data Mapper] FE changes for adding support for importable types in submappings

### DIFF
--- a/workspaces/ballerina/ballerina-core/src/interfaces/data-mapper.ts
+++ b/workspaces/ballerina/ballerina-core/src/interfaces/data-mapper.ts
@@ -17,7 +17,7 @@
  */
 
 import { TypeInfo } from "./ballerina";
-import { CodeData, InputType } from "./bi";
+import { CodeData, Imports, InputType } from "./bi";
 import { LineRange } from "./common";
 
 export enum TypeKind {
@@ -254,7 +254,7 @@ export interface DMFormProps {
     submitText?: string;
     cancelText?: string;
     nestedForm?: boolean;
-    onSubmit: (data: DMFormFieldValues, formImports?: DMFormFieldValues, importsCodedata?: CodeData) => void;
+    onSubmit: (data: DMFormFieldValues, formImports?: DMFormImports, importsCodedata?: CodeData) => void;
     onCancel?: () => void;
     isSaving?: boolean;
 }
@@ -274,6 +274,10 @@ export interface DMFormField {
 
 export interface DMFormFieldValues {
     [key: string]: any;
+}
+
+export interface DMFormImports {
+    [fieldKey: string]: Imports;
 }
 
 export interface DMViewState {

--- a/workspaces/ballerina/ballerina-visualizer/src/views/DataMapper/DataMapperView.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/DataMapper/DataMapperView.tsx
@@ -418,8 +418,9 @@ export function DataMapperView(props: DataMapperViewProps) {
                     filePath,
                     codedata: importsCodedata || { symbol: type }
                 });
-            const defaultValue = visualizableResponse.visualizableProperties?.defaultValue ?? "()";
+            console.log(">>> [Data Mapper] getVisualizableFields response:", visualizableResponse);
 
+            const defaultValue = visualizableResponse.visualizableProperties.defaultValue;
             const request = createAddSubMappingRequest(
                 filePath,
                 viewState.codedata,

--- a/workspaces/ballerina/ballerina-visualizer/src/views/DataMapper/DataMapperView.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/DataMapper/DataMapperView.tsx
@@ -48,7 +48,8 @@ import {
     TriggerKind,
     TypeKind,
     Type,
-    Imports
+    Imports,
+    DMFormImports
 } from "@wso2/ballerina-core";
 import { CompletionItem, ProgressIndicator } from "@wso2/ui-toolkit";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
@@ -407,6 +408,7 @@ export function DataMapperView(props: DataMapperViewProps) {
         type: string,
         index: number,
         targetField: string,
+        formImports?: DMFormImports,
         importsCodedata?: CodeData
     ) => {
         try {
@@ -416,9 +418,8 @@ export function DataMapperView(props: DataMapperViewProps) {
                     filePath,
                     codedata: importsCodedata || { symbol: type }
                 });
-            console.log(">>> [Data Mapper] getVisualizableFields response:", visualizableResponse);
+            const defaultValue = visualizableResponse.visualizableProperties?.defaultValue ?? "()";
 
-            const defaultValue = visualizableResponse.visualizableProperties.defaultValue;
             const request = createAddSubMappingRequest(
                 filePath,
                 viewState.codedata,
@@ -427,7 +428,8 @@ export function DataMapperView(props: DataMapperViewProps) {
                 subMappingName,
                 type,
                 name,
-                defaultValue
+                defaultValue,
+                formImports?.type
             );
 
             console.log(">>> [Data Mapper] addSubMapping request:", request);

--- a/workspaces/ballerina/ballerina-visualizer/src/views/DataMapper/utils.ts
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/DataMapper/utils.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { AddSubMappingRequest, CodeData } from "@wso2/ballerina-core";
+import { AddSubMappingRequest, CodeData, Imports } from "@wso2/ballerina-core";
 
 // Constants for default values related to the sub mapping form
 const EMPTY_LABEL = "";
@@ -29,29 +29,30 @@ const createMetadata = (label: string = EMPTY_LABEL, description: string = EMPTY
 });
 
 // Helper function to create property object
-const createProperty = (valueType: string, value: string, optional: boolean, editable: boolean) => ({
+const createProperty = (valueType: string, value: string, optional: boolean, editable: boolean, imports?: Imports) => ({
     metadata: createMetadata(),
     valueType,
     value,
     optional,
-    editable
+    editable,
+    imports
 });
 
 // Helper function to create flowNode properties
-const createFlowNodeProperties = (subMappingName: string, type: string, defaultValue: string) => ({
+const createFlowNodeProperties = (subMappingName: string, type: string, defaultValue: string, typeImports?: Imports) => ({
     expression: createProperty("EXPRESSION", defaultValue, true, true),
     variable: createProperty("IDENTIFIER", subMappingName, false, true),
-    type: createProperty("TYPE", type, false, true)
+    type: createProperty("TYPE", type, false, true, typeImports)
 });
 
 // Helper function to create flowNode
-const createFlowNode = (subMappingName: string, type: string, codedata: CodeData, defaultValue: string) => ({
+const createFlowNode = (subMappingName: string, type: string, codedata: CodeData, defaultValue: string, typeImports?: Imports) => ({
     id: subMappingName,
     returning: false,
     metadata: createMetadata(),
     codedata: codedata,
     branches: [] as any[],
-    properties: createFlowNodeProperties(subMappingName, type, defaultValue)
+    properties: createFlowNodeProperties(subMappingName, type, defaultValue, typeImports)
 });
 
 // Helper function to create AddSubMappingRequest
@@ -63,12 +64,13 @@ export const createAddSubMappingRequest = (
     subMappingName: string,
     type: string,
     varName: string,
-    defaultValue: string
+    defaultValue: string,
+    typeImports?: Imports
 ): AddSubMappingRequest => ({
     filePath,
     codedata,
     index,
     targetField,
-    flowNode: createFlowNode(subMappingName, type, codedata, defaultValue),
+    flowNode: createFlowNode(subMappingName, type, codedata, defaultValue, typeImports),
     varName
 });

--- a/workspaces/ballerina/data-mapper/src/components/DataMapper/DataMapperEditor.tsx
+++ b/workspaces/ballerina/data-mapper/src/components/DataMapper/DataMapperEditor.tsx
@@ -18,7 +18,7 @@
 // tslint:disable: jsx-no-multiline-js
 import React, { useCallback, useEffect, useReducer, useState } from "react";
 import { css, keyframes } from "@emotion/css";
-import { CodeData, ExpandedDMModel } from "@wso2/ballerina-core";
+import { CodeData, DMFormImports, ExpandedDMModel } from "@wso2/ballerina-core";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
 import { useShallow } from "zustand/react/shallow";
 
@@ -341,9 +341,10 @@ export function DataMapperEditor(props: DataMapperEditorProps) {
         type: string,
         index: number,
         targetField: string,
+        formImports?: DMFormImports,
         importsCodedata?: CodeData
     ) => {
-        await addSubMapping(subMappingName, type, index, targetField, importsCodedata);
+        await addSubMapping(subMappingName, type, index, targetField, formImports, importsCodedata);
         resetSubMappingConfig();
     }
 

--- a/workspaces/ballerina/data-mapper/src/components/DataMapper/SidePanel/SubMappingConfig/SubMappingConfigForm.tsx
+++ b/workspaces/ballerina/data-mapper/src/components/DataMapper/SidePanel/SubMappingConfig/SubMappingConfigForm.tsx
@@ -28,7 +28,7 @@ import {
 import { useDMSubMappingConfigPanelStore } from "../../../../store/store";
 import { View } from "../../Views/DataMapperView";
 
-import { CodeData, DMFormField, DMFormFieldValues, DMFormProps} from "@wso2/ballerina-core";
+import { CodeData, DMFormField, DMFormFieldValues, DMFormImports, DMFormProps} from "@wso2/ballerina-core";
 
 const ADD_NEW_SUB_MAPPING_HEADER = "Add New Sub Mapping";
 const EDIT_SUB_MAPPING_HEADER = "Edit Sub Mapping";
@@ -36,7 +36,7 @@ const EDIT_SUB_MAPPING_HEADER = "Edit Sub Mapping";
 export type SubMappingConfigFormProps = {
     views: View[];
     updateView: (updatedView: View) => void;
-    addSubMapping: (subMappingName: string, type: string, index: number, targetField: string, importsCodedata?: CodeData) => Promise<void>;
+    addSubMapping: (subMappingName: string, type: string, index: number, targetField: string, formImports?: DMFormImports, importsCodedata?: CodeData) => Promise<void>;
     generateForm: (formProps: DMFormProps) => JSX.Element;
 };
 
@@ -84,7 +84,7 @@ export function SubMappingConfigForm(props: SubMappingConfigFormProps) {
 
     const isEdit = nextSubMappingIndex === -1 && !suggestedNextSubMappingName;
 
-    const onAdd = async (data: DMFormFieldValues, importsCodedata?: CodeData) => {
+    const onAdd = async (data: DMFormFieldValues, formImports?: DMFormImports, importsCodedata?: CodeData) => {
         setFormValues({
             name: data.name,
             type: data.type
@@ -93,13 +93,13 @@ export function SubMappingConfigForm(props: SubMappingConfigFormProps) {
 
         try {
             const targetField = views[views.length - 1].targetField;
-            await addSubMapping(data.name, data.type, nextSubMappingIndex, targetField, importsCodedata);
+            await addSubMapping(data.name, data.type, nextSubMappingIndex, targetField, formImports, importsCodedata);
         } finally {
             setIsAddingNewSubMapping(false);
         }
     };
 
-    const onEdit = async (data: DMFormFieldValues, importsCodedata?: CodeData) => {
+    const onEdit = async (data: DMFormFieldValues, formImports?: DMFormImports, importsCodedata?: CodeData) => {
         // TODO: Implement onEdit
     };
 
@@ -107,11 +107,11 @@ export function SubMappingConfigForm(props: SubMappingConfigFormProps) {
         resetSubMappingConfig();
     };
 
-    const onSubmit = (data: DMFormFieldValues, formImports?: DMFormFieldValues, importsCodedata?: CodeData) => {
+    const onSubmit = (data: DMFormFieldValues, formImports?: DMFormImports, importsCodedata?: CodeData) => {
         if (isEdit) {
-            onEdit(data, importsCodedata);
+            onEdit(data, formImports, importsCodedata);
         } else {
-            onAdd(data, importsCodedata);
+            onAdd(data, formImports, importsCodedata);
         }
     };
 

--- a/workspaces/ballerina/data-mapper/src/components/DataMapper/SidePanel/SubMappingConfig/SubMappingConfigForm.tsx
+++ b/workspaces/ballerina/data-mapper/src/components/DataMapper/SidePanel/SubMappingConfig/SubMappingConfigForm.tsx
@@ -25,7 +25,7 @@ import {
     ThemeColors
 } from "@wso2/ui-toolkit";
 
-import { useDMSubMappingConfigPanelStore, SubMappingConfigFormData } from "../../../../store/store";
+import { useDMSubMappingConfigPanelStore } from "../../../../store/store";
 import { View } from "../../Views/DataMapperView";
 
 import { CodeData, DMFormField, DMFormFieldValues, DMFormProps} from "@wso2/ballerina-core";
@@ -84,13 +84,13 @@ export function SubMappingConfigForm(props: SubMappingConfigFormProps) {
 
     const isEdit = nextSubMappingIndex === -1 && !suggestedNextSubMappingName;
 
-    const onAdd = async (data: SubMappingConfigFormData, importsCodedata?: CodeData) => {
+    const onAdd = async (data: DMFormFieldValues, importsCodedata?: CodeData) => {
         setFormValues({
             name: data.name,
             type: data.type
         });
         setIsAddingNewSubMapping(true);
-        
+
         try {
             const targetField = views[views.length - 1].targetField;
             await addSubMapping(data.name, data.type, nextSubMappingIndex, targetField, importsCodedata);
@@ -99,7 +99,7 @@ export function SubMappingConfigForm(props: SubMappingConfigFormProps) {
         }
     };
 
-    const onEdit = async (data: SubMappingConfigFormData, importsCodedata?: CodeData) => {
+    const onEdit = async (data: DMFormFieldValues, importsCodedata?: CodeData) => {
         // TODO: Implement onEdit
     };
 
@@ -107,7 +107,7 @@ export function SubMappingConfigForm(props: SubMappingConfigFormProps) {
         resetSubMappingConfig();
     };
 
-    const onSubmit = (data: SubMappingConfigFormData, formImports?: DMFormFieldValues, importsCodedata?: CodeData) => {
+    const onSubmit = (data: DMFormFieldValues, formImports?: DMFormFieldValues, importsCodedata?: CodeData) => {
         if (isEdit) {
             onEdit(data, importsCodedata);
         } else {

--- a/workspaces/ballerina/data-mapper/src/index.tsx
+++ b/workspaces/ballerina/data-mapper/src/index.tsx
@@ -24,7 +24,7 @@ import type {} from "@projectstorm/react-diagrams-core";
 import type {} from "@projectstorm/react-diagrams";
 import { css, Global } from '@emotion/react';
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { DMFormProps, ModelState, IntermediateClause, Mapping, CodeData, FnMetadata, LineRange, ResultClauseType, IOType, Property, LinePosition, TypeKind } from "@wso2/ballerina-core";
+import { DMFormImports, DMFormProps, ModelState, IntermediateClause, Mapping, CodeData, FnMetadata, LineRange, ResultClauseType, IOType, Property, LinePosition, TypeKind } from "@wso2/ballerina-core";
 import { CompletionItem } from "@wso2/ui-toolkit";
 
 import { DataMapperEditor } from "./components/DataMapper/DataMapperEditor";
@@ -71,7 +71,7 @@ export interface DataMapperEditorProps {
     addClauses: (clause: IntermediateClause, targetField: string, isNew: boolean, index:number) => Promise<void>;
     deleteClause: (targetField: string, index: number) => Promise<void>;
     getClausePosition: (targetField: string, index: number) => Promise<LinePosition>;
-    addSubMapping: (subMappingName: string, type: string, index: number, targetField: string, importsCodedata?: CodeData) => Promise<void>;
+    addSubMapping: (subMappingName: string, type: string, index: number, targetField: string, formImports?: DMFormImports, importsCodedata?: CodeData) => Promise<void>;
     deleteMapping: (mapping: Mapping, viewId: string) => Promise<void>;
     deleteSubMapping: (index: number, viewId: string) => Promise<void>;
     mapWithCustomFn: (mapping: Mapping, metadata: FnMetadata, viewId: string) => Promise<void>;


### PR DESCRIPTION
## Purpose
> Resolves https://github.com/wso2-enterprise/integration-engineering/issues/1184

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced the data mapper's sub-mapping configuration to improve import and type handling throughout the workflow. Updated internal signatures to support passing form imports alongside existing code data parameters, enabling more robust import management when creating and configuring sub-mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->