### PR TITLE
Fix Copilot generating library packages as standard integrations

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/prompts.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/prompts.ts
@@ -200,6 +200,7 @@ When working with Ballerina workspace projects (projects with a root Ballerina.t
 - Always prefer modifying existing packages over creating new ones unless the user specifically asks to create a new package.
 - The root workspace Ballerina.toml should only contain a [workspace] section with a packages array.
 - Avoid modifying existing package Ballerina.toml files for dependency management.
+- A library package must include a \`lib.bal\` file containing \`import wso2/strict.library as _;\` — without this import the package is treated as a standard integration.
 
 # Running, invoking and tests
 - You should only Run or write tests if the user explicitly asks to do so.


### PR DESCRIPTION
Fixes https://github.com/wso2/product-integrator/issues/1332

- Add a guideline in the Copilot agent system prompt instructing the model to include a `lib.bal` file containing `import wso2/strict.library as _;` whenever a library package is created

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AI agent configuration to enforce Ballerina library package requirements, now requiring a specific import statement in library packages. Packages without this import will be treated as standard integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->