### PR TITLE
Hide ICP UI on Workspace Overview when running in Devant

### DIFF
--- a/workspaces/ballerina/ballerina-extension/package.json
+++ b/workspaces/ballerina/ballerina-extension/package.json
@@ -760,13 +760,13 @@
                 "command": "ballerina.icp.start",
                 "title": "Start ICP",
                 "category": "Ballerina",
-                "enablement": "isSupportedProject && !ballerina.icpRunning"
+                "enablement": "isSupportedProject && !ballerina.icpRunning && !devant.editor"
             },
             {
                 "command": "ballerina.icp.stop",
                 "title": "Stop ICP",
                 "category": "Ballerina",
-                "enablement": "isSupportedProject && ballerina.icpRunning"
+                "enablement": "isSupportedProject && ballerina.icpRunning && !devant.editor"
             },
             {
                 "command": "ballerina.showTraceWindow",

--- a/workspaces/ballerina/ballerina-extension/src/extension.ts
+++ b/workspaces/ballerina/ballerina-extension/src/extension.ts
@@ -37,7 +37,7 @@ import { activate as activateBIFeatures } from './features/bi';
 import { activate as activateERDiagram } from './views/persist-layer-diagram';
 import { activateAiPanel } from './views/ai-panel';
 import { activateMigrationPanel } from './views/migration-panel';
-import { debug, handleResolveMissingDependencies, log } from './utils';
+import { debug, handleResolveMissingDependencies, isInDevant, log } from './utils';
 import { activateUriHandlers } from './utils/uri-handlers';
 import { StateMachine } from './stateMachine';
 import { activateSubscriptions } from './views/visualizer/activate';
@@ -239,8 +239,10 @@ export async function activateBallerina(): Promise<BallerinaExtension> {
         // Activate Tracing Feature
         activateTracing(ballerinaExtInstance);
 
-        // Activate ICP (Integration Control Plane)
-        activateICP(ballerinaExtInstance);
+        // Activate ICP (Integration Control Plane) — skip in Devant
+        if (!isInDevant()) {
+            activateICP(ballerinaExtInstance);
+        }
 
         langClient = <ExtendedLangClient>ballerinaExtInstance.langClient;
         // Register showTextDocument listener
@@ -305,7 +307,7 @@ export async function activateBallerina(): Promise<BallerinaExtension> {
 }
 
 async function updateCodeServerConfig() {
-    if (!('CLOUD_STS_TOKEN' in process.env)) {
+    if (!isInDevant()) {
         return;
     }
     log("Code server environment detected");

--- a/workspaces/ballerina/ballerina-extension/src/features/bi/activator.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/bi/activator.ts
@@ -34,6 +34,7 @@ import { StateMachine } from "../../stateMachine";
 import { BiDiagramRpcManager } from "../../rpc-managers/bi-diagram/rpc-manager";
 import { readFileSync, readdirSync, statSync } from "fs";
 import path from "path";
+import { isInDevant } from "../../utils";
 import { isPositionEqual, isPositionWithinDeletedComponent } from "../../utils/history/util";
 import { startDebugging } from "../editor-support/activator";
 import {
@@ -69,8 +70,8 @@ export function activate(context: BallerinaExtension) {
         const isWebviewOpen = VisualizerWebview.currentPanel !== undefined;
         const hasActiveTextEditor = !!window.activeTextEditor;
 
-        // Check if ICP is enabled for this project
-        if (projectPath && stateMachineContext.langClient) {
+        // Check if ICP is enabled for this project (skip entirely in Devant)
+        if (!isInDevant() && projectPath && stateMachineContext.langClient) {
             try {
                 const icpStatus = await stateMachineContext.langClient.isIcpEnabled({ projectPath });
                 if (icpStatus && 'enabled' in icpStatus && icpStatus.enabled) {

--- a/workspaces/ballerina/ballerina-extension/src/features/devant/activator.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/devant/activator.ts
@@ -27,12 +27,11 @@ import { openView, StateMachine } from "../../stateMachine";
 import { commands, window } from "vscode";
 import * as path from "path";
 import * as fs from "fs";
-import { debug } from "../../utils";
+import { debug, isInDevant } from "../../utils";
 import { getPlatformExtensionAPI } from "../../utils/ai/auth";
 
 export function activateDevantFeatures(_ballerinaExtInstance: BallerinaExtension) {
-    const cloudToken = process.env.CLOUD_STS_TOKEN;
-    if (cloudToken) {
+    if (isInDevant()) {
         // Set the connection token context for Devant UI features
         commands.executeCommand("setContext", "devant.editor", true);
     }

--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
@@ -79,7 +79,7 @@ import { sendGenerationDiscardTelemetry, sendGenerationKeptTelemetry } from "../
 import { getLLMDiagnosticArrayAsString } from "../../features/natural-programming/utils";
 import { enhancePrompt as enhancePromptService } from "../../features/ai/service/prompt-enhancement/promptEnhancement";
 import { StateMachine, updateView } from "../../stateMachine";
-import { isInWI } from "../../utils";
+import { isInDevant, isInWI } from "../../utils";
 import { getLoginMethod, isPlatformExtensionAvailable, loginGithubCopilot } from "../../utils/ai/auth";
 import { normalizeCodeContext } from "../../views/ai-panel/codeContextUtils";
 import { refreshDataMapper } from "../data-mapper/utils";
@@ -194,8 +194,7 @@ export class AiPanelRpcManager implements AIPanelAPI {
         }
 
         // Don't show alert in Devant environment
-        const isInDevant = !!process.env.CLOUD_STS_TOKEN;
-        if (isInDevant) {
+        if (isInDevant()) {
             return false;
         }
 

--- a/workspaces/ballerina/ballerina-extension/src/stateMachine.ts
+++ b/workspaces/ballerina/ballerina-extension/src/stateMachine.ts
@@ -39,7 +39,7 @@ import * as path from 'path';
 import { extension } from './BalExtensionContext';
 import { AIStateMachine, openAIPanelWithPrompt } from './views/ai-panel/aiMachine';
 import { StateMachinePopup } from './stateMachinePopup';
-import { checkIsBallerinaPackage, checkIsBI, fetchScope, getOrgPackageName, UndoRedoManager, getProjectTomlValues, getOrgAndPackageName, checkIsBallerinaWorkspace, isInWI } from './utils';
+import { checkIsBallerinaPackage, checkIsBI, fetchScope, getOrgPackageName, UndoRedoManager, getProjectTomlValues, getOrgAndPackageName, checkIsBallerinaWorkspace, isInWI, isInDevant } from './utils';
 import { activateDevantFeatures } from './features/devant/activator';
 import { buildProjectsStructure } from './utils/project-artifacts';
 import { runCommandWithOutput } from './utils/runCommand';
@@ -80,7 +80,7 @@ const stateMachine = createMachine<MachineContext>(
             isBISupported: false,
             view: MACHINE_VIEW.PackageOverview,
             dependenciesResolved: false,
-            isInDevant: !!process.env.CLOUD_STS_TOKEN
+            isInDevant: isInDevant()
         },
         on: {
             RESET_TO_EXTENSION_READY: {

--- a/workspaces/ballerina/ballerina-extension/src/utils/config.ts
+++ b/workspaces/ballerina/ballerina-extension/src/utils/config.ts
@@ -233,6 +233,10 @@ export function isInWI(): boolean {
     return !!extensions.getExtension(WI_EXTENSION_ID);
 }
 
+export function isInDevant(): boolean {
+    return !!process.env.CLOUD_STS_TOKEN;
+}
+
 export async function checkIsBallerinaPackage(uri: Uri): Promise<boolean> {
     const ballerinaTomlPath = path.join(uri.fsPath, 'Ballerina.toml');
 

--- a/workspaces/ballerina/ballerina-visualizer/src/MainPanel.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/MainPanel.tsx
@@ -343,7 +343,7 @@ const MainPanel = () => {
                         case MACHINE_VIEW.WorkspaceOverview: {
                             const { WorkspaceOverview } = await import("./views/BI/WorkspaceOverview");
                             if (isStaleNavigation()) return;
-                            setViewComponent(<WorkspaceOverview />);
+                            setViewComponent(<WorkspaceOverview isInDevant={value.isInDevant} />);
                             break;
                         }
                         case MACHINE_VIEW.ServiceDesigner: {

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/WorkspaceOverview/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/WorkspaceOverview/index.tsx
@@ -534,9 +534,11 @@ function DeploymentOptions({
 function WorkspaceDevantDashboard({
     handleDeploy,
     hasDeployableIntegration,
+    hasUndeployedIntegrations,
 }: {
     handleDeploy: () => void;
     hasDeployableIntegration: boolean;
+    hasUndeployedIntegrations: boolean;
 }) {
     return (
         <React.Fragment>
@@ -548,10 +550,13 @@ function WorkspaceDevantDashboard({
             ) : (
                 <>
                     <Typography sx={{ color: "var(--vscode-descriptionForeground)" }}>
-                        Deploy your integration in WSO2 Cloud.
+                        {hasUndeployedIntegrations
+                            ? "Deploy your integration in WSO2 Cloud."
+                            : "All integrations are deployed in WSO2 Cloud."}
                     </Typography>
                     <Button
                         appearance="primary"
+                        disabled={!hasUndeployedIntegrations}
                         onClick={handleDeploy}
                         sx={{
                             display: "flex",
@@ -1140,6 +1145,7 @@ export function WorkspaceOverview({ isInDevant }: WorkspaceOverviewProps) {
                             <WorkspaceDevantDashboard
                                 handleDeploy={handleDeploy}
                                 hasDeployableIntegration={hasDeployableIntegration}
+                                hasUndeployedIntegrations={undeployedProjectScopes.length > 0}
                             />
                         )}
                     </SidePanel>

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/WorkspaceOverview/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/WorkspaceOverview/index.tsx
@@ -531,6 +531,44 @@ function DeploymentOptions({
     );
 }
 
+function WorkspaceDevantDashboard({
+    handleDeploy,
+    hasDeployableIntegration,
+}: {
+    handleDeploy: () => void;
+    hasDeployableIntegration: boolean;
+}) {
+    return (
+        <React.Fragment>
+            <Title variant="h3">Deploy to WSO2 Cloud</Title>
+            {!hasDeployableIntegration ? (
+                <Typography sx={{ color: "var(--vscode-descriptionForeground)" }}>
+                    Before you can deploy your integration to WSO2 Cloud, please add an artifact (such as a Service or Automation) to your integration.
+                </Typography>
+            ) : (
+                <>
+                    <Typography sx={{ color: "var(--vscode-descriptionForeground)" }}>
+                        Deploy your integration in WSO2 Cloud.
+                    </Typography>
+                    <Button
+                        appearance="primary"
+                        onClick={handleDeploy}
+                        sx={{
+                            display: "flex",
+                            alignItems: "center",
+                            justifyContent: "center",
+                            marginTop: "10px",
+                            mx: "auto",
+                        }}
+                    >
+                        <Codicon name="save" sx={{ marginRight: 8 }} /> Save and Deploy
+                    </Button>
+                </>
+            )}
+        </React.Fragment>
+    );
+}
+
 const ICPButtonContent = styled.div`
     display: flex;
     align-items: center;
@@ -629,7 +667,11 @@ function IntegrationControlPlane({
     );
 }
 
-export function WorkspaceOverview() {
+interface WorkspaceOverviewProps {
+    isInDevant: boolean;
+}
+
+export function WorkspaceOverview({ isInDevant }: WorkspaceOverviewProps) {
     const { rpcClient } = useRpcContext();
     const [readmeContent, setReadmeContent] = React.useState<string>("");
     const [projectCollection, setProjectCollection] = React.useState<ProjectStructureResponse>();
@@ -1069,27 +1111,37 @@ export function WorkspaceOverview() {
                 </LeftContent>
                 {hasStandardIntegrations && (
                     <SidePanel>
-                        <DeploymentOptions
-                            handleDockerBuild={handleDockerBuild}
-                            handleJarBuild={handleJarBuild}
-                            handleDeploy={handleDeploy}
-                            goToDevant={goToDevant}
-                            devantMetadata={devantMetadata}
-                            hasDeployableIntegration={hasDeployableIntegration}
-                            hasUndeployedIntegrations={undeployedProjectScopes.length > 0}
-                            deployableProjectPaths={deployableProjectPaths}
-                            libraryProjectPaths={libraryProjectPaths}
-                        />
-                        <Divider sx={{ margin: "16px 0" }} />
-                        <IntegrationControlPlane
-                            icpState={icpState}
-                            enabledCount={icpEnabledCount}
-                            totalCount={icpProjectPaths.length}
-                            onEnableAll={handleEnableAllICP}
-                            onDisableAll={handleDisableAllICP}
-                            onEnableRemaining={handleEnableRemainingICP}
-                            icpActionLoading={icpActionLoading}
-                        />
+                        {!isInDevant && (
+                            <>
+                                <DeploymentOptions
+                                    handleDockerBuild={handleDockerBuild}
+                                    handleJarBuild={handleJarBuild}
+                                    handleDeploy={handleDeploy}
+                                    goToDevant={goToDevant}
+                                    devantMetadata={devantMetadata}
+                                    hasDeployableIntegration={hasDeployableIntegration}
+                                    hasUndeployedIntegrations={undeployedProjectScopes.length > 0}
+                                    deployableProjectPaths={deployableProjectPaths}
+                                    libraryProjectPaths={libraryProjectPaths}
+                                />
+                                <Divider sx={{ margin: "16px 0" }} />
+                                <IntegrationControlPlane
+                                    icpState={icpState}
+                                    enabledCount={icpEnabledCount}
+                                    totalCount={icpProjectPaths.length}
+                                    onEnableAll={handleEnableAllICP}
+                                    onDisableAll={handleDisableAllICP}
+                                    onEnableRemaining={handleEnableRemainingICP}
+                                    icpActionLoading={icpActionLoading}
+                                />
+                            </>
+                        )}
+                        {isInDevant && (
+                            <WorkspaceDevantDashboard
+                                handleDeploy={handleDeploy}
+                                hasDeployableIntegration={hasDeployableIntegration}
+                            />
+                        )}
                     </SidePanel>
                 )}
             </MainContent>


### PR DESCRIPTION
Resolve https://github.com/wso2/product-integrator/issues/1312
## Summary

- Centralize Devant detection behind a single util `isInDevant()` in `ballerina-extension/src/utils/config.ts`; replace 4 inline `process.env.CLOUD_STS_TOKEN` checks across `stateMachine.ts`, `extension.ts`, `features/devant/activator.ts`, and `rpc-managers/ai-panel/rpc-manager.ts`.
- Apply the same Devant gating that Package Overview already has to Workspace Overview: hide the `IntegrationControlPlane` block (and the regular multi-state `DeploymentOptions`) in Devant, render a new `WorkspaceDevantDashboard` ("Save and Deploy") instead.
- Stop exposing ICP entry points entirely in Devant: `activateICP()` is skipped (no status-bar item, no `ballerina.icp.start/stop/focus` command registrations); the BI run-time "ICP server not running" prompt is skipped; and `ballerina.icp.start/stop` enablement clauses gain `&& !devant.editor` so they don't appear in the Command Palette.

## Test plan

- [ ] **Devant cloud editor** (`CLOUD_STS_TOKEN` set in env): Workspace Overview shows only the new "Deploy to WSO2 Cloud / Save and Deploy" side panel — no `Deployment Options` accordion, no `Integration Control Plane` block.
- [ ] **Devant cloud editor**: Package Overview side panel shows the existing `<DevantDashboard>` (unchanged behavior).
- [ ] **Devant cloud editor**: ICP status bar item is absent; `Ballerina: Start ICP` / `Stop ICP` do not appear in the Command Palette.
- [ ] **Devant cloud editor**: Running a BI project does not prompt to start an ICP server even if `main.bal` carries the ICP imports.
- [ ] **Local VS Code (no `CLOUD_STS_TOKEN`)**: Workspace Overview is unchanged — `Deployment Options` + `Integration Control Plane` (multi-package "X/Y integrations are ICP-enabled") render as before.
- [ ] **Local VS Code**: Package Overview side panel renders `DeploymentOptions`, ICP toggle, and `LocalICPDeployment` Start/Stop buttons as before.
- [ ] **Local VS Code**: ICP status bar item appears; `Start ICP` / `Stop ICP` are reachable from the Command Palette; BI run-time ICP server prompt fires when `main.bal` imports the ICP runtime bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an environment-aware deployment dashboard with a streamlined "Deploy to WSO2 Cloud" workflow.

* **Changes**
  * Integration Control Plane start/stop commands are disabled when the extension is running in the special environment.
  * Workspace Overview now adapts its deployment panel and available actions based on environment context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->