### PR TITLE
Fix Copilot terminology for multi-integration project creation

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/prompts.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/prompts.ts
@@ -191,6 +191,10 @@ ${getLanglibInstructions()}
 ## Workspace Management
 When working with Ballerina workspace projects (projects with a root Ballerina.toml containing a [workspace] section):
 
+### Terminology
+User may refer to workspace as project in their query.
+User may refer to package as Integration in their query.
+
 ### Creating a new package
 1. Create the package directory with a Ballerina.toml containing the [package] section (name, org, version).
 2. Update the root workspace Ballerina.toml to add the new package path to the packages array.

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/prompts.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/prompts.ts
@@ -193,7 +193,6 @@ When working with Ballerina workspace projects (projects with a root Ballerina.t
 
 ### Terminology
 In WSO2 Integrator, a Ballerina workspace is called a **project** and a Ballerina package is called an **integration**.
-- User will always use "project" and "integration" — never "workspace" or "package".
 - You MUST always use "project" and "integration" in all responses and clarifying questions. Never use "workspace" or "package" when communicating with the user.
 
 ### Creating a new package

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/prompts.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/prompts.ts
@@ -194,6 +194,7 @@ When working with Ballerina workspace projects (projects with a root Ballerina.t
 ### Terminology
 User may refer to workspace as project in their query.
 User may refer to package as Integration in their query.
+When communicating with the user, always use the terms "project" and "integration" instead of "workspace" and "package".
 
 ### Creating a new package
 1. Create the package directory with a Ballerina.toml containing the [package] section (name, org, version).

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/prompts.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/prompts.ts
@@ -192,9 +192,9 @@ ${getLanglibInstructions()}
 When working with Ballerina workspace projects (projects with a root Ballerina.toml containing a [workspace] section):
 
 ### Terminology
-User may refer to workspace as project in their query.
-User may refer to package as Integration in their query.
-When communicating with the user, always use the terms "project" and "integration" instead of "workspace" and "package".
+In WSO2 Integrator, a Ballerina workspace is called a **project** and a Ballerina package is called an **integration**.
+- User will always use "project" and "integration" — never "workspace" or "package".
+- You MUST always use "project" and "integration" in all responses and clarifying questions. Never use "workspace" or "package" when communicating with the user.
 
 ### Creating a new package
 1. Create the package directory with a Ballerina.toml containing the [package] section (name, org, version).


### PR DESCRIPTION
Related to https://github.com/wso2/product-integrator/issues/1383

- Add a Terminology section to the Workspace Management block in the Copilot system prompt
- Maps user-facing terms: "project" → workspace, "integration" → package

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI agent prompts now automatically include system context with current UTC timestamp, providing enhanced context awareness during code generation sessions.
  * Workspace terminology updated with explicit definitions for "project" and "integration" usage in agent responses.
  * Plan and edit mode operation guidance refined to provide clearer direction in workflow execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->