### PR TITLE
Fix failed to pull connector message is removed fast

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/Connection/ConnectionConfigurationPopup/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/Connection/ConnectionConfigurationPopup/index.tsx
@@ -266,12 +266,16 @@ export function ConnectionConfigurationForm(props: ConnectionConfigurationFormPr
 
     useEffect(() => {
         // Fetch node template when component mounts
+
+        let clearPullingStatusTimer: ReturnType<typeof setTimeout> | null = null;
+
         const fetchNodeTemplate = async () => {
             if (!selectedConnector.codedata) {
                 console.error(">>> Error selecting connector. No codedata found");
                 return;
             }
 
+            let shouldClearPullingStatus = true;
             try {
                 let timer: ReturnType<typeof setTimeout> | null = null;
                 let didTimeout = false;
@@ -328,16 +332,25 @@ export function ConnectionConfigurationForm(props: ConnectionConfigurationFormPr
                 }
             } catch (error) {
                 console.error(">>> Error selecting connector", error);
+                shouldClearPullingStatus = false;
                 setPullingStatus(PullingStatus.ERROR);
             } finally {
                 // After few seconds, set status to undefined
-                setTimeout(() => {
-                    setPullingStatus(undefined);
-                }, 2000);
+                if (shouldClearPullingStatus) {
+                    clearPullingStatusTimer = setTimeout(() => {
+                        setPullingStatus(undefined);
+                    }, 2000);
+                }
             }
         };
 
         fetchNodeTemplate();
+
+        return () => {
+            if (clearPullingStatusTimer) {
+                clearTimeout(clearPullingStatusTimer);
+            }
+        }
     }, [selectedConnector, fileName, target, rpcClient]);
 
     const handleOnFormSubmit = async (node: FlowNode, _editorConfig?: EditorConfig, options?: FormSubmitOptions) => {


### PR DESCRIPTION
## Purpose
> Prevent clearing PullingState after timeout in case of PullingStatus.ERROR
> Fixes https://github.com/wso2/product-integrator/issues/1090

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection configuration form initialization with more reliable state cleanup and error handling for template loading operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->