### PR TITLE
Add refresh button for cloud deployment section

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
@@ -460,20 +460,20 @@ function DeploymentOptions({
         ? (currentProjectMeta?.hasComponent ?? false)
         : false;
 
-    const stopRefreshing = () => {
+    const stopRefreshing = useCallback(() => {
         setIsRefreshing(false);
         deployedAtRefreshStart.current = null;
         waitForLastFetchRef.current = false;
         sawFetchingRef.current = false;
         if (pollIntervalRef.current !== null) { clearInterval(pollIntervalRef.current); pollIntervalRef.current = null; }
-    };
+    }, []);
 
     // Early exit: stop as soon as isDeployed changes from what it was at click time.
     useEffect(() => {
         if (isRefreshing && deployedAtRefreshStart.current !== null && isDeployed !== deployedAtRefreshStart.current) {
             stopRefreshing();
         }
-    }, [isDeployed, isRefreshing]);
+    }, [isDeployed, isRefreshing, stopRefreshing]);
 
     // Final-poll exit: called after the 5th poll. Waits for isFetching to go true→false,
     // which fires in a useEffect — meaning devantMetadata is already updated in React state
@@ -485,7 +485,7 @@ function DeploymentOptions({
         } else if (sawFetchingRef.current) {
             stopRefreshing();
         }
-    }, [isFetching]);
+    }, [isFetching, stopRefreshing]);
 
     useEffect(() => {
         return () => { if (pollIntervalRef.current !== null) clearInterval(pollIntervalRef.current); };

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
@@ -17,7 +17,7 @@
  */
 
 import React, { ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { EditableTitle } from "../../../components/EditableTitle";
 import {
     ProjectStructure,
@@ -429,13 +429,9 @@ function DeploymentOptions({
     const [expandedOptions, setExpandedOptions] = useState<Set<string>>(new Set(['cloud', 'devant']));
     const [isRefreshing, setIsRefreshing] = useState(false);
     const deployedAtRefreshStart = useRef<boolean | null>(null);
-    const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-    // Armed after the last poll fires. sawFetching ensures we wait for true→false transition.
-    const waitForLastFetchRef = useRef(false);
     const sawFetchingRef = useRef(false);
     const { rpcClient } = useRpcContext();
     const { platformExtState } = usePlatformExtContext();
-    const queryClient = useQueryClient();
 
     const toggleOption = (option: string) => {
         setExpandedOptions(prev => {
@@ -463,9 +459,7 @@ function DeploymentOptions({
     const stopRefreshing = useCallback(() => {
         setIsRefreshing(false);
         deployedAtRefreshStart.current = null;
-        waitForLastFetchRef.current = false;
         sawFetchingRef.current = false;
-        if (pollIntervalRef.current !== null) { clearInterval(pollIntervalRef.current); pollIntervalRef.current = null; }
     }, []);
 
     // Early exit: stop as soon as isDeployed changes from what it was at click time.
@@ -475,11 +469,7 @@ function DeploymentOptions({
         }
     }, [isDeployed, isRefreshing, stopRefreshing]);
 
-    // Final-poll exit: called after the 5th poll. Waits for isFetching to go true→false,
-    // which fires in a useEffect — meaning devantMetadata is already updated in React state
-    // before we clear the spinner, so the UI transition and spinner removal are atomic.
     useEffect(() => {
-        if (!waitForLastFetchRef.current) return;
         if (isFetching) {
             sawFetchingRef.current = true;
         } else if (sawFetchingRef.current) {
@@ -487,33 +477,16 @@ function DeploymentOptions({
         }
     }, [isFetching, stopRefreshing]);
 
-    useEffect(() => {
-        return () => { if (pollIntervalRef.current !== null) clearInterval(pollIntervalRef.current); };
-    }, []);
-
-    const handleRefreshDeploymentStatus = (e: React.MouseEvent) => {
+    const handleRefreshDeploymentStatus = async (e: React.MouseEvent) => {
         e.stopPropagation();
         deployedAtRefreshStart.current = isDeployed;
-        waitForLastFetchRef.current = false;
         sawFetchingRef.current = false;
         setIsRefreshing(true);
-        rpcClient.getCommonRpcClient().executeCommand({
+        await rpcClient.getCommonRpcClient().executeCommand({
             commands: [WICommandIds.RefreshDirectoryContext],
         });
-        let pollCount = 0;
-        pollIntervalRef.current = setInterval(() => {
-            pollCount++;
-            queryClient.invalidateQueries({ queryKey: ["project-devant-metadata", projectPath] });
-            if (pollCount >= 5) {
-                // Stop scheduling more polls but keep the spinner alive until this fetch
-                // lands in React state (handled by the isFetching useEffect above).
-                clearInterval(pollIntervalRef.current!);
-                pollIntervalRef.current = null;
-                waitForLastFetchRef.current = true;
-                sawFetchingRef.current = false;
-            }
-        }, 1500);
     };
+
     return (
         <>
             <div>
@@ -528,7 +501,7 @@ function DeploymentOptions({
                                     {isRefreshing ? (
                                         <ProgressRing sx={{ width: 16, height: 16 }} />
                                     ) : (
-                                        <Button appearance="icon" onClick={handleRefreshDeploymentStatus}>
+                                        <Button appearance="icon" onClick={async (e) => await handleRefreshDeploymentStatus(e)}>
                                             <Codicon name="refresh" />
                                         </Button>
                                     )}
@@ -1038,8 +1011,8 @@ export function PackageOverview(props: PackageOverviewProps) {
         });
     }
 
-    function handleClose() {
-        rpcClient.getAiPanelRpcClient().markAlertShown();
+    async function handleClose() {
+        await rpcClient.getAiPanelRpcClient().markAlertShown();
         setShowAlert(false);
     }
 

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
@@ -428,8 +428,6 @@ function DeploymentOptions({
 }: DeploymentOptionsProps) {
     const [expandedOptions, setExpandedOptions] = useState<Set<string>>(new Set(['cloud', 'devant']));
     const [isRefreshing, setIsRefreshing] = useState(false);
-    const deployedAtRefreshStart = useRef<boolean | null>(null);
-    const sawFetchingRef = useRef(false);
     const { rpcClient } = useRpcContext();
     const { platformExtState } = usePlatformExtContext();
 
@@ -445,7 +443,7 @@ function DeploymentOptions({
         });
     };
 
-    const { data: devantMetadata, isLoading: isDevantLoading, isFetching } = useQuery({
+    const { data: devantMetadata, isLoading: isDevantLoading, refetch: refetchDevantMetadata } = useQuery({
         queryKey: ["project-devant-metadata", projectPath],
         queryFn: () => rpcClient.getBIDiagramRpcClient().getWorkspaceDevantMetadata(),
         enabled: platformExtState.isExtInstalled,
@@ -458,33 +456,19 @@ function DeploymentOptions({
 
     const stopRefreshing = useCallback(() => {
         setIsRefreshing(false);
-        deployedAtRefreshStart.current = null;
-        sawFetchingRef.current = false;
     }, []);
-
-    // Early exit: stop as soon as isDeployed changes from what it was at click time.
-    useEffect(() => {
-        if (isRefreshing && deployedAtRefreshStart.current !== null && isDeployed !== deployedAtRefreshStart.current) {
-            stopRefreshing();
-        }
-    }, [isDeployed, isRefreshing, stopRefreshing]);
-
-    useEffect(() => {
-        if (isFetching) {
-            sawFetchingRef.current = true;
-        } else if (sawFetchingRef.current) {
-            stopRefreshing();
-        }
-    }, [isFetching, stopRefreshing]);
 
     const handleRefreshDeploymentStatus = async (e: React.MouseEvent) => {
         e.stopPropagation();
-        deployedAtRefreshStart.current = isDeployed;
-        sawFetchingRef.current = false;
         setIsRefreshing(true);
-        await rpcClient.getCommonRpcClient().executeCommand({
-            commands: [WICommandIds.RefreshDirectoryContext],
-        });
+        try {
+            await rpcClient.getCommonRpcClient().executeCommand({
+                commands: [WICommandIds.RefreshDirectoryContext],
+            });
+            await refetchDevantMetadata();
+        } finally {
+            stopRefreshing();
+        }
     };
 
     return (
@@ -501,7 +485,7 @@ function DeploymentOptions({
                                     {isRefreshing ? (
                                         <ProgressRing sx={{ width: 16, height: 16 }} />
                                     ) : (
-                                        <Button appearance="icon" onClick={async (e) => await handleRefreshDeploymentStatus(e)}>
+                                        <Button appearance="icon" tooltip="Refresh deployment status" onClick={handleRefreshDeploymentStatus}>
                                             <Codicon name="refresh" />
                                         </Button>
                                     )}

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
@@ -17,7 +17,7 @@
  */
 
 import React, { ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { EditableTitle } from "../../../components/EditableTitle";
 import {
     ProjectStructure,
@@ -427,8 +427,15 @@ function DeploymentOptions({
     projectPath
 }: DeploymentOptionsProps) {
     const [expandedOptions, setExpandedOptions] = useState<Set<string>>(new Set(['cloud', 'devant']));
+    const [isRefreshing, setIsRefreshing] = useState(false);
+    const deployedAtRefreshStart = useRef<boolean | null>(null);
+    const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    // Armed after the last poll fires. sawFetching ensures we wait for true→false transition.
+    const waitForLastFetchRef = useRef(false);
+    const sawFetchingRef = useRef(false);
     const { rpcClient } = useRpcContext();
     const { platformExtState } = usePlatformExtContext();
+    const queryClient = useQueryClient();
 
     const toggleOption = (option: string) => {
         setExpandedOptions(prev => {
@@ -442,7 +449,7 @@ function DeploymentOptions({
         });
     };
 
-    const { data: devantMetadata, isLoading: isDevantLoading } = useQuery({
+    const { data: devantMetadata, isLoading: isDevantLoading, isFetching } = useQuery({
         queryKey: ["project-devant-metadata", projectPath],
         queryFn: () => rpcClient.getBIDiagramRpcClient().getWorkspaceDevantMetadata(),
         enabled: platformExtState.isExtInstalled,
@@ -452,6 +459,61 @@ function DeploymentOptions({
     const isDeployed = devantMetadata?.isLoggedIn
         ? (currentProjectMeta?.hasComponent ?? false)
         : false;
+
+    const stopRefreshing = () => {
+        setIsRefreshing(false);
+        deployedAtRefreshStart.current = null;
+        waitForLastFetchRef.current = false;
+        sawFetchingRef.current = false;
+        if (pollIntervalRef.current !== null) { clearInterval(pollIntervalRef.current); pollIntervalRef.current = null; }
+    };
+
+    // Early exit: stop as soon as isDeployed changes from what it was at click time.
+    useEffect(() => {
+        if (isRefreshing && deployedAtRefreshStart.current !== null && isDeployed !== deployedAtRefreshStart.current) {
+            stopRefreshing();
+        }
+    }, [isDeployed, isRefreshing]);
+
+    // Final-poll exit: called after the 5th poll. Waits for isFetching to go true→false,
+    // which fires in a useEffect — meaning devantMetadata is already updated in React state
+    // before we clear the spinner, so the UI transition and spinner removal are atomic.
+    useEffect(() => {
+        if (!waitForLastFetchRef.current) return;
+        if (isFetching) {
+            sawFetchingRef.current = true;
+        } else if (sawFetchingRef.current) {
+            stopRefreshing();
+        }
+    }, [isFetching]);
+
+    useEffect(() => {
+        return () => { if (pollIntervalRef.current !== null) clearInterval(pollIntervalRef.current); };
+    }, []);
+
+    const handleRefreshDeploymentStatus = (e: React.MouseEvent) => {
+        e.stopPropagation();
+        deployedAtRefreshStart.current = isDeployed;
+        waitForLastFetchRef.current = false;
+        sawFetchingRef.current = false;
+        setIsRefreshing(true);
+        rpcClient.getCommonRpcClient().executeCommand({
+            commands: [WICommandIds.RefreshDirectoryContext],
+        });
+        let pollCount = 0;
+        pollIntervalRef.current = setInterval(() => {
+            pollCount++;
+            queryClient.invalidateQueries({ queryKey: ["project-devant-metadata", projectPath] });
+            if (pollCount >= 5) {
+                // Stop scheduling more polls but keep the spinner alive until this fetch
+                // lands in React state (handled by the isFetching useEffect above).
+                clearInterval(pollIntervalRef.current!);
+                pollIntervalRef.current = null;
+                waitForLastFetchRef.current = true;
+                sawFetchingRef.current = false;
+            }
+        }, 1500);
+    };
     return (
         <>
             <div>
@@ -463,17 +525,13 @@ function DeploymentOptions({
                             isDeployed ? (
                                 <DevantHeaderWrap>
                                     <span>Deployed in WSO2 Cloud</span>
-                                    <Button
-                                        appearance="icon"
-                                        onClick={(e) => {
-                                            e.stopPropagation();
-                                            rpcClient.getCommonRpcClient().executeCommand({
-                                                commands: [WICommandIds.RefreshDirectoryContext],
-                                            });
-                                        }}
-                                    >
-                                        <Codicon name="refresh" />
-                                    </Button>
+                                    {isRefreshing ? (
+                                        <ProgressRing sx={{ width: 16, height: 16 }} />
+                                    ) : (
+                                        <Button appearance="icon" onClick={handleRefreshDeploymentStatus}>
+                                            <Codicon name="refresh" />
+                                        </Button>
+                                    )}
                                 </DevantHeaderWrap>
                             ) : (
                                 "Deploy to WSO2 Cloud"
@@ -489,7 +547,7 @@ function DeploymentOptions({
                         onToggle={() => toggleOption("devant")}
                         onDeploy={isDeployed ? () => goToDevant() : handleDeploy}
                         learnMoreLink={"https://wso2.com/devant/docs/"}
-                        hasDeployableIntegration={hasDeployableIntegration}
+                        hasDeployableIntegration={hasDeployableIntegration && !isRefreshing}
                         secondaryAction={
                             isDeployed && currentProjectMeta?.hasLocalChanges
                                 ? {
@@ -904,13 +962,13 @@ export function PackageOverview(props: PackageOverviewProps) {
     const handleICP = (icpEnabled: boolean) => {
         if (icpEnabled) {
             rpcClient.getICPRpcClient().addICP({ projectPath: '' })
-                .then((res) => {
+                .then(() => {
                     setEnableICP(true);
                 }
                 );
         } else {
             rpcClient.getICPRpcClient().disableICP({ projectPath: '' })
-                .then((res) => {
+                .then(() => {
                     setEnableICP(false);
                 }
                 );
@@ -972,7 +1030,7 @@ export function PackageOverview(props: PackageOverviewProps) {
         })
     };
 
-    async function handleSettings() {
+    function handleSettings() {
         rpcClient.getAiPanelRpcClient().openAIPanel({
             type: 'text',
             planMode: false,
@@ -980,8 +1038,8 @@ export function PackageOverview(props: PackageOverviewProps) {
         });
     }
 
-    async function handleClose() {
-        await rpcClient.getAiPanelRpcClient().markAlertShown();
+    function handleClose() {
+        rpcClient.getAiPanelRpcClient().markAlertShown();
         setShowAlert(false);
     }
 

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/WorkspaceOverview/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/WorkspaceOverview/index.tsx
@@ -382,7 +382,7 @@ interface DeploymentOptionsProps {
     handleDeploy: () => Promise<void>;
     goToDevant: () => void;
     devantMetadata: WorkspaceDevantMetadata | undefined;
-    devantFetching: boolean;
+    refetchDevantMetadata: () => Promise<unknown>;
     hasDeployableIntegration: boolean;
     hasUndeployedIntegrations: boolean;
     deployableProjectPaths: Set<string>;
@@ -395,7 +395,7 @@ function DeploymentOptions({
     handleDeploy,
     goToDevant,
     devantMetadata,
-    devantFetching,
+    refetchDevantMetadata,
     hasDeployableIntegration,
     hasUndeployedIntegrations,
     deployableProjectPaths,
@@ -403,8 +403,6 @@ function DeploymentOptions({
 }: DeploymentOptionsProps) {
     const [expandedOptions, setExpandedOptions] = useState<Set<string>>(new Set(['cloud']));
     const [isRefreshing, setIsRefreshing] = useState(false);
-    const deployedCountAtRefreshStart = useRef<number | null>(null);
-    const sawFetchingRef = useRef(false);
     const { rpcClient } = useRpcContext();
     const { platformExtState } = usePlatformExtContext();
 
@@ -434,40 +432,26 @@ function DeploymentOptions({
 
     const stopRefreshing = useCallback(() => {
         setIsRefreshing(false);
-        deployedCountAtRefreshStart.current = null;
-        sawFetchingRef.current = false;
     }, []);
-
-    // Early exit: stop as soon as deployedProjects.length changes from what it was at click time.
-    useEffect(() => {
-        if (isRefreshing && deployedCountAtRefreshStart.current !== null && deployedProjects.length !== deployedCountAtRefreshStart.current) {
-            stopRefreshing();
-        }
-    }, [deployedProjects.length, isRefreshing, stopRefreshing]);
-
-    useEffect(() => {
-        if (devantFetching) {
-            sawFetchingRef.current = true;
-        } else if (sawFetchingRef.current) {
-            stopRefreshing();
-        }
-    }, [devantFetching, stopRefreshing]);
 
     const handleRefreshDeploymentStatus = async (e: React.MouseEvent) => {
         e.stopPropagation();
-        deployedCountAtRefreshStart.current = deployedProjects.length;
-        sawFetchingRef.current = false;
         setIsRefreshing(true);
-        await rpcClient.getCommonRpcClient().executeCommand({
-            commands: [WICommandIds.RefreshDirectoryContext],
-        });
+        try {
+            await rpcClient.getCommonRpcClient().executeCommand({
+                commands: [WICommandIds.RefreshDirectoryContext],
+            });
+            await refetchDevantMetadata();
+        } finally {
+            stopRefreshing();
+        }
     };
     const hasDeployedWithChanges = deployedWithChanges.length > 0;
 
     const refreshButton = isRefreshing ? (
         <ProgressRing sx={{ width: 16, height: 16 }} />
     ) : (
-        <Button appearance="icon" onClick={async (e) => await handleRefreshDeploymentStatus(e)}>
+        <Button appearance="icon" tooltip="Refresh deployment status" onClick={handleRefreshDeploymentStatus}>
             <Codicon name="refresh" />
         </Button>
     );
@@ -748,7 +732,7 @@ export function WorkspaceOverview({ isInDevant }: WorkspaceOverviewProps) {
     const [showAlert, setShowAlert] = React.useState(false);
     const [icpActionLoading, setIcpActionLoading] = React.useState<IcpAction | null>(null);
 
-    const { data: devantMetadata, isFetching: devantFetching } = useQuery({
+    const { data: devantMetadata, refetch: refetchDevantMetadata } = useQuery({
         queryKey: ["project-devant-metadata"],
         queryFn: () => rpcClient.getBIDiagramRpcClient().getWorkspaceDevantMetadata(),
         refetchInterval: 5000
@@ -1185,7 +1169,7 @@ export function WorkspaceOverview({ isInDevant }: WorkspaceOverviewProps) {
                                     handleDeploy={handleDeploy}
                                     goToDevant={goToDevant}
                                     devantMetadata={devantMetadata}
-                                    devantFetching={devantFetching}
+                                    refetchDevantMetadata={refetchDevantMetadata}
                                     hasDeployableIntegration={hasDeployableIntegration}
                                     hasUndeployedIntegrations={undeployedProjectScopes.length > 0}
                                     deployableProjectPaths={deployableProjectPaths}

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/WorkspaceOverview/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/WorkspaceOverview/index.tsx
@@ -26,7 +26,7 @@ import {
     WorkspaceDevantMetadata
 } from "@wso2/ballerina-core";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { IOpenInConsoleCmdParams, WICommandIds } from "@wso2/wso2-platform-core";
 import { Typography, Codicon, ProgressRing, Button, Icon, Divider } from "@wso2/ui-toolkit";
 import styled from "@emotion/styled";
@@ -253,6 +253,13 @@ const DeploymentOptionContainer = styled.div<DeploymentOptionContainerProps>`
     }
 `;
 
+const DeploymentTitleWrap = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+`;
+
 const DeploymentHeader = styled.div`
     display: flex;
     align-items: center;
@@ -261,6 +268,7 @@ const DeploymentHeader = styled.div`
         font-size: 13px;
         font-weight: 600;
         margin: 0;
+        width: 100%;
     }
 `;
 
@@ -276,7 +284,7 @@ const DeploymentBody = styled.div<DeploymentBodyProps>`
 `;
 
 interface DeploymentOptionProps {
-    title: string;
+    title: React.ReactNode;
     description: string;
     buttonText: string;
     isExpanded: boolean;
@@ -393,8 +401,22 @@ function DeploymentOptions({
     libraryProjectPaths
 }: DeploymentOptionsProps) {
     const [expandedOptions, setExpandedOptions] = useState<Set<string>>(new Set(['cloud']));
+    const [isRefreshing, setIsRefreshing] = useState(false);
+    const deployedCountAtRefreshStart = useRef<number | null>(null);
+    const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const waitForLastFetchRef = useRef(false);
+    const sawFetchingRef = useRef(false);
     const { rpcClient } = useRpcContext();
     const { platformExtState } = usePlatformExtContext();
+    const queryClient = useQueryClient();
+
+    // Lightweight subscription to get isFetching for the same query key.
+    // TanStack Query deduplicates network requests, so no extra API calls are made.
+    const { isFetching: devantFetching } = useQuery({
+        queryKey: ["project-devant-metadata"],
+        queryFn: () => rpcClient.getBIDiagramRpcClient().getWorkspaceDevantMetadata(),
+        refetchInterval: 5000,
+    });
 
     const toggleOption = (option: string) => {
         setExpandedOptions(prev => {
@@ -416,13 +438,74 @@ function DeploymentOptions({
         p => !p.hasComponent && !libraryProjectPaths.has(p.projectPath)
     ) || [];
     const deployedWithChanges = deployedProjects.filter(p => p.hasLocalChanges);
-    
+
     const hasDeployedProjects = deployedProjects.length > 0;
     const hasUndeployedProjects = undeployedProjects.length > 0;
+
+    const stopRefreshing = () => {
+        setIsRefreshing(false);
+        deployedCountAtRefreshStart.current = null;
+        waitForLastFetchRef.current = false;
+        sawFetchingRef.current = false;
+        if (pollIntervalRef.current !== null) { clearInterval(pollIntervalRef.current); pollIntervalRef.current = null; }
+    };
+
+    // Early exit: stop as soon as deployedProjects.length changes from what it was at click time.
+    useEffect(() => {
+        if (isRefreshing && deployedCountAtRefreshStart.current !== null && deployedProjects.length !== deployedCountAtRefreshStart.current) {
+            stopRefreshing();
+        }
+    }, [deployedProjects.length, isRefreshing]);
+
+    // Final-poll exit: after the 5th poll, wait for devantFetching to go true→false.
+    // useEffect fires after the render, so devantMetadata (and deployedProjects) is already
+    // updated before the spinner is cleared — UI transition and spinner removal are atomic.
+    useEffect(() => {
+        if (!waitForLastFetchRef.current) return;
+        if (devantFetching) {
+            sawFetchingRef.current = true;
+        } else if (sawFetchingRef.current) {
+            stopRefreshing();
+        }
+    }, [devantFetching]);
+
+    useEffect(() => {
+        return () => { if (pollIntervalRef.current !== null) clearInterval(pollIntervalRef.current); };
+    }, []);
+
+    const handleRefreshDeploymentStatus = (e: React.MouseEvent) => {
+        e.stopPropagation();
+        deployedCountAtRefreshStart.current = deployedProjects.length;
+        waitForLastFetchRef.current = false;
+        sawFetchingRef.current = false;
+        setIsRefreshing(true);
+        rpcClient.getCommonRpcClient().executeCommand({
+            commands: [WICommandIds.RefreshDirectoryContext],
+        });
+        let pollCount = 0;
+        pollIntervalRef.current = setInterval(() => {
+            pollCount++;
+            queryClient.invalidateQueries({ queryKey: ["project-devant-metadata"] });
+            if (pollCount >= 5) {
+                clearInterval(pollIntervalRef.current!);
+                pollIntervalRef.current = null;
+                waitForLastFetchRef.current = true;
+                sawFetchingRef.current = false;
+            }
+        }, 1500);
+    };
     const hasDeployedWithChanges = deployedWithChanges.length > 0;
 
+    const refreshButton = isRefreshing ? (
+        <ProgressRing sx={{ width: 16, height: 16 }} />
+    ) : (
+        <Button appearance="icon" onClick={handleRefreshDeploymentStatus}>
+            <Codicon name="refresh" />
+        </Button>
+    );
+
     // Determine title, description, button text, and whether deployment is allowed
-    let title = "Deploy to WSO2 Cloud";
+    let title: React.ReactNode = "Deploy to WSO2 Cloud";
     let description = "Deploy your integrations to WSO2 Cloud.";
     let buttonText = "Deploy";
     let primaryAction: () => void | Promise<void> = handleDeploy;
@@ -432,7 +515,12 @@ function DeploymentOptions({
 
     if (hasDeployedProjects && !hasUndeployedProjects) {
         // All projects are deployed - disable deployment button
-        title = "Deployed in WSO2 Cloud";
+        title = (
+            <DeploymentTitleWrap>
+                <span>Deployed in WSO2 Cloud</span>
+                {refreshButton}
+            </DeploymentTitleWrap>
+        );
         description = "All integrations are deployed in WSO2 Cloud.";
         buttonText = "View in Console";
         primaryAction = goToDevant;
@@ -447,7 +535,12 @@ function DeploymentOptions({
         }
     } else if (hasDeployedProjects && hasUndeployedProjects) {
         // Mixed state: some deployed, some not - show clear message about remaining
-        title = "Partially Deployed in WSO2 Cloud";
+        title = (
+            <DeploymentTitleWrap>
+                <span>Partially Deployed in WSO2 Cloud</span>
+                {refreshButton}
+            </DeploymentTitleWrap>
+        );
         
         // Separate deployable and non-deployable undeployed projects
         const deployableUndeployed = undeployedProjects.filter(p => deployableProjectPaths.has(p.projectPath));
@@ -501,8 +594,8 @@ function DeploymentOptions({
                         onToggle={() => toggleOption("cloud")}
                         onDeploy={primaryAction}
                         learnMoreLink={"https://wso2.com/devant/docs/"}
-                        hasDeployableIntegration={!isDeploymentDisabled}
-                        disabledTooltip={disabledTooltip}
+                        hasDeployableIntegration={!isDeploymentDisabled && !isRefreshing}
+                        disabledTooltip={isRefreshing ? "Refreshing deployment status…" : disabledTooltip}
                         secondaryAction={secondaryAction}
                     />
                 )}

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/WorkspaceOverview/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/WorkspaceOverview/index.tsx
@@ -383,6 +383,7 @@ interface DeploymentOptionsProps {
     handleDeploy: () => Promise<void>;
     goToDevant: () => void;
     devantMetadata: WorkspaceDevantMetadata | undefined;
+    devantFetching: boolean;
     hasDeployableIntegration: boolean;
     hasUndeployedIntegrations: boolean;
     deployableProjectPaths: Set<string>;
@@ -395,6 +396,7 @@ function DeploymentOptions({
     handleDeploy,
     goToDevant,
     devantMetadata,
+    devantFetching,
     hasDeployableIntegration,
     hasUndeployedIntegrations,
     deployableProjectPaths,
@@ -409,14 +411,6 @@ function DeploymentOptions({
     const { rpcClient } = useRpcContext();
     const { platformExtState } = usePlatformExtContext();
     const queryClient = useQueryClient();
-
-    // Lightweight subscription to get isFetching for the same query key.
-    // TanStack Query deduplicates network requests, so no extra API calls are made.
-    const { isFetching: devantFetching } = useQuery({
-        queryKey: ["project-devant-metadata"],
-        queryFn: () => rpcClient.getBIDiagramRpcClient().getWorkspaceDevantMetadata(),
-        refetchInterval: 5000,
-    });
 
     const toggleOption = (option: string) => {
         setExpandedOptions(prev => {
@@ -442,20 +436,20 @@ function DeploymentOptions({
     const hasDeployedProjects = deployedProjects.length > 0;
     const hasUndeployedProjects = undeployedProjects.length > 0;
 
-    const stopRefreshing = () => {
+    const stopRefreshing = useCallback(() => {
         setIsRefreshing(false);
         deployedCountAtRefreshStart.current = null;
         waitForLastFetchRef.current = false;
         sawFetchingRef.current = false;
         if (pollIntervalRef.current !== null) { clearInterval(pollIntervalRef.current); pollIntervalRef.current = null; }
-    };
+    }, []);
 
     // Early exit: stop as soon as deployedProjects.length changes from what it was at click time.
     useEffect(() => {
         if (isRefreshing && deployedCountAtRefreshStart.current !== null && deployedProjects.length !== deployedCountAtRefreshStart.current) {
             stopRefreshing();
         }
-    }, [deployedProjects.length, isRefreshing]);
+    }, [deployedProjects.length, isRefreshing, stopRefreshing]);
 
     // Final-poll exit: after the 5th poll, wait for devantFetching to go true→false.
     // useEffect fires after the render, so devantMetadata (and deployedProjects) is already
@@ -467,7 +461,7 @@ function DeploymentOptions({
         } else if (sawFetchingRef.current) {
             stopRefreshing();
         }
-    }, [devantFetching]);
+    }, [devantFetching, stopRefreshing]);
 
     useEffect(() => {
         return () => { if (pollIntervalRef.current !== null) clearInterval(pollIntervalRef.current); };
@@ -780,7 +774,7 @@ export function WorkspaceOverview({ isInDevant }: WorkspaceOverviewProps) {
     const [showAlert, setShowAlert] = React.useState(false);
     const [icpActionLoading, setIcpActionLoading] = React.useState<IcpAction | null>(null);
 
-    const { data: devantMetadata } = useQuery({
+    const { data: devantMetadata, isFetching: devantFetching } = useQuery({
         queryKey: ["project-devant-metadata"],
         queryFn: () => rpcClient.getBIDiagramRpcClient().getWorkspaceDevantMetadata(),
         refetchInterval: 5000
@@ -1217,6 +1211,7 @@ export function WorkspaceOverview({ isInDevant }: WorkspaceOverviewProps) {
                                     handleDeploy={handleDeploy}
                                     goToDevant={goToDevant}
                                     devantMetadata={devantMetadata}
+                                    devantFetching={devantFetching}
                                     hasDeployableIntegration={hasDeployableIntegration}
                                     hasUndeployedIntegrations={undeployedProjectScopes.length > 0}
                                     deployableProjectPaths={deployableProjectPaths}

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/WorkspaceOverview/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/WorkspaceOverview/index.tsx
@@ -26,7 +26,7 @@ import {
     WorkspaceDevantMetadata
 } from "@wso2/ballerina-core";
 import { useRpcContext } from "@wso2/ballerina-rpc-client";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { IOpenInConsoleCmdParams, WICommandIds } from "@wso2/wso2-platform-core";
 import { Typography, Codicon, ProgressRing, Button, Icon, Divider } from "@wso2/ui-toolkit";
 import styled from "@emotion/styled";
@@ -34,7 +34,6 @@ import { ThemeColors } from "@wso2/ui-toolkit";
 import { VSCodeLink } from "@vscode/webview-ui-toolkit/react";
 import ReactMarkdown from "react-markdown";
 import { AlertBoxWithClose } from "../../AIPanel/AlertBoxWithClose";
-import { UndoRedoGroup } from "../../../components/UndoRedoGroup";
 import { PackageListView } from "./PackageListView";
 import { getWorkspaceProjectScopes } from "../PackageOverview/utils";
 import { usePlatformExtContext } from "../../../providers/platform-ext-ctx-provider";
@@ -405,12 +404,9 @@ function DeploymentOptions({
     const [expandedOptions, setExpandedOptions] = useState<Set<string>>(new Set(['cloud']));
     const [isRefreshing, setIsRefreshing] = useState(false);
     const deployedCountAtRefreshStart = useRef<number | null>(null);
-    const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-    const waitForLastFetchRef = useRef(false);
     const sawFetchingRef = useRef(false);
     const { rpcClient } = useRpcContext();
     const { platformExtState } = usePlatformExtContext();
-    const queryClient = useQueryClient();
 
     const toggleOption = (option: string) => {
         setExpandedOptions(prev => {
@@ -439,9 +435,7 @@ function DeploymentOptions({
     const stopRefreshing = useCallback(() => {
         setIsRefreshing(false);
         deployedCountAtRefreshStart.current = null;
-        waitForLastFetchRef.current = false;
         sawFetchingRef.current = false;
-        if (pollIntervalRef.current !== null) { clearInterval(pollIntervalRef.current); pollIntervalRef.current = null; }
     }, []);
 
     // Early exit: stop as soon as deployedProjects.length changes from what it was at click time.
@@ -451,11 +445,7 @@ function DeploymentOptions({
         }
     }, [deployedProjects.length, isRefreshing, stopRefreshing]);
 
-    // Final-poll exit: after the 5th poll, wait for devantFetching to go true→false.
-    // useEffect fires after the render, so devantMetadata (and deployedProjects) is already
-    // updated before the spinner is cleared — UI transition and spinner removal are atomic.
     useEffect(() => {
-        if (!waitForLastFetchRef.current) return;
         if (devantFetching) {
             sawFetchingRef.current = true;
         } else if (sawFetchingRef.current) {
@@ -463,37 +453,21 @@ function DeploymentOptions({
         }
     }, [devantFetching, stopRefreshing]);
 
-    useEffect(() => {
-        return () => { if (pollIntervalRef.current !== null) clearInterval(pollIntervalRef.current); };
-    }, []);
-
-    const handleRefreshDeploymentStatus = (e: React.MouseEvent) => {
+    const handleRefreshDeploymentStatus = async (e: React.MouseEvent) => {
         e.stopPropagation();
         deployedCountAtRefreshStart.current = deployedProjects.length;
-        waitForLastFetchRef.current = false;
         sawFetchingRef.current = false;
         setIsRefreshing(true);
-        rpcClient.getCommonRpcClient().executeCommand({
+        await rpcClient.getCommonRpcClient().executeCommand({
             commands: [WICommandIds.RefreshDirectoryContext],
         });
-        let pollCount = 0;
-        pollIntervalRef.current = setInterval(() => {
-            pollCount++;
-            queryClient.invalidateQueries({ queryKey: ["project-devant-metadata"] });
-            if (pollCount >= 5) {
-                clearInterval(pollIntervalRef.current!);
-                pollIntervalRef.current = null;
-                waitForLastFetchRef.current = true;
-                sawFetchingRef.current = false;
-            }
-        }, 1500);
     };
     const hasDeployedWithChanges = deployedWithChanges.length > 0;
 
     const refreshButton = isRefreshing ? (
         <ProgressRing sx={{ width: 16, height: 16 }} />
     ) : (
-        <Button appearance="icon" onClick={handleRefreshDeploymentStatus}>
+        <Button appearance="icon" onClick={async (e) => await handleRefreshDeploymentStatus(e)}>
             <Codicon name="refresh" />
         </Button>
     );


### PR DESCRIPTION
## Purpose
$title

Addresses: https://github.com/wso2/product-integrator/issues/1442


https://github.com/user-attachments/assets/2899de4e-ee2f-44bf-a83d-863fa67af23f



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manually refresh WSO2 Cloud deployment status from package and workspace overviews.
  * Visual loading indicator shown inline while refresh is in progress.
  * Refresh stops early if deployment status changes or the fetch completes.
  * Deploy action is disabled during refresh and shows a “Refreshing deployment status…” hint.
  * Cloud deployment headers now include a refresh control aligned with the title.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/vscode-extensions/pull/2221)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->