### PR TITLE
Fix Hurl Client File reading issue

### DIFF
--- a/workspaces/api-tryit/hurl-runner/src/hurl-runner.ts
+++ b/workspaces/api-tryit/hurl-runner/src/hurl-runner.ts
@@ -393,6 +393,9 @@ export class HurlRunnerImpl implements HurlRunner {
 
 	private buildHurlArgs(filePath: string, reportPath: string, options: HurlRunOptions): string[] {
 		const args = [filePath, '--report-json', reportPath];
+		if (options.file_root) {
+			args.push('--file-root', options.file_root);
+		}
 		// --test suppresses all response output; omit it when the caller wants the response body
 		if (!options.includeResponseOutput) {
 			args.push('--test');

--- a/workspaces/api-tryit/hurl-runner/src/hurl-runner.ts
+++ b/workspaces/api-tryit/hurl-runner/src/hurl-runner.ts
@@ -393,8 +393,8 @@ export class HurlRunnerImpl implements HurlRunner {
 
 	private buildHurlArgs(filePath: string, reportPath: string, options: HurlRunOptions): string[] {
 		const args = [filePath, '--report-json', reportPath];
-		if (options.file_root) {
-			args.push('--file-root', options.file_root);
+		if (options.fileRoot) {
+			args.push('--file-root', options.fileRoot);
 		}
 		// --test suppresses all response output; omit it when the caller wants the response body
 		if (!options.includeResponseOutput) {

--- a/workspaces/api-tryit/hurl-runner/src/types.ts
+++ b/workspaces/api-tryit/hurl-runner/src/types.ts
@@ -36,7 +36,7 @@ export interface HurlRunOptions {
 	timeoutMs?: number;
 	env?: Record<string, string>;
 	variables?: Record<string, string>;
-	file_root?: string;
+	fileRoot?: string;
 	insecure?: boolean;
 	followRedirects?: boolean;
 	includeResponseOutput?: boolean;

--- a/workspaces/api-tryit/hurl-runner/src/types.ts
+++ b/workspaces/api-tryit/hurl-runner/src/types.ts
@@ -36,6 +36,7 @@ export interface HurlRunOptions {
 	timeoutMs?: number;
 	env?: Record<string, string>;
 	variables?: Record<string, string>;
+	file_root?: string;
 	insecure?: boolean;
 	followRedirects?: boolean;
 	includeResponseOutput?: boolean;

--- a/workspaces/hurl-client/hurl-client-extension/package.json
+++ b/workspaces/hurl-client/hurl-client-extension/package.json
@@ -151,6 +151,12 @@
           "type": "string",
           "default": "7.1.0",
           "description": "Managed hurl version to install."
+        },
+        "hurl-client.fileRoot": {
+          "type": "string",
+          "default": "",
+          "scope": "resource",
+          "description": "Default file root directory for Hurl notebook execution. If set, overrides the notebook's directory. Used as the base path for file references in Hurl requests."
         }
       }
     }

--- a/workspaces/hurl-client/hurl-client-extension/src/notebook/HurlNotebookController.ts
+++ b/workspaces/hurl-client/hurl-client-extension/src/notebook/HurlNotebookController.ts
@@ -65,16 +65,17 @@ export class HurlNotebookController {
 
     private async executeHandler(
         cells: vscode.NotebookCell[],
-        _notebook: vscode.NotebookDocument,
+        notebook: vscode.NotebookDocument,
         controller: vscode.NotebookController
     ): Promise<void> {
         for (const cell of cells) {
-            await this.executeCell(cell, controller);
+            await this.executeCell(cell, notebook, controller);
         }
     }
 
     private async executeCell(
         cell: vscode.NotebookCell,
+        notebook: vscode.NotebookDocument,
         controller: vscode.NotebookController
     ): Promise<void> {
         const execution = controller.createNotebookCellExecution(cell);
@@ -97,10 +98,15 @@ export class HurlNotebookController {
             const tempFile = path.join(tempDir, 'cell.hurl');
             await fs.writeFile(tempFile, hurlContent, 'utf-8');
 
+            // Determine file_root: check configuration and fallback to notebook directory.
+            const configuredFileRoot = vscode.workspace.getConfiguration('hurl-client', notebook.uri).get<string>('fileRoot');
+            const notebookPath = notebook.uri.fsPath;
+            const fileRoot = configuredFileRoot || path.dirname(notebookPath);
+
             const runner = createHurlRunner();
             const result = await runner.run(
                 { collectionPath: tempDir, includePatterns: ['cell.hurl'] },
-                { commandPath, includeResponseOutput: true, continueOnError: true }
+                { commandPath, includeResponseOutput: true, continueOnError: true, file_root: fileRoot }
             );
 
             const fileResult = result.files[0];

--- a/workspaces/hurl-client/hurl-client-extension/src/notebook/HurlNotebookController.ts
+++ b/workspaces/hurl-client/hurl-client-extension/src/notebook/HurlNotebookController.ts
@@ -98,7 +98,7 @@ export class HurlNotebookController {
             const tempFile = path.join(tempDir, 'cell.hurl');
             await fs.writeFile(tempFile, hurlContent, 'utf-8');
 
-            // Determine file_root: check configuration and fallback to notebook directory.
+            // Determine fileRoot: check configuration and fallback to notebook directory.
             const configuredFileRoot = vscode.workspace.getConfiguration('hurl-client', notebook.uri).get<string>('fileRoot');
             const notebookPath = notebook.uri.fsPath;
             const fileRoot = configuredFileRoot || path.dirname(notebookPath);
@@ -106,7 +106,7 @@ export class HurlNotebookController {
             const runner = createHurlRunner();
             const result = await runner.run(
                 { collectionPath: tempDir, includePatterns: ['cell.hurl'] },
-                { commandPath, includeResponseOutput: true, continueOnError: true, file_root: fileRoot }
+                { commandPath, includeResponseOutput: true, continueOnError: true, fileRoot: fileRoot }
             );
 
             const fileResult = result.files[0];


### PR DESCRIPTION
## Purpose
> Fix Issue https://github.com/wso2/product-integrator/issues/1424

### Aproach
> The fix was implemented by introducing support for the file_root parameter in the Hurl Runner(translated to the --file-root argument for the Hurl binary). When executing Hurl scripts from the Hurl Client Notebook, the notebook’s directory is now automatically passed as the file_root value. This allows relative file references in multipart form-data file fields to resolve correctly by default, matching the behavior of the Hurl CLI.

- Additionally, a hurl-client.fileRoot configuration was added. When configured, this value overrides the notebook directory and is passed to the runner as the file_root option, allowing users to explicitly control the base directory used for resolving file references.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a configurable file root setting for Hurl notebooks. You can now specify a default base directory for file references in your Hurl requests. The setting can override the notebook directory and defaults to the notebook location if not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->