### PR TITLE
Fix design diagram navigation in ReviewMode and ReviewBar for workspace projects

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/ReviewBar/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/ReviewBar/index.tsx
@@ -381,7 +381,13 @@ function getChangeTypeLabel(changeType: number): string {
 
 function buildGroups(semanticDiffs: SemanticDiff[], loadDesignDiagrams?: boolean): DiffGroup[] {
     const designCount = loadDesignDiagrams ? 1 : 0;
-    return buildGroupsWithOffset(semanticDiffs, designCount).groups;
+    const { groups } = buildGroupsWithOffset(semanticDiffs, designCount);
+    if (!loadDesignDiagrams) return groups;
+    const designGroup: DiffGroup = {
+        groupLabel: "design",
+        entries: [{ symbol: "", changeType: ChangeTypeEnum.MODIFICATION, label: "Design Diagram", kindLabel: "design", nodeKind: -1, viewIndex: 0 }],
+    };
+    return [designGroup, ...groups];
 }
 
 const PackageContent = styled.div`
@@ -398,10 +404,7 @@ function buildPackageGroups(
     diffPackageMap: string[],
     loadDesignDiagrams?: boolean
 ): PackageGroup[] {
-    const designCount = loadDesignDiagrams ? 1 : 0;
-    let globalViewIndex = designCount;
-
-    // Group diffs by package name using the parallel map, preserving order
+    // Group diffs by package, preserving first-appearance order
     const orderedPkgs: string[] = [];
     const pkgDiffsMap: Record<string, SemanticDiff[]> = {};
     for (let i = 0; i < semanticDiffs.length; i++) {
@@ -413,15 +416,29 @@ function buildPackageGroups(
         pkgDiffsMap[pkgName].push(semanticDiffs[i]);
     }
 
+    // Design diagrams align 1:1 with packages that have diffs, in the same order
+    const designCount = loadDesignDiagrams ? orderedPkgs.length : 0;
+    let globalViewIndex = designCount;
+
     const result: PackageGroup[] = [];
-    for (const pkgName of orderedPkgs) {
+    for (let pi = 0; pi < orderedPkgs.length; pi++) {
+        const pkgName = orderedPkgs[pi];
         const diffs = pkgDiffsMap[pkgName];
         if (diffs.length === 0) continue;
 
         const { groups, viewCount } = buildGroupsWithOffset(diffs, globalViewIndex);
         globalViewIndex += viewCount;
 
-        result.push({ packageName: pkgName, groups });
+        let finalGroups = groups;
+        if (loadDesignDiagrams) {
+            const designGroup: DiffGroup = {
+                groupLabel: "design",
+                entries: [{ symbol: "", changeType: ChangeTypeEnum.MODIFICATION, label: "Design Diagram", kindLabel: "design", nodeKind: -1, viewIndex: pi }],
+            };
+            finalGroups = [designGroup, ...groups];
+        }
+
+        result.push({ packageName: pkgName, groups: finalGroups });
     }
 
     return result;
@@ -616,6 +633,7 @@ const CollapsibleGroupList: React.FC<{
                 const isService = group.groupLabel.startsWith("service ");
                 const isFunctions = group.groupLabel === "functions";
                 const isTypes = group.groupLabel === "types";
+                const isDesign = group.groupLabel === "design";
                 const isCollapsible = isService || isFunctions;
                 const isCollapsed = !!collapsed[gi];
 
@@ -643,7 +661,17 @@ const CollapsibleGroupList: React.FC<{
                             </CollapsibleHeader>
                         )}
                         {!isCollapsed && (
-                            isTypes ? (
+                            isDesign ? (
+                                <TypesRow
+                                    onClick={onClickEntry ? () => onClickEntry(group.entries[0].viewIndex) : undefined}
+                                    disabled={!onClickEntry}
+                                >
+                                    <CardLeft>
+                                        <span className="codicon codicon-type-hierarchy" style={{ fontSize: "11px", color: "var(--vscode-descriptionForeground)" }} />
+                                        <span>Design Diagram</span>
+                                    </CardLeft>
+                                </TypesRow>
+                            ) : isTypes ? (
                                 <TypesRow
                                     onClick={onClickEntry ? () => onClickEntry(group.entries[0].viewIndex) : undefined}
                                     disabled={!onClickEntry}

--- a/workspaces/ballerina/ballerina-visualizer/src/views/ReviewMode/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/ReviewMode/index.tsx
@@ -265,10 +265,26 @@ export function ReviewMode(): JSX.Element {
             setSemanticDiffData({ semanticDiffs, loadDesignDiagrams });
 
             const packagesToReview = isWorkspaceProject ? affectedPackages : [tempDirPath];
+            const normalizedTempDir = tempDirPath.replace(/\\/g, "/");
+            const filteredPackages = isWorkspaceProject
+                ? packagesToReview.filter((p: string) => p.replace(/\\/g, "/") !== normalizedTempDir)
+                : packagesToReview;
             const allViews: ReviewView[] = [];
 
             if (loadDesignDiagrams && semanticDiffs.length > 0) {
-                packagesToReview.forEach((packagePath: string) => {
+                const pkgsWithDiffs = new Set<string>();
+                for (const diff of semanticDiffs) {
+                    const uriPath = diff.uri.replace(/^[a-z][a-z0-9+.-]*:\/\//, "").replace(/\\/g, "/");
+                    for (const pkgPath of filteredPackages) {
+                        const normalizedPkgPath = pkgPath.replace(/\\/g, "/");
+                        if (uriPath.startsWith(normalizedPkgPath + "/") || uriPath === normalizedPkgPath) {
+                            pkgsWithDiffs.add(pkgPath);
+                            break;
+                        }
+                    }
+                }
+                filteredPackages.forEach((packagePath: string) => {
+                    if (!pkgsWithDiffs.has(packagePath)) return;
                     const packageName = getPackageName(packagePath);
                     allViews.push({
                         type: DiagramType.COMPONENT,
@@ -286,7 +302,7 @@ export function ReviewMode(): JSX.Element {
                 let belongsToPackage = tempDirPath;
                 let packageName: string | undefined;
                 if (isWorkspaceProject) {
-                    for (const pkgPath of packagesToReview) {
+                    for (const pkgPath of filteredPackages) {
                         const normalizedUri = diff.uri.replace(/\\/g, "/");
                         const normalizedPkgPath = pkgPath.replace(/\\/g, "/");
                         if (normalizedUri.startsWith(normalizedPkgPath + "/") || normalizedUri === normalizedPkgPath) {


### PR DESCRIPTION
Related to https://github.com/wso2/product-integrator/issues/1429

- Skip workspace root temp dir when creating design diagram views in ReviewMode to remove the spurious duplicate view
- Add a Design Diagram chip in the ReviewBar for each package so users can navigate directly to it
- Fix design diagram count and per-package view index in ReviewBar using filtered affectedPackages so diff chip indices are correct when multiple packages are affected


<img width="781" height="443" alt="Screenshot 2026-05-07 at 8 48 28 PM" src="https://github.com/user-attachments/assets/7b0ad76a-8f89-4d98-9654-b1534d66c5b0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Package-level design diagrams with enhanced grouping and organization based on affected packages.
  * Dedicated design diagram display mode in diagram organization.

* **Bug Fixes**
  * Resolved cross-platform filesystem path handling to ensure consistent operation across Windows, macOS, and Linux environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->