### PR TITLE
Reduce LS didOpen events by opening only Ballerina.toml per package

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/features/ai/utils/project/ls-schema-notifications.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/utils/project/ls-schema-notifications.ts
@@ -196,36 +196,37 @@ export function sendAgentDidOpenForFreshProjects(tempProjectPath: string, projec
 
   projects.forEach(project => {
     const pkgPath = project.packagePath || ""; // Empty for single package, relative path for workspace
-    
+
     // Add root-level source files
     project.sourceFiles.forEach(f => {
       const relativePath = pkgPath ? path.join(pkgPath, f.filePath) : f.filePath;
       allFiles.push(relativePath);
     });
-    
+
     // Add module files
     project.projectModules?.forEach(module => {
       module.sourceFiles.forEach(f => {
-        const relativePath = pkgPath 
+        const relativePath = pkgPath
           ? path.join(pkgPath, 'modules', module.moduleName, f.filePath)
           : path.join('modules', module.moduleName, f.filePath);
         allFiles.push(relativePath);
       });
     });
-    
+
     // Add test files
     if (project.projectTests) {
       project.projectTests.forEach(f => {
-        const relativePath = pkgPath 
+        const relativePath = pkgPath
           ? path.join(pkgPath, 'tests', f.filePath)
           : path.join('tests', f.filePath);
         allFiles.push(relativePath);
       });
     }
   });
-  
-  console.log(`[AgentNotification] Sending didOpen for ${allFiles.length} files across ${projects.length} project(s)`);
-  allFiles.forEach(file => sendBothSchemaDidOpen(tempProjectPath, file));
+
+  const tomlFiles = allFiles.filter(f => f.endsWith('Ballerina.toml'));
+  console.log(`[AgentNotification] Sending didOpen for ${tomlFiles.length} Ballerina.toml(s) across ${projects.length} project(s)`);
+  tomlFiles.forEach(file => sendBothSchemaDidOpen(tempProjectPath, file));
 }
 
 /**

--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/ai-panel/utils.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/ai-panel/utils.ts
@@ -93,10 +93,9 @@ export async function addToIntegration(workspaceFolderPath: string, fileChanges:
             unsubscribe();
         });
 
-        // Set a timeout to reject if no notification is received within 10 seconds
         const timeoutId = setTimeout(() => {
-            console.log("No artifact update notification received within 10 seconds");
-            reject(new Error("Operation timed out. Please try again."));
+            console.warn("No artifact update notification received within 10 seconds");
+            resolve([]);
             unsubscribe();
         }, 10000);
 


### PR DESCRIPTION
Related to https://github.com/wso2/product-integrator/issues/1165
Related to https://github.com/wso2/product-integrator/issues/1380

- Replace per-file didOpen for every `.bal` file with a single `Ballerina.toml` didOpen per package — the LS triggers a full `loadProject()` scan from a single toml open, making per-file opens redundant
- Resolve instead of rejecting on artifact notification timeout — fixes integration flow on slow machines where the 10s window was too tight

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Streamlined project initialization to open only essential configuration files instead of all discovered files, improving startup efficiency
  * Enhanced artifact update timeout handling to gracefully complete with a warning instead of failing operations, improving system resilience during network delays

<!-- end of auto-generated comment: release notes by coderabbit.ai -->