### PR TITLE
fix: clear orphaned webview tabs before opening visualizer or AI panel

### DIFF
--- a/workspaces/ballerina/ballerina-extension/package.json
+++ b/workspaces/ballerina/ballerina-extension/package.json
@@ -2,7 +2,7 @@
     "name": "ballerina",
     "displayName": "Ballerina",
     "description": "Ballerina Language support, debugging, graphical visualization, AI-based data-mapping and many more.",
-    "version": "5.9.4-beta575",
+    "version": "5.9.4",
     "publisher": "wso2",
     "icon": "resources/images/ballerina.png",
     "homepage": "https://wso2.com/ballerina/vscode/docs",

--- a/workspaces/ballerina/ballerina-extension/package.json
+++ b/workspaces/ballerina/ballerina-extension/package.json
@@ -2,7 +2,7 @@
     "name": "ballerina",
     "displayName": "Ballerina",
     "description": "Ballerina Language support, debugging, graphical visualization, AI-based data-mapping and many more.",
-    "version": "5.9.4",
+    "version": "5.9.4-beta575",
     "publisher": "wso2",
     "icon": "resources/images/ballerina.png",
     "homepage": "https://wso2.com/ballerina/vscode/docs",

--- a/workspaces/ballerina/ballerina-extension/src/extension.ts
+++ b/workspaces/ballerina/ballerina-extension/src/extension.ts
@@ -42,6 +42,7 @@ import { activateUriHandlers } from './utils/uri-handlers';
 import { StateMachine } from './stateMachine';
 import { activateSubscriptions } from './views/visualizer/activate';
 import { VisualizerWebview } from './views/visualizer/webview';
+import { AiPanelWebview } from './views/ai-panel/webview';
 import { extension } from './BalExtensionContext';
 import { ExtendedClientCapabilities } from '@wso2/ballerina-core';
 import { RPCLayer } from './RPCLayer';
