### PR TITLE
Fix code blocks visible in MarkdownDescription component

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/Form/MarkdownDescription.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/Form/MarkdownDescription.tsx
@@ -50,14 +50,11 @@ const MarkdownContainer = styled.div`
     }
 
     pre {
-        margin: 8px 0;
-        padding: 8px;
-        overflow-x: auto;
-        background: var(--vscode-editor-inactiveSelectionBackground);
-        border-radius: 4px;
+        display: none;
     }
 
     code {
+        display: inline;
         font-family: var(--vscode-editor-font-family);
     }
 


### PR DESCRIPTION
## Purpose
> Related issue: https://github.com/wso2/product-integrator/issues/1174

## Summary

During the refactor in #2165 that extracted the markdown rendering into the reusable `MarkdownDescription` component, the CSS rules that hid fenced code blocks (`pre { display: none }`) and kept inline code visible (`code { display: inline }`) were not carried over.

The new component instead added visible `pre` styling, causing ``` code blocks to appear in the side panel node descriptions where they should be hidden.

This fix restores the original behavior:
- Fenced code blocks (` ``` `) are hidden via `pre { display: none }`
- Inline code (`` ` ``) remains visible via `code { display: inline }`

## Goals
Restore the correct markdown rendering behavior where only inline code is shown and fenced code blocks are hidden in node descriptions.

## Approach
Updated `MarkdownDescription.tsx` to replace the `pre` block styling with `display: none` and added `display: inline` to the `code` rule, matching the original styles in `Form/index.tsx` before the refactor.

## Automation tests
- Unit tests: N/A (visual/rendering fix)

## Security checks
- Followed secure coding standards: yes
- Ran FindSecurityBugs plugin: N/A
- No keys, passwords, tokens, or secrets committed: yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Modified how code elements are displayed in markdown descriptions. Code blocks are now hidden while inline code uses inline display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->