### PR TITLE
Fix: allow collapsing sections during search in side panel

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/GroupList/index.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/GroupList/index.tsx
@@ -178,18 +178,19 @@ namespace S {
 interface GroupListProps {
     category: Category;
     expand?: boolean;
+    onToggle?: (isOpen: boolean) => void;
     onSelect: (node: Node, category: string) => void;
     enableSingleNodeDirectNav?: boolean;
     onImportDevantConn?: (devantConn: ConnectionListItem) => void;
 }
 
 export function GroupList(props: GroupListProps) {
-    const { category, expand, onSelect, enableSingleNodeDirectNav, onImportDevantConn } = props;
+    const { category, expand, onToggle, onSelect, enableSingleNodeDirectNav, onImportDevantConn } = props;
 
     const [showList, setShowList] = useState(expand ?? false);
 
     const nodes = category.items as Node[];
-    const openList = expand || showList;
+    const openList = expand !== undefined ? expand : showList;
     const enabledNodes = nodes.filter((node) => node.enabled);
     const isSingleNode = enabledNodes.length === 1 && enableSingleNodeDirectNav;
 
@@ -197,7 +198,11 @@ export function GroupList(props: GroupListProps) {
         if (isSingleNode) {
             onSelect(enabledNodes[0], category.title);
         } else {
-            setShowList(!showList);
+            if (expand !== undefined) {
+                onToggle?.(!expand);
+            } else {
+                setShowList(!showList);
+            }
         }
     };
 

--- a/workspaces/ballerina/ballerina-side-panel/src/components/NodeList/index.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/NodeList/index.tsx
@@ -397,6 +397,9 @@ export function NodeList(props: NodeListProps) {
     const [isSearching, setIsSearching] = useState(false);
     const [expandedMoreSections, setExpandedMoreSections] = useState<Record<string, boolean>>({});
     const [expandedCategories, setExpandedCategoriesState] = useState<Record<string, boolean>>({});
+    const [searchCollapsedCategories, setSearchCollapsedCategories] = useState<Record<string, boolean>>({});
+    const [searchCollapsedMoreSections, setSearchCollapsedMoreSections] = useState<Record<string, boolean>>({});
+    const [searchCollapsedConnections, setSearchCollapsedConnections] = useState<Record<string, boolean>>({});
     const { rpcClient } = useRpcContext();
     const [isNPSupported, setIsNPSupported] = useState(false);
 
@@ -444,6 +447,12 @@ export function NodeList(props: NodeListProps) {
         }
     }, [searchText]);
 
+    useEffect(() => {
+        setSearchCollapsedCategories({});
+        setSearchCollapsedMoreSections({});
+        setSearchCollapsedConnections({});
+    }, [searchText]);
+
     const handleSearch = (text: string) => {
         onSearchTextChange(text);
     };
@@ -464,6 +473,13 @@ export function NodeList(props: NodeListProps) {
     }, [categories]);
 
     const toggleMoreSection = (sectionKey: string) => {
+        if (searchText && searchText.length > 0) {
+            setSearchCollapsedMoreSections((prev) => ({
+                ...prev,
+                [sectionKey]: !prev[sectionKey],
+            }));
+            return;
+        }
         setExpandedMoreSections((prev) => ({
             ...prev,
             [sectionKey]: !prev[sectionKey],
@@ -471,6 +487,13 @@ export function NodeList(props: NodeListProps) {
     };
 
     const toggleCategory = (categoryTitle: string) => {
+        if (searchText && searchText.length > 0) {
+            setSearchCollapsedCategories((prev) => ({
+                ...prev,
+                [categoryTitle]: !prev[categoryTitle],
+            }));
+            return;
+        }
         const newExpandedState = {
             ...expandedCategories,
             [categoryTitle]: !expandedCategories[categoryTitle],
@@ -590,7 +613,9 @@ export function NodeList(props: NodeListProps) {
 
                     if (isMoreSubcategory) {
                         const sectionKey = `${parentCategoryTitle}-${subcategory.title}`;
-                        const isExpanded = expandedMoreSections[sectionKey] || searchText?.length > 0;
+                        const isExpanded = searchText?.length > 0
+                            ? !searchCollapsedMoreSections[sectionKey]
+                            : expandedMoreSections[sectionKey];
 
                         return (
                             <S.AdvancedSubcategoryContainer key={subcategory.title + index}>
@@ -639,7 +664,12 @@ export function NodeList(props: NodeListProps) {
                     <GroupList
                         key={category.title + index + "tooltip"}
                         category={category}
-                        expand={searchText?.length > 0}
+                        expand={searchText?.length > 0 ? !searchCollapsedConnections[category.title] : undefined}
+                        onToggle={(isOpen) => {
+                            if (searchText?.length > 0) {
+                                setSearchCollapsedConnections((prev) => ({ ...prev, [category.title]: !isOpen }));
+                            }
+                        }}
                         onSelect={handleAddNode}
                         onImportDevantConn={onImportDevantConn}
                         enableSingleNodeDirectNav={enableSingleNodeDirectNav}
@@ -703,7 +733,9 @@ export function NodeList(props: NodeListProps) {
                         return null;
                     }
 
-                    const isCategoryExpanded = shouldExpandAll || expandedCategories[group.title] !== false;
+                    const isCategoryExpanded = shouldExpandAll
+                        ? !searchCollapsedCategories[group.title]
+                        : expandedCategories[group.title] !== false;
 
                     return (
                         <React.Fragment key={group.title + index}>


### PR DESCRIPTION
## Summary

- In search mode, all sections were forced open and users had no way to collapse individual categories/sections
- Added three new state maps (`searchCollapsedCategories`, `searchCollapsedMoreSections`, `searchCollapsedConnections`) to track user-initiated collapses during search
- When the search query changes, all collapse states reset so sections re-expand to show new results
- `GroupList` updated to support parent-controlled open state via `onToggle` callback, with `openList = expand !== undefined ? expand : showList` so the parent's decision fully controls visibility when searching

Fixes https://github.com/wso2/product-integrator/issues/798


https://github.com/user-attachments/assets/384b384a-c8ce-4cd3-9aa9-7416a93c2c29



## Test plan

- [x] Type a search query → all sections expand as before
- [x] Click to collapse a section while in search mode → section collapses, others remain open
- [x] Type a different/longer search query → all sections re-expand (including the previously collapsed one)
- [x] Clear search → sections return to their pre-search persisted state (localStorage)
- [x] Verify collapse/expand in non-search mode still persists to localStorage normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Side panel group and node lists now support controlled expansion with callback notifications for state changes.

* **Bug Fixes**
  * Search filtering now maintains separate collapse states during active searches for improved behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->