@@ -132,6 +133,16 @@ export async function activate(context: ExtensionContext) {
     extension.context = context;
     // Init RPC Layer methods
     RPCLayer.init();
+
+    // Register serializers that dispose orphaned webview tabs restored by VS Code after a restart.
+    // Without this, previously open panels leave behind empty placeholder tabs on reload.
+    const disposeOnRestore: vscode.WebviewPanelSerializer = {
+        deserializeWebviewPanel: async (panel) => { panel.dispose(); }
+    };
+    context.subscriptions.push(
+        vscode.window.registerWebviewPanelSerializer(VisualizerWebview.viewType, disposeOnRestore),
+        vscode.window.registerWebviewPanelSerializer(AiPanelWebview.viewType, disposeOnRestore),
+    );
 
     // Wait for the ballerina extension to be ready
     await StateMachine.initialize();

--- a/workspaces/ballerina/ballerina-extension/src/stateMachine.ts
+++ b/workspaces/ballerina/ballerina-extension/src/stateMachine.ts
@@ -44,6 +44,7 @@ import { activateDevantFeatures } from './features/devant/activator';
 import { buildProjectsStructure } from './utils/project-artifacts';
 import { runCommandWithOutput } from './utils/runCommand';
 import { buildOutputChannel } from './utils/logger';
+import { closeOrphanWebviewTabs } from './views/closeOrphanWebviewTabs';
 
 export interface ProjectMetadata {
     readonly isBI: boolean;
@@ -551,27 +552,31 @@ const stateMachine = createMachine<MachineContext>(
         },
         openWebView: (context, event) => {
             // Get context values from the project storage so that we can restore the earlier state when user reopens vscode
-            return new Promise((resolve, reject) => {
-                if (!VisualizerWebview.currentPanel) {
-                    extension.ballerinaExtInstance.setContext(extension.context);
-                    VisualizerWebview.currentPanel = new VisualizerWebview();
-                    RPCLayer._messenger.onNotification(webviewReady, () => {
-                        history = new History();
-                        undoRedoManager = new UndoRedoManager();
-                        const webview = VisualizerWebview.currentPanel?.getWebview();
-                        if (webview && (context.isBI || context.view === MACHINE_VIEW.BIWelcome)) {
-                            const biExtension = isInWI() || extensions.getExtension('wso2.ballerina-integrator');
-                            webview.iconPath = {
-                                light: Uri.file(path.join(extension.context.extensionPath, 'resources', 'icons', biExtension ? 'wso2-dark.svg' : 'ballerina.svg')),
-                                dark: Uri.file(path.join(extension.context.extensionPath, 'resources', 'icons', biExtension ? 'wso2-light.svg' : 'ballerina-inverse.svg'))
-                            };
-                        }
+            return new Promise(async (resolve, reject) => {
+                try {
+                    if (!VisualizerWebview.currentPanel) {
+                        await closeOrphanWebviewTabs([VisualizerWebview.viewType]);
+                        extension.ballerinaExtInstance.setContext(extension.context);
+                        VisualizerWebview.currentPanel = new VisualizerWebview();
+                        RPCLayer._messenger.onNotification(webviewReady, () => {
+                            history = new History();
+                            undoRedoManager = new UndoRedoManager();
+                            const webview = VisualizerWebview.currentPanel?.getWebview();
+                            if (webview && (context.isBI || context.view === MACHINE_VIEW.BIWelcome)) {
+                                const biExtension = isInWI() || extensions.getExtension('wso2.ballerina-integrator');
+                                webview.iconPath = {
+                                    light: Uri.file(path.join(extension.context.extensionPath, 'resources', 'icons', biExtension ? 'wso2-dark.svg' : 'ballerina.svg')),
+                                    dark: Uri.file(path.join(extension.context.extensionPath, 'resources', 'icons', biExtension ? 'wso2-light.svg' : 'ballerina-inverse.svg'))
+                                };
+                            }
+                            resolve(true);
+                        });
+                    } else {
+                        VisualizerWebview.currentPanel!.getWebview()?.reveal();
                         resolve(true);
-                    });
-
-                } else {
-                    VisualizerWebview.currentPanel!.getWebview()?.reveal();
-                    resolve(true);
+                    }
+                } catch (e) {
+                    reject(e);
                 }
             });
         },

--- a/workspaces/ballerina/ballerina-extension/src/views/ai-panel/aiMachine.ts
+++ b/workspaces/ballerina/ballerina-extension/src/views/ai-panel/aiMachine.ts
@@ -33,10 +33,12 @@ import {
 } from '../../utils/ai/auth';
 import * as vscode from 'vscode';
 import { notifyAiPromptUpdated } from '../../RPCLayer';
+import { closeOrphanWebviewTabs } from '../closeOrphanWebviewTabs';
 
-export const openAIWebview = (defaultprompt?: AIPanelPrompt) => {
+export const openAIWebview = async (defaultprompt?: AIPanelPrompt) => {
     extension.aiChatDefaultPrompt = defaultprompt;
     if (!AiPanelWebview.currentPanel) {
+        await closeOrphanWebviewTabs([AiPanelWebview.viewType]);
         AiPanelWebview.currentPanel = new AiPanelWebview();
     } else {
         AiPanelWebview.currentPanel!.getWebview()?.reveal();

--- a/workspaces/ballerina/ballerina-extension/src/views/closeOrphanWebviewTabs.ts
+++ b/workspaces/ballerina/ballerina-extension/src/views/closeOrphanWebviewTabs.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/workspaces/ballerina/ballerina-extension/src/views/closeOrphanWebviewTabs.ts
+++ b/workspaces/ballerina/ballerina-extension/src/views/closeOrphanWebviewTabs.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import * as vscode from "vscode";
+
+/**
+ * Closes all webview tabs whose viewType matches any of the given raw viewType strings.
+ *
+ * VS Code prefixes the stored tab viewType as "mainThreadWebview-<viewType>", so
+ * comparison checks both an exact match and the "-<viewType>" suffix.
+ *
+ * Call this before creating a new webview panel to remove orphaned empty tabs that
+ * VS Code persisted from a previous session but could not restore (no serializer).
+ */
+export async function closeOrphanWebviewTabs(viewTypes: string[]): Promise<void> {
+    const tabsToClose: vscode.Tab[] = [];
+
+    for (const tabGroup of vscode.window.tabGroups.all) {
+        for (const tab of tabGroup.tabs) {
+            if (!(tab.input instanceof vscode.TabInputWebview)) {
+                continue;
+            }
+            const inputViewType = tab.input.viewType;
+            const matches = viewTypes.some(
+                (vt) => inputViewType === vt || inputViewType.endsWith(`-${vt}`)
+            );
+            if (matches) {
+                tabsToClose.push(tab);
+            }
+        }
+    }
+
+    if (tabsToClose.length > 0) {
+        await vscode.window.tabGroups.close(tabsToClose);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes empty/orphaned split-view tabs that accumulate in VS Code after the Ballerina Visualizer or AI Panel is open when VS Code is closed and then reopened.

Relates to https://github.com/wso2/product-integrator/issues/1206, https://github.com/wso2/product-integrator/issues/1335


https://github.com/user-attachments/assets/c1d26d2d-24cb-4e18-aacf-b886795ac6c3



**Root causes addressed:**

1. **No `WebviewPanelSerializer` registered** — VS Code persists open webview tabs across sessions. Without a serializer, it leaves empty placeholder tabs on restart that the extension has no reference to. Each new open stacks another panel on top of the orphans.

2. **`new Promise(async ...)` error-swallowing bug** — Changing the `openWebView` executor to `async` (to support `await closeOrphanWebviewTabs(...)`) introduced a silent hang: errors thrown inside an async Promise executor do not reject the outer Promise. When `extension.ballerinaExtInstance` is `undefined` (e.g. when the WI extension activates Ballerina before VS Code does), the original synchronous executor would throw → reject → XState `onError` → continue. The async executor swallowed the error, leaving the state machine stuck in `renderInitialView` and blocking `activate()` from returning — manifesting as a permanent **"Loading WSO2 Integrator..."** state in the activity panel.

## Changes

- **`extension.ts`** — Register `WebviewPanelSerializer`s for both `ballerina.visualizer` and `ballerina.ai-panel` in `activate()`. The serializer immediately disposes any panel VS Code attempts to restore, removing orphaned placeholder tabs at startup.
- **`views/closeOrphanWebviewTabs.ts`** *(new)* — Utility that iterates `vscode.window.tabGroups.all` and closes any `TabInputWebview` tab whose viewType matches a given list. Handles VS Code's `"mainThreadWebview-<viewType>"` prefix via `endsWith`.
- **`stateMachine.ts`** — Call `closeOrphanWebviewTabs([VisualizerWebview.viewType])` before creating a new `VisualizerWebview`. Wrap the async executor body in `try/catch` so errors properly call `reject(e)` rather than being swallowed.
- **`views/ai-panel/aiMachine.ts`** — Call `closeOrphanWebviewTabs([AiPanelWebview.viewType])` before creating a new `AiPanelWebview`.

## Test plan

- [x] Open a BI project in VS Code with both the Ballerina Visualizer and AI Panel visible.
- [x] Fully close VS Code (quit the application).
- [x] Reopen VS Code on the same project — confirm **no empty/blank webview tabs** remain.
- [x] From the WI extension tree view, click an item that opens the visualizer — confirm exactly **one** Ballerina Visualizer tab appears with no extra empty splits.
- [x] Repeat the open/close cycle 2–3 times to confirm splits do not accumulate.
- [x] Confirm the **"Loading WSO2 Integrator..."** state resolves correctly and does not persist.
- [x] Open the AI panel beside the visualizer — confirm the existing column-One placement logic still works.
- [ ] Close each panel via its tab close button and confirm `dispose()` runs cleanly (state machine resets).