### PR TITLE
Fix server running issue when cipher-tool is enabled

### DIFF
--- a/workspaces/mi/mi-extension/src/debugger/debugHelper.ts
+++ b/workspaces/mi/mi-extension/src/debugger/debugHelper.ts
@@ -350,9 +350,57 @@ async function getCarFiles(targetDirectory) {
 let serverProcess: ChildProcess;
 const debugConsole = vscode.debug.activeDebugConsole;
 
+export function isCipherToolEnabled(serverPath: string): boolean {
+    const secretConfPath = path.join(serverPath, 'conf', 'security', 'secret-conf.properties');
+    if (!fs.existsSync(secretConfPath)) {
+        return false;
+    }
+    const lines = fs.readFileSync(secretConfPath, 'utf-8').split(/\r?\n/);
+    return lines.some(line => {
+        const trimmed = line.trim();
+        if (trimmed.startsWith('#')) {
+            return false;
+        }
+        const [key, ...rest] = trimmed.split('=');
+        const value = rest.join('=').split('#')[0].trim();
+        return key.trim() === 'secVault.enabled' && value === 'true';
+    });
+}
+
+export async function promptAndWriteCipherToolPassword(serverPath: string): Promise<boolean> {
+    if (!isCipherToolEnabled(serverPath)) {
+        return true;
+    }
+    const password = await vscode.window.showInputBox({
+        title: 'Cipher Tool Decrypt Password',
+        prompt: 'Enter the decrypt password for the cipher tool',
+        password: true,
+        ignoreFocusOut: true,
+        placeHolder: 'Decrypt password',
+        validateInput: (value: string) => value.trim() === '' ? 'Password cannot be blank' : undefined
+    });
+    if (password === undefined) {
+        return false;
+    }
+    const passwordFileName = process.platform === 'win32' ? 'password-tmp.txt' : 'password-tmp';
+    try {
+        fs.writeFileSync(path.join(serverPath, passwordFileName), password, { encoding: 'utf8' });
+        return true;
+    } catch (err) {
+        vscode.window.showErrorMessage(`Failed to write cipher tool password file: ${(err as Error).message}`);
+        return false;
+    }
+}
+
 // Start the server
 export async function startServer(projectUri: string, serverPath: string, isDebug: boolean): Promise<void> {
     return new Promise<void>(async (resolve, reject) => {
+        const passwordWritten = await promptAndWriteCipherToolPassword(serverPath);
+        if (!passwordWritten) {
+            reject('Server startup cancelled: cipher tool decrypt password was not provided.');
+            return;
+        }
+
         if (DebuggerConfig.getProjectList().length > 0) {
             for (const project of DebuggerConfig.getProjectList()) {
                 const filePath = path.resolve(project, '.env');

--- a/workspaces/mi/mi-extension/src/test-explorer/runner.ts
+++ b/workspaces/mi/mi-extension/src/test-explorer/runner.ts
@@ -26,7 +26,7 @@ import { discoverTests, gatherTestItems } from "./discover";
 import { testController } from "./activator";
 import path = require("path");
 import { getProjectRoot } from "./helper";
-import { getServerPath, setJavaHomeInEnvironmentAndPath } from "../debugger/debugHelper";
+import { getServerPath, setJavaHomeInEnvironmentAndPath, promptAndWriteCipherToolPassword } from "../debugger/debugHelper";
 import { TestRunnerConfig } from "./config";
 import { ChildProcess } from "child_process";
 import treeKill = require("tree-kill");
@@ -241,6 +241,12 @@ async function startTestServer(serverPath: string, projectRoot: string, printToO
             const filePath = path.resolve(projectRoot, '.env');
             if (fs.existsSync(filePath)) {
                 loadEnvVariables(filePath)
+            }
+
+            const passwordWritten = await promptAndWriteCipherToolPassword(serverPath);
+            if (!passwordWritten) {
+                reject('Server startup cancelled: cipher tool decrypt password was not provided.');
+                return;
             }
 
             const scriptFile = process.platform === "win32" ? "micro-integrator.bat" : "micro-integrator.sh";


### PR DESCRIPTION
This PR will fix the issue https://github.com/wso2/mi-vscode/issues/1479

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server startup (including test server) now detects when cipher decryption is enabled and prompts for a decryption password before launching. Blank input is validated, the password is stored temporarily for the session, and startup is aborted with a clear cancellation message if the prompt is dismissed or the write fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->