### PR TITLE
Add Ballerina E2E writer skill

### DIFF
--- a/.agents/skills/ballerina-e2e-writer/SKILL.md
+++ b/.agents/skills/ballerina-e2e-writer/SKILL.md
@@ -25,14 +25,22 @@ For user-facing instructions and prompt examples, see `USER_GUIDE.md` in this sk
    ```
 
 4. Write small step files in `steps/*.step.js`. Keep each step focused and rerunnable.
+   For diagram flows, steps must build the flow through the product UI:
+   click the diagram plus button, open the node palette, search or select the node, fill the form, then save.
 5. Run the steps through the named daemon:
 
    ```bash
    bash e2e-test/e2e-authoring/scripts/run-steps.sh <scenario-name> e2e-test/e2e-authoring/scenarios/<scenario-name>/steps
    ```
 
-6. If a selector is unstable, add a stable `data-testid` in the relevant `workspaces/ballerina/*/src` UI package. Do not use generated Emotion class names.
-7. Once the step flow is proven, promote it into `e2e-test/e2e-playwright-tests`.
+6. If a selector is unstable, add a stable `data-testid` in the relevant `workspaces/ballerina/*/src` UI package. Do not use dynamic/generated class names as selectors, including Emotion class names.
+   If product source was changed for a new `data-testid`, rebuild the VSIX before rerunning E2E:
+
+   ```bash
+   rush build -t ballerina
+   ```
+
+7. Once the step flow is proven, promote the same UI flow into `e2e-test/e2e-playwright-tests`.
 8. Register the promoted spec in `e2e-test/e2e-playwright-tests/test.list.ts`.
 9. Verify with:
 
@@ -48,6 +56,11 @@ For user-facing instructions and prompt examples, see `USER_GUIDE.md` in this sk
 - Prefer existing helpers: `initTest`, `getWebview`, `addArtifact`, `ProjectExplorer`, and `Diagram`.
 - Extension webview action selectors should be `data-testid`, stable roles, or stable accessible names.
 - VS Code shell selectors may use stable workbench ARIA labels where needed.
+- Do not create or modify Ballerina flow files directly to build the scenario. Source files may be read for final verification only.
+- Build diagram flows top-to-bottom so each saved form leaves the project compilable for the next form.
+- When a form input opens the helper panel, either use it intentionally to choose inputs/variables or press `Escape` to dismiss it before saving. The helper panel can cover the Save button.
+- Fill form fields through stable labels, `data-testid`, CodeMirror helpers, or helper-panel selections. Never select extension UI by dynamic/generated class names such as Emotion CSS classes.
+- Always use the authoring harness first, then promote the passing UI flow into `e2e-playwright-tests`, and verify with `npm run e2e-test -- --grep "<test name>"`.
 
 ## Useful Commands
 

--- a/.agents/skills/ballerina-e2e-writer/SKILL.md
+++ b/.agents/skills/ballerina-e2e-writer/SKILL.md
@@ -60,6 +60,7 @@ For user-facing instructions and prompt examples, see `USER_GUIDE.md` in this sk
 - Build diagram flows top-to-bottom so each saved form leaves the project compilable for the next form.
 - When a form input opens the helper panel, either use it intentionally to choose inputs/variables or press `Escape` to dismiss it before saving. The helper panel can cover the Save button.
 - Fill form fields through stable labels, `data-testid`, CodeMirror helpers, or helper-panel selections. Never select extension UI by dynamic/generated class names such as Emotion CSS classes.
+- Add terminal-visible progress logs for each major E2E step using `logStep` from `e2e-playwright-tests/utils/helpers`, so headless failures show the last completed action.
 - Always use the authoring harness first, then promote the passing UI flow into `e2e-playwright-tests`, and verify with `npm run e2e-test -- --grep "<test name>"`.
 
 ## Useful Commands

--- a/.agents/skills/ballerina-e2e-writer/SKILL.md
+++ b/.agents/skills/ballerina-e2e-writer/SKILL.md
@@ -12,17 +12,19 @@ For user-facing instructions and prompt examples, see `USER_GUIDE.md` in this sk
 ## Workflow
 
 1. Read the requested scenario and existing tests in `e2e-test/e2e-playwright-tests`.
-2. Ensure the Ballerina VSIX exists locally. If it is missing, ask the user to run:
+2. Ensure the Ballerina VSIX exists locally. Check for a file matching `ballerina-*.vsix` in the workspace root (e.g., `ballerina-5.11.0.vsix`). If none is found, ask the user to run:
 
    ```bash
    rush build -t ballerina
    ```
 
-3. Create or update an authoring scenario under:
+3. Create `scenario.md` under the authoring scenario directory before writing any step files:
 
    ```text
-   e2e-test/e2e-authoring/scenarios/<scenario-name>/
+   e2e-test/e2e-authoring/scenarios/<scenario-name>/scenario.md
    ```
+
+   If the user only described the scenario in the prompt, derive the steps and write `scenario.md` now. If the user provided a `scenario.md` path, read it first.
 
 4. Write small step files in `steps/*.step.js`. Keep each step focused and rerunnable.
    For diagram flows, steps must build the flow through the product UI:
@@ -34,19 +36,27 @@ For user-facing instructions and prompt examples, see `USER_GUIDE.md` in this sk
    ```
 
 6. If a selector is unstable, add a stable `data-testid` in the relevant `workspaces/ballerina/*/src` UI package. Do not use dynamic/generated class names as selectors, including Emotion class names.
-   If product source was changed for a new `data-testid`, rebuild the VSIX before rerunning E2E:
+   After adding any `data-testid` — even a single attribute in one file — always rebuild the VSIX before rerunning steps:
 
    ```bash
    rush build -t ballerina
    ```
 
-7. Once the step flow is proven, promote the same UI flow into `e2e-test/e2e-playwright-tests`.
+7. Once the step flow is proven, promote the same UI flow into a new spec file. Place the spec in the subdirectory that best matches the integration category, following the existing layout:
+
+   ```text
+   e2e-test/e2e-playwright-tests/<category>/<scenario-name>.spec.ts
+   ```
+
+   Existing categories: `api-integration`, `file-integration`, `other-artifacts`, `diagram`, `configuration`, `type-editor`. Check the subdirectories and pick the closest match.
 8. Register the promoted spec in `e2e-test/e2e-playwright-tests/test.list.ts`.
 9. Verify with:
 
    ```bash
    npm run e2e-test -- --grep "<test name>"
    ```
+
+   A passing run prints each `logStep` line to the terminal and exits 0. If the extension fails to launch, check the VS Code host stderr for VSIX load errors — this means a stale build; rebuild and rerun.
 
 ## Harness Rules
 

--- a/.agents/skills/ballerina-e2e-writer/SKILL.md
+++ b/.agents/skills/ballerina-e2e-writer/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: ballerina-e2e-writer
+description: Use when adding or updating Ballerina extension E2E tests that need agent-assisted VS Code authoring before promotion into the Playwright suite.
+---
+
+# Ballerina E2E Writer
+
+Use this skill when adding new Ballerina extension user-flow E2E coverage in `workspaces/ballerina/ballerina-extension`.
+
+For user-facing instructions and prompt examples, see `USER_GUIDE.md` in this skill directory.
+
+## Workflow
+
+1. Read the requested scenario and existing tests in `e2e-test/e2e-playwright-tests`.
+2. Ensure the Ballerina VSIX exists locally. If it is missing, ask the user to run:
+
+   ```bash
+   rush build -t ballerina
+   ```
+
+3. Create or update an authoring scenario under:
+
+   ```text
+   e2e-test/e2e-authoring/scenarios/<scenario-name>/
+   ```
+
+4. Write small step files in `steps/*.step.js`. Keep each step focused and rerunnable.
+5. Run the steps through the named daemon:
+
+   ```bash
+   bash e2e-test/e2e-authoring/scripts/run-steps.sh <scenario-name> e2e-test/e2e-authoring/scenarios/<scenario-name>/steps
+   ```
+
+6. If a selector is unstable, add a stable `data-testid` in the relevant `workspaces/ballerina/*/src` UI package. Do not use generated Emotion class names.
+7. Once the step flow is proven, promote it into `e2e-test/e2e-playwright-tests`.
+8. Register the promoted spec in `e2e-test/e2e-playwright-tests/test.list.ts`.
+9. Verify with:
+
+   ```bash
+   npm run e2e-test -- --grep "<test name>"
+   ```
+
+## Harness Rules
+
+- The authoring daemon is only for scenario discovery and fast iteration.
+- The committed source of truth is the normal Playwright spec.
+- Use `@wso2/playwright-vscode-tester` launch behavior through the authoring daemon.
+- Prefer existing helpers: `initTest`, `getWebview`, `addArtifact`, `ProjectExplorer`, and `Diagram`.
+- Extension webview action selectors should be `data-testid`, stable roles, or stable accessible names.
+- VS Code shell selectors may use stable workbench ARIA labels where needed.
+
+## Useful Commands
+
+Run all authoring steps:
+
+```bash
+cd workspaces/ballerina/ballerina-extension
+bash e2e-test/e2e-authoring/scripts/run-steps.sh http-upload e2e-test/e2e-authoring/scenarios/http-upload/steps
+```
+
+Run a step range:
+
+```bash
+bash e2e-test/e2e-authoring/scripts/run-steps.sh http-upload e2e-test/e2e-authoring/scenarios/http-upload/steps 02 03
+```
+
+Run promoted test:
+
+```bash
+npm run e2e-test -- --grep "HTTP Upload"
+```

--- a/.agents/skills/ballerina-e2e-writer/USER_GUIDE.md
+++ b/.agents/skills/ballerina-e2e-writer/USER_GUIDE.md
@@ -40,11 +40,7 @@ Create a new Ballerina extension E2E test for this scenario:
 - <describe how to run or verify the integration>
 - <describe the expected final result>
 
-Create scenario.md if it does not exist.
-Use the authoring harness first.
-Do not use generated Emotion/class selectors.
-Add data-testid selectors where the product UI needs stable selectors.
-Promote the proven flow into e2e-playwright-tests and run the targeted npm run e2e-test command.
+Use "<test name>" as the promoted test name.
 ```
 
 ## Prompt: Existing Scenario File
@@ -55,9 +51,7 @@ Use the ballerina-e2e-writer skill.
 Implement the E2E scenario described in:
 workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/<scenario-name>/scenario.md
 
-Use the authoring harness first, then promote the passing flow into e2e-playwright-tests.
-Avoid generated class selectors. Add data-testid selectors if needed.
-Verify with npm run e2e-test -- --grep "<test name>".
+Use "<test name>" as the promoted test name.
 ```
 
 ## Example Prompt
@@ -78,9 +72,7 @@ Create a new E2E test for an HTTP upload flow:
 - run the integration
 - call the endpoint and verify the JSON response
 
-Create scenario.md and authoring steps if needed.
-Promote the proven flow into e2e-playwright-tests.
-Run npm run e2e-test -- --grep "HTTP Upload".
+Use "HTTP Upload" as the promoted test name.
 ```
 
 ## Useful Commands

--- a/.agents/skills/ballerina-e2e-writer/USER_GUIDE.md
+++ b/.agents/skills/ballerina-e2e-writer/USER_GUIDE.md
@@ -1,0 +1,105 @@
+# Ballerina E2E Writer User Guide
+
+Use `ballerina-e2e-writer` when you want an AI agent to create a new Ballerina extension E2E test from a user-flow description.
+
+## What the User Provides
+
+You do not have to write Playwright code first.
+
+Provide either:
+
+- a short scenario description in the prompt, or
+- a prepared `scenario.md` file under `workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/<scenario-name>/scenario.md`.
+
+If you only describe the scenario, the agent should create `scenario.md` for you.
+
+## Expected Flow
+
+1. User describes the scenario.
+2. Agent reads `ballerina-e2e-writer`.
+3. Agent creates or updates `scenario.md`.
+4. Agent creates small authoring step files under `steps/*.step.js`.
+5. Agent runs the authoring flow through the VS Code daemon.
+6. Agent adds missing `data-testid` selectors if needed.
+7. Agent promotes the proven flow into `e2e-playwright-tests`.
+8. Agent registers the test in `test.list.ts`.
+9. Agent verifies with `npm run e2e-test -- --grep "<test name>"`.
+
+The files under `e2e-authoring/scenarios/<scenario-name>/steps` are for discovery and debugging. The committed CI test is the promoted Playwright spec under `e2e-playwright-tests`.
+
+## Prompt: Scenario Only
+
+```text
+Use the ballerina-e2e-writer skill.
+
+Create a new Ballerina extension E2E test for this scenario:
+
+- <describe the first user action>
+- <describe the next user action>
+- <describe the expected editor or diagram state>
+- <describe how to run or verify the integration>
+- <describe the expected final result>
+
+Create scenario.md if it does not exist.
+Use the authoring harness first.
+Do not use generated Emotion/class selectors.
+Add data-testid selectors where the product UI needs stable selectors.
+Promote the proven flow into e2e-playwright-tests and run the targeted npm run e2e-test command.
+```
+
+## Prompt: Existing Scenario File
+
+```text
+Use the ballerina-e2e-writer skill.
+
+Implement the E2E scenario described in:
+workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/<scenario-name>/scenario.md
+
+Use the authoring harness first, then promote the passing flow into e2e-playwright-tests.
+Avoid generated class selectors. Add data-testid selectors if needed.
+Verify with npm run e2e-test -- --grep "<test name>".
+```
+
+## Example Prompt
+
+```text
+Use the ballerina-e2e-writer skill.
+
+Create a new E2E test for an HTTP upload flow:
+
+- create a new integration project
+- create an HTTP service
+- add a POST /upload resource
+- configure a query parameter named name
+- configure a JSON payload
+- add a return node from the diagram using the plus button
+- select payload from the helper panel and customize the return expression
+- save and confirm the diagram/source is updated
+- run the integration
+- call the endpoint and verify the JSON response
+
+Create scenario.md and authoring steps if needed.
+Promote the proven flow into e2e-playwright-tests.
+Run npm run e2e-test -- --grep "HTTP Upload".
+```
+
+## Useful Commands
+
+Run all authoring steps:
+
+```bash
+cd workspaces/ballerina/ballerina-extension
+bash e2e-test/e2e-authoring/scripts/run-steps.sh <scenario-name> e2e-test/e2e-authoring/scenarios/<scenario-name>/steps
+```
+
+Run part of a scenario:
+
+```bash
+bash e2e-test/e2e-authoring/scripts/run-steps.sh <scenario-name> e2e-test/e2e-authoring/scenarios/<scenario-name>/steps 02 04
+```
+
+Run the promoted E2E:
+
+```bash
+npm run e2e-test -- --grep "<test name>"
+```

--- a/.claude/commands
+++ b/.claude/commands
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.gitignore
+++ b/.gitignore
@@ -83,7 +83,8 @@ extensions.json
 !sample-mi-project.zip
 package.json.backup
 
-.claude/
+.claude/*
+!.claude/commands
 
 pnpm-lock.yaml
 

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/helpers/flow-nodes.js
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/helpers/flow-nodes.js
@@ -10,6 +10,20 @@ const FLOW_NODES_IF_SOURCE = [
   'else'
 ];
 
+const FLOW_NODES_LOGGING_SOURCE = [
+  'log:printError("sample error log")',
+  'log:printWarn("sample warn log")'
+];
+
+const FLOW_NODES_MATCH_SOURCE = [
+  'match count',
+  '1 =>'
+];
+
+const FLOW_NODES_WHILE_SOURCE = [
+  'while count < 3'
+];
+
 globalThis.addAutomationArtifact = async () => {
   const frame = await getBIWebview();
   await frame.getByRole('button', { name: /Add Artifact/i }).click({ force: true });
@@ -37,7 +51,6 @@ globalThis.clickNextDiagramPlus = async () => {
     scrollable?.scrollTo?.({ top: 0, behavior: 'instant' });
     window.scrollTo(0, 0);
   }).catch(() => {});
-  await frame.mouse.wheel(0, -1200).catch(() => {});
   await frame.waitForTimeout(500);
 
   const clickedId = await frame.locator('[data-testid]').evaluateAll((elements) => {
@@ -70,20 +83,30 @@ globalThis.clickNextDiagramPlus = async () => {
 globalThis.selectFlowNode = async (nodeLabel, category) => {
   const frame = await getBIWebview();
   await clickNextDiagramPlus();
-  if (category) {
-    const categoryHeader = frame.getByText(category, { exact: true }).first();
+  const panel = frame.locator('[data-testid="side-panel"]').first();
+  await panel.waitFor({ state: 'visible', timeout: 30000 });
+
+  const search = panel.locator('input[placeholder*="Search"], input[type="text"]').first();
+  if (await search.isVisible({ timeout: 5000 }).catch(() => false)) {
+    await search.fill(nodeLabel);
+    await frame.waitForTimeout(1200);
+  } else if (category) {
+    const categoryHeader = panel.getByText(category, { exact: true }).first();
     if (await categoryHeader.isVisible({ timeout: 5000 }).catch(() => false)) {
       await categoryHeader.click({ force: true }).catch(() => {});
     }
   }
-  let node = frame.getByText(nodeLabel, { exact: true }).last();
+
+  let node = panel.getByText(nodeLabel, { exact: true }).last();
   if (!await node.isVisible({ timeout: 5000 }).catch(() => false)) {
-    const search = frame.locator('input[placeholder*="Search"], input[type="text"]').first();
-    if (await search.isVisible({ timeout: 5000 }).catch(() => false)) {
-      await search.fill(nodeLabel);
-      await frame.waitForTimeout(1000);
+    if (category) {
+      const categoryHeader = panel.getByText(category, { exact: true }).first();
+      if (await categoryHeader.isVisible({ timeout: 5000 }).catch(() => false)) {
+        await categoryHeader.click({ force: true }).catch(() => {});
+        await frame.waitForTimeout(500);
+      }
     }
-    node = frame.getByText(nodeLabel, { exact: true }).last();
+    node = panel.getByText(nodeLabel, { exact: true }).last();
   }
   try {
     await node.waitFor({ state: 'visible', timeout: 30000 });
@@ -138,13 +161,38 @@ globalThis.addLogNode = async (nodeLabel, message) => {
 globalThis.addIfElseNode = async (condition) => {
   const frame = await getBIWebview();
   await selectFlowNode('If', 'Control');
-  await fillFlowNodeForm({
-    'branch-0': { type: 'cmEditor', value: condition, additionalProps: { clickLabel: true } }
+  const form = new Form(window, BI_INTEGRATOR_LABEL, frame);
+  await form.switchToFormView(false, frame);
+  await cmFill(condition, 0);
+  const panel = frame.locator('[data-testid="side-panel"]').first();
+  await panel.evaluate((element) => element.scrollTo({ top: element.scrollHeight, behavior: 'instant' })).catch(() => {});
+  await frame.waitForTimeout(500);
+  const addElse = panel.getByText('Add Else Block', { exact: true }).first();
+  await addElse.waitFor({ state: 'visible', timeout: 10000 });
+  await addElse.evaluate((element) => {
+    const clickable = element.closest('button, vscode-button, a, [role="button"]') || element;
+    clickable.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
   });
-  const addElse = frame.getByText('Add Else Block', { exact: true }).first();
-  if (await addElse.isVisible({ timeout: 5000 }).catch(() => false)) {
-    await addElse.click({ force: true });
-  }
+  await panel.getByText('Remove Else Block', { exact: true }).waitFor({ state: 'visible', timeout: 10000 });
+  await saveOpenFlowNodeForm();
+};
+
+globalThis.addMatchNode = async (target, firstPattern = '1') => {
+  const frame = await getBIWebview();
+  await selectFlowNode('Match', 'Control');
+  const form = new Form(window, BI_INTEGRATOR_LABEL, frame);
+  await form.switchToFormView(false, frame);
+  await cmFill(target, 0);
+  await cmFill(firstPattern, 1);
+  await saveOpenFlowNodeForm();
+};
+
+globalThis.addWhileNode = async (condition) => {
+  const frame = await getBIWebview();
+  await selectFlowNode('While', 'Control');
+  const form = new Form(window, BI_INTEGRATOR_LABEL, frame);
+  await form.switchToFormView(false, frame);
+  await cmFill(condition, 0);
   await saveOpenFlowNodeForm();
 };
 
@@ -168,3 +216,19 @@ globalThis.verifyFlowNodesSource = async (expected = FLOW_NODES_BASE_SOURCE) => 
 
 globalThis.verifyFlowNodesBaseSource = async () => verifyFlowNodesSource(FLOW_NODES_BASE_SOURCE);
 globalThis.verifyFlowNodesIfSource = async () => verifyFlowNodesSource([...FLOW_NODES_BASE_SOURCE, ...FLOW_NODES_IF_SOURCE]);
+globalThis.verifyFlowNodesLoggingSource = async () => verifyFlowNodesSource([
+  ...FLOW_NODES_BASE_SOURCE,
+  ...FLOW_NODES_IF_SOURCE,
+  ...FLOW_NODES_LOGGING_SOURCE
+]);
+globalThis.verifyFlowNodesMatchSource = async () => verifyFlowNodesSource([
+  ...FLOW_NODES_BASE_SOURCE,
+  ...FLOW_NODES_IF_SOURCE,
+  ...FLOW_NODES_MATCH_SOURCE
+]);
+globalThis.verifyFlowNodesWhileSource = async () => verifyFlowNodesSource([
+  ...FLOW_NODES_BASE_SOURCE,
+  ...FLOW_NODES_IF_SOURCE,
+  ...FLOW_NODES_LOGGING_SOURCE,
+  ...FLOW_NODES_WHILE_SOURCE
+]);

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/helpers/flow-nodes.js
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/helpers/flow-nodes.js
@@ -1,0 +1,170 @@
+const FLOW_NODES_BASE_SOURCE = [
+  'int count = 1',
+  'string msg = "started"',
+  'log:printInfo',
+  'log:printDebug'
+];
+
+const FLOW_NODES_IF_SOURCE = [
+  'if count > 10',
+  'else'
+];
+
+globalThis.addAutomationArtifact = async () => {
+  const frame = await getBIWebview();
+  await frame.getByRole('button', { name: /Add Artifact/i }).click({ force: true });
+  await frame.locator('#automation').first().click({ force: true });
+  await frame.getByRole('heading', { name: /Create New Automation/i }).waitFor({ timeout: 30000 });
+  await frame.getByRole('button', { name: 'Create' }).click({ force: true });
+  await frame.locator('[data-testid="bi-diagram-canvas"], #bi-diagram-canvas').waitFor({ timeout: 60000 });
+};
+
+globalThis.dismissHelperPanel = async () => {
+  await ensureWorkbench();
+  await window.keyboard.press('Escape');
+  await window.waitForTimeout(300);
+  await window.keyboard.press('Escape');
+  await window.waitForTimeout(300);
+};
+
+globalThis.clickNextDiagramPlus = async () => {
+  const frame = await getBIWebview();
+  const canvas = frame.locator('[data-testid="bi-diagram-canvas"], #bi-diagram-canvas');
+  await canvas.waitFor({ timeout: 30000 });
+  await canvas.evaluate((element) => {
+    element.scrollIntoView({ block: 'start', inline: 'nearest' });
+    const scrollable = element.closest('[style*="overflow"]') || element.parentElement;
+    scrollable?.scrollTo?.({ top: 0, behavior: 'instant' });
+    window.scrollTo(0, 0);
+  }).catch(() => {});
+  await frame.mouse.wheel(0, -1200).catch(() => {});
+  await frame.waitForTimeout(500);
+
+  const clickedId = await frame.locator('[data-testid]').evaluateAll((elements) => {
+    const candidates = elements.filter((element) => {
+      const id = element.getAttribute('data-testid') || '';
+      return id.startsWith('link-add-button') || id.startsWith('empty-node-add-button');
+    });
+    const target = candidates.find((element) => (element.getAttribute('data-testid') || '').startsWith('empty-node-add-button'))
+      || candidates[candidates.length - 2]
+      || candidates[candidates.length - 1];
+    if (!target) {
+      return '';
+    }
+    for (const type of ['pointerover', 'mouseover', 'mouseenter', 'pointerenter']) {
+      target.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true, view: window }));
+    }
+    for (const type of ['pointerdown', 'mousedown', 'mouseup', 'click']) {
+      target.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true, view: window }));
+    }
+    return target.getAttribute('data-testid') || '';
+  });
+
+  await frame.waitForTimeout(1000);
+  const text = await frame.locator('body').innerText().catch(() => '');
+  if (!text.includes('Statement') && !text.includes('Control') && !text.includes('Logging')) {
+    throw new Error(`node palette did not open after clicking diagram plus "${clickedId}"\n${text}`);
+  }
+};
+
+globalThis.selectFlowNode = async (nodeLabel, category) => {
+  const frame = await getBIWebview();
+  await clickNextDiagramPlus();
+  if (category) {
+    const categoryHeader = frame.getByText(category, { exact: true }).first();
+    if (await categoryHeader.isVisible({ timeout: 5000 }).catch(() => false)) {
+      await categoryHeader.click({ force: true }).catch(() => {});
+    }
+  }
+  let node = frame.getByText(nodeLabel, { exact: true }).last();
+  if (!await node.isVisible({ timeout: 5000 }).catch(() => false)) {
+    const search = frame.locator('input[placeholder*="Search"], input[type="text"]').first();
+    if (await search.isVisible({ timeout: 5000 }).catch(() => false)) {
+      await search.fill(nodeLabel);
+      await frame.waitForTimeout(1000);
+    }
+    node = frame.getByText(nodeLabel, { exact: true }).last();
+  }
+  try {
+    await node.waitFor({ state: 'visible', timeout: 30000 });
+  } catch (error) {
+    const text = await frame.locator('body').innerText().catch(() => '');
+    throw new Error(`node "${nodeLabel}" was not visible in palette: ${error.message}\n${text}`);
+  }
+  await node.click({ force: true });
+  await frame.waitForTimeout(1000);
+};
+
+globalThis.saveOpenFlowNodeForm = async () => {
+  const frame = await getBIWebview();
+  await dismissHelperPanel();
+  const save = frame.getByRole('button', { name: 'Save' }).last();
+  await save.waitFor({ timeout: 30000 });
+  await save.click({ force: true });
+  await frame.locator('[data-testid="bi-diagram-canvas"], #bi-diagram-canvas').waitFor({ timeout: 60000 });
+  await frame.waitForTimeout(1000);
+};
+
+globalThis.fillFlowNodeForm = async (values) => {
+  const frame = await getBIWebview();
+  const form = new Form(window, BI_INTEGRATOR_LABEL, frame);
+  await form.switchToFormView(false, frame);
+  await form.fill({ values });
+  await dismissHelperPanel();
+};
+
+globalThis.addDeclareVariableNode = async (name, type, expression) => {
+  await selectFlowNode('Declare Variable', 'Statement');
+  await fillFlowNodeForm({
+    'Name*Name of the variable': { type: 'input', value: name },
+    'Type': { type: 'textarea', value: type, additionalProps: { clickLabel: true } },
+    'expression': { type: 'cmEditor', value: expression, additionalProps: { clickLabel: true } }
+  });
+  await saveOpenFlowNodeForm();
+};
+
+globalThis.addLogNode = async (nodeLabel, message) => {
+  await selectFlowNode(nodeLabel, 'Logging');
+  await fillFlowNodeForm({
+    'msg': {
+      type: 'cmEditor',
+      value: message,
+      additionalProps: { switchMode: 'primary-mode', clickLabel: true, window }
+    }
+  });
+  await saveOpenFlowNodeForm();
+};
+
+globalThis.addIfElseNode = async (condition) => {
+  const frame = await getBIWebview();
+  await selectFlowNode('If', 'Control');
+  await fillFlowNodeForm({
+    'branch-0': { type: 'cmEditor', value: condition, additionalProps: { clickLabel: true } }
+  });
+  const addElse = frame.getByText('Add Else Block', { exact: true }).first();
+  if (await addElse.isVisible({ timeout: 5000 }).catch(() => false)) {
+    await addElse.click({ force: true });
+  }
+  await saveOpenFlowNodeForm();
+};
+
+globalThis.addGenericFlowNode = async (nodeLabel, category, values = {}) => {
+  await selectFlowNode(nodeLabel, category);
+  if (Object.keys(values).length > 0) {
+    await fillFlowNodeForm(values);
+  }
+  await saveOpenFlowNodeForm();
+};
+
+globalThis.verifyFlowNodesSource = async (expected = FLOW_NODES_BASE_SOURCE) => {
+  const state = JSON.parse(fs.readFileSync(path.join(sessionDir, 'state.json'), 'utf8'));
+  const source = fs.readFileSync(path.join(state.integrationDir, 'automation.bal'), 'utf8');
+  const missing = expected.filter((fragment) => !source.includes(fragment));
+  if (missing.length > 0) {
+    throw new Error(`automation.bal is missing expected flow source:\n${missing.join('\n')}\n\n${source}`);
+  }
+  console.log(`verified ${expected.length} source fragments`);
+};
+
+globalThis.verifyFlowNodesBaseSource = async () => verifyFlowNodesSource(FLOW_NODES_BASE_SOURCE);
+globalThis.verifyFlowNodesIfSource = async () => verifyFlowNodesSource([...FLOW_NODES_BASE_SOURCE, ...FLOW_NODES_IF_SOURCE]);

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/helpers/flow-nodes.js
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/helpers/flow-nodes.js
@@ -184,6 +184,31 @@ globalThis.addMatchNode = async (target, firstPattern = '1') => {
   await form.switchToFormView(false, frame);
   await cmFill(target, 0);
   await cmFill(firstPattern, 1);
+
+  const panel = frame.locator('[data-testid="side-panel"]').first();
+  await panel.evaluate((element) => element.scrollTo({ top: element.scrollHeight, behavior: 'instant' })).catch(() => {});
+  await frame.waitForTimeout(500);
+
+  // Add Case 2
+  const addCase = panel.getByText('Add Case', { exact: true }).first();
+  if (await addCase.isVisible({ timeout: 5000 }).catch(() => false)) {
+    await addCase.evaluate((element) => {
+      const clickable = element.closest('button, vscode-button, a, [role="button"]') || element;
+      clickable.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
+    });
+    await frame.waitForTimeout(300);
+  }
+
+  // Add Default case
+  const addDefault = panel.getByText('Add Default', { exact: true }).first();
+  if (await addDefault.isVisible({ timeout: 5000 }).catch(() => false)) {
+    await addDefault.evaluate((element) => {
+      const clickable = element.closest('button, vscode-button, a, [role="button"]') || element;
+      clickable.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
+    });
+    await frame.waitForTimeout(300);
+  }
+
   await saveOpenFlowNodeForm();
 };
 

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/helpers/flow-nodes.js
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/helpers/flow-nodes.js
@@ -158,45 +158,74 @@ globalThis.addLogNode = async (nodeLabel, message) => {
   await saveOpenFlowNodeForm();
 };
 
-globalThis.addIfElseNode = async (condition) => {
+globalThis.addIfElseNode = async (condition, elseIfConditions = [], hasElseBlock = true) => {
   const frame = await getBIWebview();
   await selectFlowNode('If', 'Control');
   const form = new Form(window, BI_INTEGRATOR_LABEL, frame);
   await form.switchToFormView(false, frame);
   await cmFill(condition, 0);
+
   const panel = frame.locator('[data-testid="side-panel"]').first();
   await panel.evaluate((element) => element.scrollTo({ top: element.scrollHeight, behavior: 'instant' })).catch(() => {});
   await frame.waitForTimeout(500);
-  const addElse = panel.getByText('Add Else Block', { exact: true }).first();
-  await addElse.waitFor({ state: 'visible', timeout: 10000 });
-  await addElse.evaluate((element) => {
-    const clickable = element.closest('button, vscode-button, a, [role="button"]') || element;
-    clickable.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
-  });
-  await panel.getByText('Remove Else Block', { exact: true }).waitFor({ state: 'visible', timeout: 10000 });
+
+  // Add else-if blocks for each condition
+  for (let i = 0; i < elseIfConditions.length; i++) {
+    const addElseIf = panel.getByText('Add Else If Block', { exact: true }).first();
+    if (await addElseIf.isVisible({ timeout: 5000 }).catch(() => false)) {
+      await addElseIf.evaluate((element) => {
+        const clickable = element.closest('button, vscode-button, a, [role="button"]') || element;
+        clickable.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
+      });
+      await frame.waitForTimeout(500);
+      // Fill the else-if condition at the next CodeMirror index
+      await cmFill(elseIfConditions[i], i + 1);
+      await frame.waitForTimeout(300);
+    }
+  }
+
+  // Add final Else block
+  if (hasElseBlock) {
+    const addElse = panel.getByText('Add Else Block', { exact: true }).first();
+    if (await addElse.isVisible({ timeout: 5000 }).catch(() => false)) {
+      await addElse.evaluate((element) => {
+        const clickable = element.closest('button, vscode-button, a, [role="button"]') || element;
+        clickable.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
+      });
+      await frame.waitForTimeout(300);
+    }
+  }
+
   await saveOpenFlowNodeForm();
 };
 
-globalThis.addMatchNode = async (target, firstPattern = '1') => {
+globalThis.addMatchNode = async (target, patterns = ['1', '2']) => {
   const frame = await getBIWebview();
   await selectFlowNode('Match', 'Control');
   const form = new Form(window, BI_INTEGRATOR_LABEL, frame);
   await form.switchToFormView(false, frame);
   await cmFill(target, 0);
-  await cmFill(firstPattern, 1);
+
+  // Fill first pattern
+  await cmFill(patterns[0], 1);
 
   const panel = frame.locator('[data-testid="side-panel"]').first();
   await panel.evaluate((element) => element.scrollTo({ top: element.scrollHeight, behavior: 'instant' })).catch(() => {});
   await frame.waitForTimeout(500);
 
-  // Add Case 2
-  const addCase = panel.getByText('Add Case', { exact: true }).first();
-  if (await addCase.isVisible({ timeout: 5000 }).catch(() => false)) {
-    await addCase.evaluate((element) => {
-      const clickable = element.closest('button, vscode-button, a, [role="button"]') || element;
-      clickable.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
-    });
-    await frame.waitForTimeout(300);
+  // Add and fill additional cases
+  for (let i = 1; i < patterns.length; i++) {
+    const addCase = panel.getByText('Add Case', { exact: true }).first();
+    if (await addCase.isVisible({ timeout: 5000 }).catch(() => false)) {
+      await addCase.evaluate((element) => {
+        const clickable = element.closest('button, vscode-button, a, [role="button"]') || element;
+        clickable.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
+      });
+      await frame.waitForTimeout(500);
+      // Fill the new case pattern at the next CodeMirror index
+      await cmFill(patterns[i], i + 1);
+      await frame.waitForTimeout(300);
+    }
   }
 
   // Add Default case

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/helpers/flow-nodes.js
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/helpers/flow-nodes.js
@@ -1,26 +1,26 @@
-const FLOW_NODES_BASE_SOURCE = [
+globalThis.FLOW_NODES_BASE_SOURCE = [
   'int count = 1',
   'string msg = "started"',
   'log:printInfo',
   'log:printDebug'
 ];
 
-const FLOW_NODES_IF_SOURCE = [
+globalThis.FLOW_NODES_IF_SOURCE = [
   'if count > 10',
   'else'
 ];
 
-const FLOW_NODES_LOGGING_SOURCE = [
+globalThis.FLOW_NODES_LOGGING_SOURCE = [
   'log:printError("sample error log")',
   'log:printWarn("sample warn log")'
 ];
 
-const FLOW_NODES_MATCH_SOURCE = [
+globalThis.FLOW_NODES_MATCH_SOURCE = [
   'match count',
   '1 =>'
 ];
 
-const FLOW_NODES_WHILE_SOURCE = [
+globalThis.FLOW_NODES_WHILE_SOURCE = [
   'while count < 3'
 ];
 

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/helpers/http-service.js
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/helpers/http-service.js
@@ -144,11 +144,7 @@ globalThis.openProjectFileInEditor = async (fileName) => {
 
 globalThis.runIntegrationAndWaitForUpload = async () => {
   await openProjectFileInEditor('main.bal');
-  const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
-  await window.keyboard.press(`${modifier}+Shift+P`);
-  await window.waitForTimeout(500);
-  await window.keyboard.type('Run Integration');
-  await window.keyboard.press('Enter');
+  await extendedPage.executePaletteCommand('BI.project.run');
   return waitForEndpoint('http://localhost:9090/upload?name=probe.txt', 120000, {
     method: 'POST',
     body: '{"content":"hello"}',

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/helpers/http-service.js
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/helpers/http-service.js
@@ -1,0 +1,157 @@
+globalThis.addArtifact = async (artifactName, testId) => {
+  const frame = await getBIWebview();
+  await frame.getByRole('button', { name: /Add Artifact/i }).click({ force: true });
+  if (testId) {
+    await frame.locator(`[data-testid="${testId}"], #${testId}`).first().click({ force: true });
+    return;
+  }
+  await frame.getByText(artifactName, { exact: true }).last().click({ force: true });
+};
+
+globalThis.clickVisibleText = async (frame, text) => {
+  const target = frame.getByText(text, { exact: true }).last();
+  await target.waitFor({ state: 'attached', timeout: 30000 });
+  try {
+    await target.click({ force: true, timeout: 5000 });
+  } catch {
+    await target.evaluate((element) => element.click());
+  }
+};
+
+globalThis.createHttpServiceWithResource = async (method = 'POST', resourcePath = 'upload') => {
+  await addArtifact('HTTP Service', 'http-service-card');
+  let frame = await getBIWebview();
+  await frame.getByRole('textbox', { name: /Service Base Path/i }).fill('/');
+  await frame.getByRole('button', { name: 'Create' }).click({ force: true });
+  await waitForText('Add Resource', 60000);
+
+  frame = await getBIWebview();
+  await frame.getByRole('button', { name: /Add Resource/i }).first().click({ force: true });
+  await clickVisibleText(frame, method);
+  const resourceInput = frame.getByRole('textbox', { name: /Resource Path/i })
+    .or(frame.locator('[data-testid="resource-path-input"]'))
+    .or(frame.locator('input[placeholder*="path/foo"]'));
+  await resourceInput.first().fill(resourcePath);
+  await clickVisibleText(frame, 'Save');
+  await frame.locator('[data-testid="bi-diagram-canvas"]').waitFor({ timeout: 60000 });
+  return { method, resourcePath };
+};
+
+globalThis.configureUploadResourceIO = async () => {
+  const frame = await getBIWebview();
+  await frame.getByRole('button', { name: /Configure/i }).click({ force: true });
+  await waitForText('Resource Configuration', 30000);
+
+  await frame.getByText('Query Parameter', { exact: true }).click({ force: true });
+  await frame.getByRole('textbox', { name: 'Name*' }).last().fill('name');
+  await frame.getByRole('button', { name: 'Save' }).first().click({ force: true });
+  await waitForText('string name', 30000);
+
+  await frame.getByText('Define Payload', { exact: true }).click({ force: true });
+  await waitForText('Define Payload', 30000);
+  await frame.locator('textarea').fill('{"content":"hello"}');
+  await frame.getByRole('button', { name: 'Import Type' }).click({ force: true });
+  await frame.getByRole('heading', { name: 'Payload' }).waitFor({ timeout: 30000 });
+  await frame.getByText('UploadPayload', { exact: true }).waitFor({ timeout: 30000 });
+  await frame.getByText('payload', { exact: true }).waitFor({ timeout: 30000 });
+
+  await frame.getByRole('button', { name: 'Save' }).last().click({ force: true });
+  await frame.locator('[data-testid="bi-diagram-canvas"]').waitFor({ timeout: 60000 });
+  await frame.waitForTimeout(3000);
+  const mainBal = fs.readFileSync(path.join(newProjectPath, 'main.bal'), 'utf8');
+  if (!mainBal.includes('@http:Payload UploadPayload payload') || !mainBal.includes('@http:Query string name')) {
+    throw new Error(`Resource configuration was not saved to main.bal:\n${mainBal}`);
+  }
+  return { queryName: 'name', payloadType: 'UploadPayload' };
+};
+
+globalThis.addReturnNodeFromDiagram = async (
+  expression = '{key: string `uploads/${name}`, size: payload.content.length()}'
+) => {
+  const frame = await getBIWebview();
+  const isNodePanelOpen = (text) => text.includes('Connections') && text.includes('Return');
+  for (let attempt = 0; attempt < 10; attempt++) {
+    const addButton = frame.locator('[data-testid="empty-node-add-button-1"]').first();
+    if (await addButton.isVisible({ timeout: 1000 }).catch(() => false)) {
+      await addButton.hover({ force: true }).catch(() => {});
+      await addButton.click({ force: true, timeout: 3000 }).catch(() => {});
+    }
+    await frame.waitForTimeout(1000);
+    let current = await snapshot().catch(() => '');
+    if (isNodePanelOpen(current)) break;
+    const clickedId = await frame.locator('[data-testid]').evaluateAll((elements) => {
+      const isVisible = (element) => {
+        const rect = element.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0;
+      };
+      const candidates = elements.filter((element) => {
+        const id = element.getAttribute('data-testid') || '';
+        return isVisible(element) && (id.startsWith('empty-node-add-button') || id.startsWith('link-add-button'));
+      });
+      const target = candidates.find((element) => (element.getAttribute('data-testid') || '').startsWith('empty-node-add-button'))
+        || candidates[0];
+      if (!target) return '';
+      for (const type of ['pointerdown', 'mousedown', 'mouseup', 'click']) {
+        target.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true, view: window }));
+      }
+      return target.getAttribute('data-testid') || '';
+    });
+    await frame.waitForTimeout(1000);
+    current = await snapshot().catch(() => '');
+    if (isNodePanelOpen(current)) break;
+    if (attempt === 9) {
+      const finalSnapshot = await snapshot().catch((error) => `snapshot failed: ${error.message}`);
+      throw new Error(`Node panel did not open after clicking diagram add button "${clickedId}"\n${finalSnapshot}`);
+    }
+  }
+  await waitForText('Control', 30000);
+  await frame.getByText('Return', { exact: true }).click({ force: true });
+  await waitForText('Return value.', 30000);
+  await frame.locator('[data-testid="ex-editor-expression"]').click({ force: true });
+  await frame.getByRole('button', { name: 'Open Helper Panel' }).click({ force: true });
+  await waitForText('Inputs', 30000);
+  await frame.getByText('Inputs', { exact: true }).click({ force: true });
+  await waitForText('payload', 30000);
+  await frame.getByText('payload', { exact: true }).click({ force: true });
+  await frame.locator('[data-testid="ex-editor-expression"] .cm-content').evaluate((element) => {
+    if (element.textContent !== 'payload') {
+      throw new Error(`Expected helper to insert "payload", found "${element.textContent}"`);
+    }
+  });
+  await frame.locator('[data-testid="ex-editor-expression"] .cm-content').click({ force: true });
+  await window.keyboard.press(process.platform === 'darwin' ? 'Meta+A' : 'Control+A');
+  await window.keyboard.type(expression);
+  await frame.getByRole('button', { name: 'Close Helper Panel' }).click({ force: true }).catch(() => {});
+  await frame.getByText('Return value.', { exact: true }).click({ force: true }).catch(() => {});
+  await frame.getByRole('button', { name: 'Save' }).click({ force: true });
+  await waitForText('Return', 60000);
+  const mainBal = fs.readFileSync(path.join(newProjectPath, 'main.bal'), 'utf8');
+  if (!mainBal.includes('return {key: string `uploads/${name}`, size: payload.content.length()};')) {
+    throw new Error(`Return node was not saved to main.bal:\n${mainBal}`);
+  }
+  return expression;
+};
+
+globalThis.openProjectFileInEditor = async (fileName) => {
+  await ensureWorkbench();
+  const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+  await window.keyboard.press(`${modifier}+p`);
+  await window.waitForTimeout(500);
+  await window.keyboard.type(fileName);
+  await window.keyboard.press('Enter');
+  await window.waitForTimeout(1500);
+};
+
+globalThis.runIntegrationAndWaitForUpload = async () => {
+  await openProjectFileInEditor('main.bal');
+  const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+  await window.keyboard.press(`${modifier}+Shift+P`);
+  await window.waitForTimeout(500);
+  await window.keyboard.type('Run Integration');
+  await window.keyboard.press('Enter');
+  return waitForEndpoint('http://localhost:9090/upload?name=probe.txt', 120000, {
+    method: 'POST',
+    body: '{"content":"hello"}',
+    headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/helpers/project.js
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/helpers/project.js
@@ -1,0 +1,59 @@
+globalThis.openIntegratorActivity = async () => {
+  await ensureWorkbench();
+  const activity = window.locator(
+    `#workbench\\.parts\\.activitybar a.action-label[aria-label="${BI_INTEGRATOR_LABEL}"]`
+  ).first();
+  await activity.waitFor({ state: 'visible', timeout: 120000 });
+  await activity.click();
+};
+
+globalThis.createProjectAndIntegration = async (baseName = 'Authoring') => {
+  const suffix = Date.now();
+  const projectName = `${baseName}Project${suffix}`;
+  const integrationName = `${baseName}Integration${suffix}`;
+  await openIntegratorActivity();
+
+  const sideBar = window.locator('#workbench\\.parts\\.sidebar');
+  const getStarted = sideBar.getByRole('button', { name: 'Get Started' }).first();
+  try {
+    await getStarted.waitFor({ state: 'visible', timeout: 120000 });
+    await getStarted.click();
+  } catch (error) {
+    const host = await hostSnapshot().catch(() => '');
+    throw new Error(`Get Started button was not available in the WSO2 Integrator side panel: ${error.message}\n${host}`);
+  }
+
+  let frame = await waitForGuest('Welcome', 60000).catch(() => waitForGuest(BI_INTEGRATOR_LABEL, 60000));
+  const createHeading = frame.getByRole('heading', { name: 'Create New Integration' });
+  if (await createHeading.isVisible({ timeout: 10000 }).catch(() => false)) {
+    await frame.getByRole('button', { name: 'Create' }).first().click();
+  }
+
+  frame = await waitForGuest('Welcome', 30000).catch(() => waitForGuest(BI_INTEGRATOR_LABEL, 30000));
+  await frame.getByRole('textbox', { name: /Integration Name/i }).fill(integrationName);
+  await frame.getByRole('textbox', { name: /Project Name/i }).fill(projectName);
+
+  const projectPathInput = frame.getByRole('textbox', { name: /Select Path/i })
+    .or(frame.locator('input#project-folder-selector-input'));
+  if (await projectPathInput.first().isVisible({ timeout: 2000 }).catch(() => false)) {
+    await projectPathInput.first().fill(dataFolder);
+  }
+
+  await frame.getByRole('button', { name: 'Create Integration' }).click({ force: true });
+  frame = await waitForGuest(BI_INTEGRATOR_LABEL, 120000);
+  await frame.getByText(projectName, { exact: true }).waitFor({ timeout: 120000 });
+  await frame.getByText(integrationName, { exact: true }).click({ force: true });
+  await waitForText('Add Artifact', 60000);
+  const projectDir = path.join(dataFolder, projectName.toLowerCase());
+  const integrationDir = path.join(projectDir, integrationName.toLowerCase());
+  globalThis.newProjectPath = integrationDir;
+  return { projectName, integrationName, projectDir, integrationDir };
+};
+
+globalThis.navigateToIntegrationOverview = async (integrationName) => {
+  const frame = await getBIWebview();
+  const existing = await snapshot().catch(() => '');
+  if (existing.includes('Add Artifact') && existing.includes('Run')) return;
+  await frame.getByText(integrationName, { exact: true }).first().click({ force: true }).catch(() => {});
+  await waitForText('Add Artifact', 60000);
+};

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/scenario.md
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/scenario.md
@@ -1,0 +1,33 @@
+# Flow Nodes Automation Scenario
+
+Create a comprehensive E2E test that validates Statement, Control, Logging, Concurrency, Type/Mapping, Function, and Connection nodes in a Ballerina Integrator Automation flow.
+
+## Goal
+
+Create a project and Automation artifact, author a complete `automation.bal` flow, and verify the generated source contains every Statement, Control, Logging, Concurrency, Type/Mapping, Function, and Connection construct in the scenario.
+
+## Steps
+
+| Step | Action | Nodes Added |
+|------|--------|-------------|
+| 01 | Create project | - |
+| 02 | Create Automation artifact | - |
+| 03 | Add logging + variables | Log Info, Declare Variable (int count), Declare Variable (string msg), Log Debug |
+| 04 | Add If/Else condition | If (count > 10), Update Variable, Else, Update Variable |
+| 05 | Add Match/Switch | Match (count), Case 1, Case 2, Default |
+| 06 | Add more logging | Log Error, Log Warn |
+| 07 | Add Foreach loop | Foreach, Update Variable |
+| 08 | Add While loop | While, Update Variable |
+| 09 | Add Type + Map Data | Create Type artifact, Map Data node |
+| 10 | Add Function + Call | Create Function artifact, Call Function node |
+| 11 | Add HTTP Connection | HTTP Client connection, Connection Action (GET) |
+| 12 | Add Concurrency | Fork, Wait |
+| 13 | Add Lock | Lock, Update Variable |
+| 14 | Add Return | Return node |
+| 15 | Verify source | Check `automation.bal` contains all generated code |
+
+## Selector Policy
+
+- Use `data-testid`, roles, and stable accessible text only.
+- Do not use Emotion or generated class selectors.
+- Add missing product `data-testid` values before promoting a UI-driven selector.

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/01_project.step.js
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/01_project.step.js
@@ -1,0 +1,5 @@
+{
+  const state = await createProjectAndIntegration('FlowNodes');
+  fs.writeFileSync(path.join(sessionDir, 'state.json'), JSON.stringify(state, null, 2));
+  console.log(`created ${state.projectName}/${state.integrationName}`);
+}

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/02_automation.step.js
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/02_automation.step.js
@@ -1,0 +1,6 @@
+{
+  const state = JSON.parse(fs.readFileSync(path.join(sessionDir, 'state.json'), 'utf8'));
+  await navigateToIntegrationOverview(state.integrationName);
+  await addAutomationArtifact();
+  console.log('created Automation artifact');
+}

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/03_logging_variables.step.js
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/03_logging_variables.step.js
@@ -1,0 +1,7 @@
+{
+  await addLogNode('Log Info', 'flow started');
+  await addDeclareVariableNode('count', 'int', '1');
+  await addDeclareVariableNode('msg', 'string', '"started"');
+  await addLogNode('Log Debug', 'string `initial ${count} ${msg}`');
+  await verifyFlowNodesBaseSource();
+}

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/04_if_else.step.js
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/04_if_else.step.js
@@ -1,0 +1,4 @@
+{
+  await addIfElseNode('count > 10');
+  await verifyFlowNodesIfSource();
+}

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/05_match.step.js
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/05_match.step.js
@@ -1,4 +1,4 @@
 {
-  await addMatchNode('count');
+  await addMatchNode('count', ['1', '2']);
   await verifyFlowNodesMatchSource();
 }

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/05_match.step.js
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/05_match.step.js
@@ -1,0 +1,3 @@
+{
+  console.log('TODO: add Match node through diagram form after stable selectors are identified');
+}

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/05_match.step.js
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/05_match.step.js
@@ -1,3 +1,4 @@
 {
-  console.log('TODO: add Match node through diagram form after stable selectors are identified');
+  await addMatchNode('count');
+  await verifyFlowNodesMatchSource();
 }

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/06_more_logging.step.js
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/06_more_logging.step.js
@@ -1,0 +1,4 @@
+{
+  await addLogNode('Log Error', 'sample error log');
+  await addLogNode('Log Warn', 'sample warn log');
+}

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/06_more_logging.step.js
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/06_more_logging.step.js
@@ -1,4 +1,5 @@
 {
   await addLogNode('Log Error', 'sample error log');
   await addLogNode('Log Warn', 'sample warn log');
+  await verifyFlowNodesLoggingSource();
 }

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/07_foreach.step.js
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/07_foreach.step.js
@@ -1,0 +1,3 @@
+{
+  console.log('TODO: add Foreach node through diagram form after stable selectors are identified');
+}

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/08_while.step.js
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/08_while.step.js
@@ -1,0 +1,3 @@
+{
+  console.log('TODO: add While node through diagram form after stable selectors are identified');
+}

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/08_while.step.js
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/08_while.step.js
@@ -1,3 +1,4 @@
 {
-  console.log('TODO: add While node through diagram form after stable selectors are identified');
+  await addWhileNode('count < 3');
+  await verifyFlowNodesWhileSource();
 }

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/09_type_map_data.step.js
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/09_type_map_data.step.js
@@ -1,0 +1,3 @@
+{
+  console.log('TODO: add Type artifact and Map Data node through diagram form after stable selectors are identified');
+}

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/10_function_call.step.js
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/10_function_call.step.js
@@ -1,0 +1,3 @@
+{
+  console.log('TODO: add Function artifact and Call Function node through diagram form after stable selectors are identified');
+}

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/11_http_connection.step.js
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/11_http_connection.step.js
@@ -1,0 +1,3 @@
+{
+  console.log('TODO: add HTTP connection and Connection Action node through diagram form after stable selectors are identified');
+}

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/12_concurrency.step.js
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/12_concurrency.step.js
@@ -1,0 +1,3 @@
+{
+  console.log('TODO: add Fork and Wait nodes through diagram form after stable selectors are identified');
+}

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/13_lock.step.js
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/13_lock.step.js
@@ -1,0 +1,3 @@
+{
+  console.log('TODO: add Lock node through diagram form after stable selectors are identified');
+}

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/14_return.step.js
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/14_return.step.js
@@ -1,0 +1,3 @@
+{
+  console.log('TODO: add Return node through diagram form after stable selectors are identified');
+}

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/15_verify_source.step.js
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/15_verify_source.step.js
@@ -1,0 +1,3 @@
+{
+  await verifyFlowNodesIfSource();
+}

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/15_verify_source.step.js
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/flow-nodes/steps/15_verify_source.step.js
@@ -1,3 +1,6 @@
 {
+  await verifyFlowNodesLoggingSource();
   await verifyFlowNodesIfSource();
+  await verifyFlowNodesMatchSource();
+  await verifyFlowNodesWhileSource();
 }

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/http-upload/scenario.md
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/http-upload/scenario.md
@@ -1,0 +1,6 @@
+Create an HTTP upload integration.
+
+The scenario creates a BI project and integration, adds an HTTP service with a
+POST `/upload` resource, configures the source to return JSON containing the
+uploaded key, runs the integration, and verifies that posting bytes to
+`/upload?name=probe.txt` returns a JSON body containing `uploads/probe.txt`.

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/http-upload/scenario.md
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/http-upload/scenario.md
@@ -1,6 +1,6 @@
 Create an HTTP upload integration.
 
-The scenario creates a BI project and integration, adds an HTTP service with a
+The scenario creates a project and integration, adds an HTTP service with a
 POST `/upload` resource, configures the source to return JSON containing the
 uploaded key, runs the integration, and verifies that posting bytes to
 `/upload?name=probe.txt` returns a JSON body containing `uploads/probe.txt`.

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/http-upload/steps/01_project.step.js
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/http-upload/steps/01_project.step.js
@@ -1,0 +1,5 @@
+{
+  const state = await createProjectAndIntegration('HttpUpload');
+  fs.writeFileSync(path.join(sessionDir, 'state.json'), JSON.stringify(state, null, 2));
+  console.log(`created ${state.projectName}/${state.integrationName}`);
+}

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/http-upload/steps/02_http_service.step.js
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/http-upload/steps/02_http_service.step.js
@@ -1,0 +1,6 @@
+{
+  const state = JSON.parse(fs.readFileSync(path.join(sessionDir, 'state.json'), 'utf8'));
+  await navigateToIntegrationOverview(state.integrationName);
+  await createHttpServiceWithResource('POST', 'upload');
+  console.log('created HTTP POST /upload');
+}

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/http-upload/steps/03_source_and_run.step.js
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scenarios/http-upload/steps/03_source_and_run.step.js
@@ -1,0 +1,9 @@
+{
+  await configureUploadResourceIO();
+  await addReturnNodeFromDiagram();
+  const result = await runIntegrationAndWaitForUpload();
+  if (![200, 201].includes(result.status) || !result.body.includes('uploads/probe.txt') || !result.body.includes('"size":5')) {
+    throw new Error(`unexpected upload response: ${JSON.stringify(result)}`);
+  }
+  console.log(JSON.stringify(result));
+}

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scripts/daemon.mjs
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scripts/daemon.mjs
@@ -8,6 +8,7 @@
  */
 import fs from 'fs';
 import http from 'http';
+import https from 'https';
 import path from 'path';
 import vm from 'vm';
 import { execSync } from 'child_process';
@@ -165,6 +166,8 @@ const ctx = vm.createContext({
   process,
   fs,
   path,
+  http,
+  https,
   execSync,
   Form,
   ExtendedPage,

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scripts/daemon.mjs
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scripts/daemon.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+/*
+ * Demo-skill style Ballerina E2E writer daemon.
+ *
+ * This intentionally launches VS Code through @wso2/playwright-vscode-tester,
+ * matching the committed E2E runner, then exposes a tiny HTTP endpoint that
+ * evaluates authoring step JavaScript against that live IDE session.
+ */
+import fs from 'fs';
+import http from 'http';
+import path from 'path';
+import vm from 'vm';
+import { execSync } from 'child_process';
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+
+const require = createRequire(import.meta.url);
+const {
+  downloadExtensionFromMarketplace,
+  ExtendedPage,
+  startVSCode,
+  switchToIFrame,
+  Form,
+} = require('@wso2/playwright-vscode-tester');
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const authoringRoot = path.resolve(scriptDir, '..');
+const extensionRoot = path.resolve(authoringRoot, '..', '..');
+const e2eRoot = path.join(extensionRoot, 'e2e-test');
+const resourcesFolder = path.join(e2eRoot, 'test-resources');
+const dataFolder = path.join(e2eRoot, 'data');
+const newProjectPath = path.join(dataFolder, 'test_project');
+const extensionsFolder = path.join(extensionRoot, 'vsix');
+const repoRootExtensionsFolder = path.resolve(extensionRoot, '..', '..', '..');
+const authoringResourcesFolder = path.join(resourcesFolder, 'authoring');
+const extensionsWorkRoot = path.join(authoringResourcesFolder, 'extensions-install');
+const marketplaceExtensionsFolder = path.join(extensionsWorkRoot, 'marketplace-cache');
+const preExtensionId = 'WSO2.wso2-integrator';
+const vscodeVersion = process.env.BI_E2E_VSCODE_VERSION ?? 'latest';
+const BI_INTEGRATOR_LABEL = 'WSO2 Integrator';
+
+const sessionName = process.argv[2];
+if (!sessionName) {
+  console.error('Usage: daemon.mjs <session-name> [workspace-path]');
+  process.exit(1);
+}
+if (!/^[a-zA-Z0-9_-]+$/.test(sessionName)) {
+  console.error(`invalid session name: "${sessionName}" (allowed: a-z A-Z 0-9 _ -)`);
+  process.exit(1);
+}
+
+const requestedWorkspace = process.argv[3] ? path.resolve(process.argv[3]) : dataFolder;
+const sessionDir = `/tmp/ballerina-e2e-${sessionName}`;
+const portFile = path.join(sessionDir, 'daemon.port');
+const pidFile = path.join(sessionDir, 'daemon.pid');
+const execScript = path.join(sessionDir, 'exec.sh');
+const logPath = path.join(sessionDir, 'daemon.log');
+
+function log(message) {
+  fs.appendFileSync(logPath, `[${new Date().toISOString().slice(11, 23)}] ${message}\n`);
+}
+
+function isAlive() {
+  if (!fs.existsSync(portFile)) return false;
+  const existingPort = fs.readFileSync(portFile, 'utf8').trim();
+  try {
+    execSync(`curl -sf --max-time 2 http://127.0.0.1:${existingPort} --data-binary '"ping"'`, { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+if (isAlive()) {
+  console.error(`daemon "${sessionName}" already running (session: ${sessionDir})`);
+  process.exit(1);
+}
+
+fs.rmSync(sessionDir, { recursive: true, force: true });
+fs.mkdirSync(sessionDir, { recursive: true });
+fs.mkdirSync(authoringResourcesFolder, { recursive: true });
+
+function resetAuthoringDataFolder() {
+  fs.rmSync(dataFolder, { recursive: true, force: true });
+  fs.mkdirSync(dataFolder, { recursive: true, mode: 0o777 });
+}
+
+function resolveBallerinaVsixPath() {
+  const searchFolders = [extensionsFolder, repoRootExtensionsFolder].filter((folder) => fs.existsSync(folder));
+  const findFiles = () => searchFolders.flatMap((folder) => fs.readdirSync(folder)
+    .filter((file) => /^ballerina-.*\.vsix$/i.test(file))
+    .filter((file) => !/^ballerina-integrator-/i.test(file))
+    .map((file) => ({
+      file,
+      fullPath: path.join(folder, file),
+      mtime: fs.statSync(path.join(folder, file)).mtimeMs,
+    })))
+    .sort((a, b) => b.mtime - a.mtime);
+
+  let files = findFiles();
+  if (files.length === 0) {
+    log('No local Ballerina VSIX found; running "rush build -t ballerina"');
+    execSync('rush build -t ballerina', {
+      cwd: repoRootExtensionsFolder,
+      stdio: 'inherit',
+      timeout: 60 * 60 * 1000,
+    });
+    files = findFiles();
+  }
+
+  if (files.length === 0) {
+    throw new Error(`No local Ballerina VSIX found in: ${searchFolders.join(', ')} after running "rush build -t ballerina".`);
+  }
+  return files[0].fullPath;
+}
+
+async function prepareExtensionsForLaunch(profileName) {
+  fs.mkdirSync(extensionsWorkRoot, { recursive: true });
+  fs.mkdirSync(marketplaceExtensionsFolder, { recursive: true });
+
+  await downloadExtensionFromMarketplace(preExtensionId, marketplaceExtensionsFolder, true);
+
+  const launchExtensionsFolder = path.join(extensionsWorkRoot, profileName);
+  fs.rmSync(launchExtensionsFolder, { recursive: true, force: true });
+  fs.mkdirSync(launchExtensionsFolder, { recursive: true });
+
+  const ballerinaVsix = resolveBallerinaVsixPath();
+  fs.copyFileSync(ballerinaVsix, path.join(launchExtensionsFolder, path.basename(ballerinaVsix)));
+
+  const prereqVsix = fs.readdirSync(marketplaceExtensionsFolder)
+    .find((file) => /^wso2-integrator-.*\.vsix$/i.test(file));
+  if (!prereqVsix) {
+    throw new Error(`Prerequisite VSIX for ${preExtensionId} not found in: ${marketplaceExtensionsFolder}`);
+  }
+  fs.copyFileSync(path.join(marketplaceExtensionsFolder, prereqVsix), path.join(launchExtensionsFolder, prereqVsix));
+
+  return launchExtensionsFolder;
+}
+
+async function launchIDE() {
+  resetAuthoringDataFolder();
+  const profileName = `bi-authoring-${sessionName}-${process.pid}`;
+  const launchExtensionsFolder = await prepareExtensionsForLaunch(profileName);
+  log(`starting VS Code profile=${profileName} workspace=${requestedWorkspace}`);
+  const vscode = await startVSCode(
+    resourcesFolder,
+    vscodeVersion,
+    undefined,
+    false,
+    launchExtensionsFolder,
+    requestedWorkspace,
+    profileName
+  );
+  const firstWindow = await vscode.firstWindow({ timeout: 60000 });
+  const extendedPage = new ExtendedPage(firstWindow);
+  await firstWindow.waitForLoadState('domcontentloaded').catch(() => {});
+  log('VS Code window ready');
+  return { vscode, window: firstWindow, extendedPage };
+}
+
+const launched = await launchIDE();
+const ctx = vm.createContext({
+  ...launched,
+  console,
+  process,
+  fs,
+  path,
+  execSync,
+  Form,
+  ExtendedPage,
+  switchToIFrame,
+  BI_INTEGRATOR_LABEL,
+  sessionDir,
+  extensionRoot,
+  e2eRoot,
+  dataFolder,
+  newProjectPath,
+});
+
+function load(file) {
+  vm.runInContext(fs.readFileSync(file, 'utf8'), ctx, { filename: file });
+  log(`loaded ${path.relative(authoringRoot, file)}`);
+}
+
+load(path.join(scriptDir, 'prelude.js'));
+const helpersDir = path.join(authoringRoot, 'helpers');
+for (const file of fs.readdirSync(helpersDir).sort()) {
+  if (file.endsWith('.js')) load(path.join(helpersDir, file));
+}
+fs.watch(helpersDir, (_, file) => {
+  if (!file?.endsWith('.js')) return;
+  try {
+    load(path.join(helpersDir, file));
+  } catch (error) {
+    log(`reload error ${file}: ${error.message}`);
+  }
+});
+
+let tail = Promise.resolve();
+http.createServer((req, res) => {
+  let body = '';
+  req.on('data', (chunk) => { body += chunk; });
+  req.on('end', () => {
+    const preview = body.trim().slice(0, 120).replace(/\n/g, ' ');
+    const run = async () => {
+      log(`run: ${preview}`);
+      ctx.console = { log: (...args) => res.write(args.map(String).join(' ') + '\n') };
+      const wrapped = `(async()=>{return(${body})})()`;
+      let code;
+      try {
+        new vm.Script(wrapped);
+        code = wrapped;
+      } catch {
+        code = `(async()=>{${body}})()`;
+      }
+      const result = vm.runInContext(code, ctx, { timeout: 600000 });
+      return result instanceof Promise ? result : Promise.resolve(result);
+    };
+    const next = tail.then(run);
+    tail = next.then(() => {}, () => {});
+    next.then(
+      (result) => {
+        log(`ok: ${preview}`);
+        const out = typeof result === 'string' ? result : JSON.stringify(result) ?? '';
+        res.end(out || (result === undefined ? 'ok' : String(result)));
+      },
+      (error) => {
+        log(`err: ${error.message}`);
+        res.end((error.stack ?? error.message) + '\n');
+      }
+    );
+  });
+}).listen(0, '127.0.0.1', function onListen() {
+  const { port } = this.address();
+  fs.writeFileSync(portFile, String(port));
+  fs.writeFileSync(pidFile, String(process.pid));
+  fs.writeFileSync(execScript, `#!/bin/bash\nexec curl -s --max-time \${TIMEOUT:-900} -X POST http://127.0.0.1:${port} --data-binary @-\n`, { mode: 0o755 });
+  log(`ready on :${port}`);
+  console.error(`ballerina-e2e-writer daemon '${sessionName}' ready: ${execScript}`);
+});
+
+process.on('SIGTERM', async () => {
+  await launched.vscode.close().catch(() => {});
+  process.exit(0);
+});
+process.on('SIGINT', async () => {
+  await launched.vscode.close().catch(() => {});
+  process.exit(0);
+});

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scripts/daemon.mjs
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scripts/daemon.mjs
@@ -86,8 +86,8 @@ function resetAuthoringDataFolder() {
 }
 
 function resolveBallerinaVsixPath() {
-  const searchFolders = [extensionsFolder, repoRootExtensionsFolder].filter((folder) => fs.existsSync(folder));
-  const findFiles = () => searchFolders.flatMap((folder) => fs.readdirSync(folder)
+  const candidateFolders = [extensionsFolder, repoRootExtensionsFolder];
+  const findFiles = () => candidateFolders.filter((folder) => fs.existsSync(folder)).flatMap((folder) => fs.readdirSync(folder)
     .filter((file) => /^ballerina-.*\.vsix$/i.test(file))
     .filter((file) => !/^ballerina-integrator-/i.test(file))
     .map((file) => ({
@@ -109,7 +109,7 @@ function resolveBallerinaVsixPath() {
   }
 
   if (files.length === 0) {
-    throw new Error(`No local Ballerina VSIX found in: ${searchFolders.join(', ')} after running "rush build -t ballerina".`);
+    throw new Error(`No local Ballerina VSIX found in: ${candidateFolders.join(', ')} after running "rush build -t ballerina".`);
   }
   return files[0].fullPath;
 }
@@ -204,7 +204,7 @@ http.createServer((req, res) => {
     const preview = body.trim().slice(0, 120).replace(/\n/g, ' ');
     const run = async () => {
       log(`run: ${preview}`);
-      ctx.console = { log: (...args) => res.write(args.map(String).join(' ') + '\n') };
+      ctx.console = { log: (...args) => { if (!res.writableEnded) res.write(args.map(String).join(' ') + '\n'); } };
       const wrapped = `(async()=>{return(${body})})()`;
       let code;
       try {
@@ -213,8 +213,14 @@ http.createServer((req, res) => {
       } catch {
         code = `(async()=>{${body}})()`;
       }
-      const result = vm.runInContext(code, ctx, { timeout: 600000 });
-      return result instanceof Promise ? result : Promise.resolve(result);
+      const result = vm.runInContext(code, ctx);
+      if (!(result instanceof Promise)) return result;
+      const STEP_TIMEOUT_MS = 600000;
+      let timer;
+      const timeoutPromise = new Promise((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`step timed out after ${STEP_TIMEOUT_MS}ms`)), STEP_TIMEOUT_MS);
+      });
+      return Promise.race([result, timeoutPromise]).finally(() => clearTimeout(timer));
     };
     const next = tail.then(run);
     tail = next.then(() => {}, () => {});
@@ -226,6 +232,7 @@ http.createServer((req, res) => {
       },
       (error) => {
         log(`err: ${error.message}`);
+        res.writeHead(500);
         res.end((error.stack ?? error.message) + '\n');
       }
     );
@@ -234,7 +241,7 @@ http.createServer((req, res) => {
   const { port } = this.address();
   fs.writeFileSync(portFile, String(port));
   fs.writeFileSync(pidFile, String(process.pid));
-  fs.writeFileSync(execScript, `#!/bin/bash\nexec curl -s --max-time \${TIMEOUT:-900} -X POST http://127.0.0.1:${port} --data-binary @-\n`, { mode: 0o755 });
+  fs.writeFileSync(execScript, `#!/bin/bash\nexec curl -s --fail-with-body --max-time \${TIMEOUT:-900} -X POST http://127.0.0.1:${port} --data-binary @-\n`, { mode: 0o755 });
   log(`ready on :${port}`);
   console.error(`ballerina-e2e-writer daemon '${sessionName}' ready: ${execScript}`);
 });

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scripts/prelude.js
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scripts/prelude.js
@@ -66,6 +66,7 @@ globalThis.hostSnapshot = async () => {
 };
 
 globalThis.waitForText = async (text, timeout = 30000) => {
+  await ensureWorkbench();
   const deadline = Date.now() + timeout;
   while (Date.now() < deadline) {
     const snap = await snapshot().catch(() => '');
@@ -118,11 +119,11 @@ globalThis.recordSelectorGap = (description, preferredTestId) => {
 
 globalThis.waitForEndpoint = async (url, timeout = 60000, opts = {}) => {
   const deadline = Date.now() + timeout;
+  const body = opts.bodyFile ? fs.readFileSync(opts.bodyFile) : opts.body;
   while (Date.now() < deadline) {
     const result = await new Promise((resolve) => {
       const u = new URL(url);
       const lib = u.protocol === 'https:' ? https : http;
-      const body = opts.bodyFile ? fs.readFileSync(opts.bodyFile) : opts.body;
       const req = lib.request(
         u,
         { method: opts.method || 'GET', headers: opts.headers || {}, timeout: 5000 },

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scripts/prelude.js
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scripts/prelude.js
@@ -117,26 +117,27 @@ globalThis.recordSelectorGap = (description, preferredTestId) => {
 };
 
 globalThis.waitForEndpoint = async (url, timeout = 60000, opts = {}) => {
-  const method = opts.method || 'GET';
-  const headerArgs = Object.entries(opts.headers || {})
-    .map(([key, value]) => `-H '${key}: ${String(value).replace(/'/g, "'\\''")}'`)
-    .join(' ');
-  const bodyArg = opts.bodyFile
-    ? `--data-binary @${opts.bodyFile}`
-    : opts.body
-      ? `--data-raw '${String(opts.body).replace(/'/g, "'\\''")}'`
-      : '';
-  const cmd = `curl -s -o /dev/stdout -w '\\n%{http_code}' --max-time 5 -X ${method} ${headerArgs} ${bodyArg ? `${bodyArg} ` : ''}'${url}'`;
   const deadline = Date.now() + timeout;
   while (Date.now() < deadline) {
-    try {
-      const raw = execSync(cmd, { encoding: 'utf8', timeout: 10000 });
-      const lines = raw.split('\n');
-      const status = Number(lines.pop());
-      if (status > 0) return { status, body: lines.join('\n') };
-    } catch {
-      // Retry until timeout.
-    }
+    const result = await new Promise((resolve) => {
+      const u = new URL(url);
+      const lib = u.protocol === 'https:' ? https : http;
+      const body = opts.bodyFile ? fs.readFileSync(opts.bodyFile) : opts.body;
+      const req = lib.request(
+        u,
+        { method: opts.method || 'GET', headers: opts.headers || {}, timeout: 5000 },
+        (res) => {
+          const chunks = [];
+          res.on('data', (c) => chunks.push(c));
+          res.on('end', () => resolve({ status: res.statusCode, body: Buffer.concat(chunks).toString('utf8') }));
+        }
+      );
+      req.on('error', () => resolve(null));
+      req.on('timeout', () => { req.destroy(); resolve(null); });
+      if (body !== undefined) req.write(body);
+      req.end();
+    });
+    if (result && result.status > 0) return result;
     await window.waitForTimeout(1000);
   }
   throw new Error(`waitForEndpoint("${url}") timed out after ${timeout}ms`);

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scripts/prelude.js
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scripts/prelude.js
@@ -1,0 +1,143 @@
+// Loaded into the authoring daemon VM context.
+
+globalThis.guestFrame = null;
+
+globalThis.ensureWorkbench = async () => {
+  if (!window || window.isClosed?.()) {
+    window = await vscode.firstWindow({ timeout: 60000 });
+    extendedPage = new ExtendedPage(window);
+  }
+  return window;
+};
+
+globalThis.waitForGuest = async (viewName = BI_INTEGRATOR_LABEL, timeout = 30000) => {
+  await ensureWorkbench();
+  const deadline = Date.now() + timeout;
+  let lastError = 'unknown';
+  while (Date.now() < deadline) {
+    try {
+      const frame = await switchToIFrame(viewName, window, 5000);
+      if (frame) {
+        guestFrame = frame;
+        return frame;
+      }
+      lastError = `switchToIFrame(${viewName}) returned no frame`;
+    } catch (error) {
+      lastError = error.message;
+    }
+    try {
+      const webview = window.locator('iframe.webview.ready').last();
+      if (await webview.isVisible({ timeout: 1000 }).catch(() => false)) {
+        const outer = await (await webview.elementHandle()).contentFrame();
+        const child = outer?.childFrames().find((frame) => {
+          try {
+            return frame.url().includes('vscode-webview') || frame.url().includes('fake.html');
+          } catch {
+            return false;
+          }
+        }) ?? outer?.childFrames()[0] ?? outer;
+        if (child) {
+          await child.waitForLoadState().catch(() => {});
+          guestFrame = child;
+          return child;
+        }
+      }
+    } catch (error) {
+      lastError = error.message;
+    }
+    await window.waitForTimeout(500);
+  }
+  throw new Error(`BI webview not ready: ${lastError}`);
+};
+
+globalThis.getBIWebview = async (timeout = 30000) => waitForGuest(BI_INTEGRATOR_LABEL, timeout);
+
+globalThis.snapshot = async (filter) => {
+  const frame = await getBIWebview();
+  const raw = await frame.locator('body').ariaSnapshot();
+  if (!filter) return raw;
+  const re = filter instanceof RegExp ? filter : new RegExp(filter, 'i');
+  return raw.split('\n').filter((line) => re.test(line)).join('\n');
+};
+
+globalThis.hostSnapshot = async () => {
+  await ensureWorkbench();
+  return window.locator('body').ariaSnapshot();
+};
+
+globalThis.waitForText = async (text, timeout = 30000) => {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    const snap = await snapshot().catch(() => '');
+    if (snap.includes(text)) return snap;
+    await window.waitForTimeout(500);
+  }
+  throw new Error(`waitForText("${text}") timed out after ${timeout}ms`);
+};
+
+globalThis.guestClick = async (locator) => {
+  await locator.waitFor({ state: 'visible', timeout: 30000 });
+  await locator.scrollIntoViewIfNeeded().catch(() => {});
+  await locator.click({ force: true });
+};
+
+globalThis.guestFill = async (locator, text) => {
+  await locator.waitFor({ state: 'visible', timeout: 30000 });
+  await locator.click({ force: true });
+  await locator.fill('').catch(async () => {
+    await window.keyboard.press(process.platform === 'darwin' ? 'Meta+A' : 'Control+A');
+  });
+  await window.keyboard.type(text);
+};
+
+globalThis.cmFill = async (text, index = 0) => {
+  const frame = await getBIWebview();
+  await frame.evaluate(({ text, index }) => {
+    const els = document.querySelectorAll('.cm-content');
+    const el = els[index];
+    if (!el) throw new Error(`CodeMirror editor not found at index ${index}`);
+    const view = el.cmView?.view;
+    if (!view) throw new Error('CodeMirror view instance not found');
+    view.focus();
+    view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: text } });
+  }, { text, index });
+};
+
+globalThis.listTestIds = async () => {
+  const frame = await getBIWebview();
+  return frame.locator('[data-testid]').evaluateAll((els) =>
+    els.map((el) => el.getAttribute('data-testid')).filter(Boolean).sort()
+  );
+};
+
+globalThis.recordSelectorGap = (description, preferredTestId) => {
+  const out = path.join(sessionDir, 'selector-gaps.md');
+  fs.appendFileSync(out, `- ${description} -> \`${preferredTestId}\`\n`);
+  return out;
+};
+
+globalThis.waitForEndpoint = async (url, timeout = 60000, opts = {}) => {
+  const method = opts.method || 'GET';
+  const headerArgs = Object.entries(opts.headers || {})
+    .map(([key, value]) => `-H '${key}: ${String(value).replace(/'/g, "'\\''")}'`)
+    .join(' ');
+  const bodyArg = opts.bodyFile
+    ? `--data-binary @${opts.bodyFile}`
+    : opts.body
+      ? `--data-raw '${String(opts.body).replace(/'/g, "'\\''")}'`
+      : '';
+  const cmd = `curl -s -o /dev/stdout -w '\\n%{http_code}' --max-time 5 -X ${method} ${headerArgs} ${bodyArg ? `${bodyArg} ` : ''}'${url}'`;
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    try {
+      const raw = execSync(cmd, { encoding: 'utf8', timeout: 10000 });
+      const lines = raw.split('\n');
+      const status = Number(lines.pop());
+      if (status > 0) return { status, body: lines.join('\n') };
+    } catch {
+      // Retry until timeout.
+    }
+    await window.waitForTimeout(1000);
+  }
+  throw new Error(`waitForEndpoint("${url}") timed out after ${timeout}ms`);
+};

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scripts/run-steps.sh
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scripts/run-steps.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -euo pipefail
+
+NAME="${1:?usage: run-steps.sh <daemon-name> <steps-dir> [from] [to]}"
+STEPS_DIR="${2:?usage: run-steps.sh <daemon-name> <steps-dir> [from] [to]}"
+FROM="${3:-01}"
+TO="${4:-99}"
+
+[ -d "$STEPS_DIR" ] || { echo "not a directory: $STEPS_DIR" >&2; exit 1; }
+STEPS_DIR="$(cd "$STEPS_DIR" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SESSION_DIR="/tmp/ballerina-e2e-${NAME}"
+PORT_FILE="$SESSION_DIR/daemon.port"
+EXEC="$SESSION_DIR/exec.sh"
+
+alive() {
+  [ -f "$PORT_FILE" ] || return 1
+  local port
+  port="$(cat "$PORT_FILE")"
+  curl -sf --max-time 2 "http://127.0.0.1:$port" --data-binary '"ping"' >/dev/null 2>&1 || return 1
+  echo "$port"
+}
+
+PORT="$(alive || true)"
+if [ -z "$PORT" ]; then
+  echo "starting Ballerina E2E writer daemon '$NAME'..." >&2
+  # Clean up any orphaned Electron process from a previous failed daemon with
+  # the same profile prefix before opening a new window.
+  pkill -f "bi-authoring-${NAME}-" 2>/dev/null || true
+  nohup node "$SCRIPT_DIR/daemon.mjs" "$NAME" >/dev/null 2>&1 &
+  for _ in $(seq 1 120); do
+    PORT="$(alive || true)"
+    [ -n "$PORT" ] && break
+    sleep 1
+  done
+  [ -z "$PORT" ] && { echo "daemon '$NAME' failed to start (see $SESSION_DIR/daemon.log)" >&2; exit 1; }
+fi
+
+FILES="$(find "$STEPS_DIR" -maxdepth 1 -name '*.step.js' -type f | sort | while read -r file; do
+  n="$(basename "$file" | grep -o '^[0-9]*')"
+  if [ "$n" -ge "$FROM" ] 2>/dev/null && [ "$n" -le "$TO" ] 2>/dev/null; then
+    echo "$file"
+  fi
+done)"
+
+[ -n "$FILES" ] || { echo "no matching steps in $STEPS_DIR" >&2; exit 1; }
+
+echo "daemon '$NAME' on :$PORT" >&2
+echo "steps: $FILES" >&2
+OUTPUT="$(cat $FILES | "$EXEC")"
+printf '%s\n' "$OUTPUT"
+
+if printf '%s\n' "$OUTPUT" | grep -Eq '(^|[[:space:]])(Error|SyntaxError|TimeoutError):|locator\.'; then
+  echo "step execution failed; see $SESSION_DIR/daemon.log" >&2
+  exit 1
+fi

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scripts/run-steps.sh
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-authoring/scripts/run-steps.sh
@@ -36,21 +36,17 @@ if [ -z "$PORT" ]; then
   [ -z "$PORT" ] && { echo "daemon '$NAME' failed to start (see $SESSION_DIR/daemon.log)" >&2; exit 1; }
 fi
 
-FILES="$(find "$STEPS_DIR" -maxdepth 1 -name '*.step.js' -type f | sort | while read -r file; do
+FILES=()
+while IFS= read -r file; do
   n="$(basename "$file" | grep -o '^[0-9]*')"
   if [ "$n" -ge "$FROM" ] 2>/dev/null && [ "$n" -le "$TO" ] 2>/dev/null; then
-    echo "$file"
+    FILES+=("$file")
   fi
-done)"
+done < <(find "$STEPS_DIR" -maxdepth 1 -name '*.step.js' -type f | sort)
 
-[ -n "$FILES" ] || { echo "no matching steps in $STEPS_DIR" >&2; exit 1; }
+[ "${#FILES[@]}" -gt 0 ] || { echo "no matching steps in $STEPS_DIR" >&2; exit 1; }
 
 echo "daemon '$NAME' on :$PORT" >&2
-echo "steps: $FILES" >&2
-OUTPUT="$(cat $FILES | "$EXEC")"
+printf 'steps: %s\n' "${FILES[@]}" >&2
+OUTPUT="$(cat "${FILES[@]}" | "$EXEC")" || { echo "step execution failed; see $SESSION_DIR/daemon.log" >&2; printf '%s\n' "$OUTPUT"; exit 1; }
 printf '%s\n' "$OUTPUT"
-
-if printf '%s\n' "$OUTPUT" | grep -Eq '(^|[[:space:]])(Error|SyntaxError|TimeoutError):|locator\.'; then
-  echo "step execution failed; see $SESSION_DIR/daemon.log" >&2
-  exit 1
-fi

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/api-integration/http-upload.spec.ts
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/api-integration/http-upload.spec.ts
@@ -1,0 +1,197 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { expect, test } from '@playwright/test';
+import { addArtifact, BI_INTEGRATOR_LABEL, BI_WEBVIEW_NOT_FOUND_ERROR, initTest, page } from '../utils/helpers';
+import { switchToIFrame, Form } from '@wso2/playwright-vscode-tester';
+import { FileUtils } from '../utils/helpers/fileSystem';
+
+async function waitForEndpoint(url: string, timeoutMs: number): Promise<{ status: number; body: string }> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        try {
+            const response = await fetch(url, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: '{"content":"hello"}',
+            });
+            return { status: response.status, body: await response.text() };
+        } catch {
+            await page.page.waitForTimeout(1000);
+        }
+    }
+    throw new Error(`Timed out waiting for ${url}`);
+}
+
+async function clickVisibleText(locatorOwner: ReturnType<typeof switchToIFrame> extends Promise<infer T> ? NonNullable<T> : never, text: string) {
+    const target = locatorOwner.getByText(text, { exact: true }).last();
+    await target.waitFor({ state: 'attached', timeout: 30000 });
+    try {
+        await target.click({ force: true, timeout: 5000 });
+    } catch {
+        await target.evaluate((element) => (element as HTMLElement).click());
+    }
+}
+
+async function clickButtonText(locatorOwner: ReturnType<typeof switchToIFrame> extends Promise<infer T> ? NonNullable<T> : never, text: string, index = -1) {
+    const buttons = locatorOwner.getByRole('button', { name: text });
+    const target = index >= 0 ? buttons.nth(index) : buttons.last();
+    await target.waitFor({ state: 'attached', timeout: 30000 });
+    try {
+        await target.click({ force: true, timeout: 5000 });
+    } catch {
+        await target.evaluate((element) => (element as HTMLElement).click());
+    }
+}
+
+async function configureUploadResourceIO(locatorOwner: ReturnType<typeof switchToIFrame> extends Promise<infer T> ? NonNullable<T> : never) {
+    await locatorOwner.getByRole('button', { name: /Configure/i }).click({ force: true });
+    await expect(locatorOwner.getByText('Resource Configuration', { exact: true })).toBeVisible({ timeout: 30000 });
+
+    await locatorOwner.getByText('Query Parameter', { exact: true }).click({ force: true });
+    await locatorOwner.getByRole('textbox', { name: 'Name*' }).last().fill('name');
+    await clickButtonText(locatorOwner, 'Save', 0);
+    await expect.poll(async () => locatorOwner.locator('body').innerText(), { timeout: 30000 }).toContain('name');
+
+    await locatorOwner.getByText('Define Payload', { exact: true }).click({ force: true });
+    await expect(locatorOwner.getByRole('heading', { name: 'Define Payload' })).toBeVisible({ timeout: 30000 });
+    await locatorOwner.locator('textarea').fill('{"content":"hello"}');
+    await clickButtonText(locatorOwner, 'Import Type');
+    await expect(locatorOwner.getByRole('heading', { name: 'Payload' })).toBeVisible({ timeout: 30000 });
+    await expect(locatorOwner.getByText('UploadPayload', { exact: true }).first()).toBeVisible({ timeout: 30000 });
+    await expect(locatorOwner.getByText('payload', { exact: true }).first()).toBeVisible({ timeout: 30000 });
+
+    await clickButtonText(locatorOwner, 'Save');
+    await locatorOwner.locator('[data-testid="bi-diagram-canvas"]').waitFor({ timeout: 60000 });
+    await expect.poll(() => FileUtils.readProjectFile('main.bal'), { timeout: 30000 }).toContain('@http:Payload UploadPayload payload');
+    await expect.poll(() => FileUtils.readProjectFile('main.bal'), { timeout: 30000 }).toContain('@http:Query string name');
+}
+
+async function addReturnNodeFromDiagram(locatorOwner: ReturnType<typeof switchToIFrame> extends Promise<infer T> ? NonNullable<T> : never) {
+    for (let attempt = 0; attempt < 10; attempt++) {
+        const addButton = locatorOwner.locator('[data-testid="empty-node-add-button-1"]').first();
+        if (await addButton.isVisible({ timeout: 1000 }).catch(() => false)) {
+            await addButton.hover({ force: true }).catch(() => {});
+            await addButton.click({ force: true, timeout: 3000 }).catch(() => {});
+        }
+        await page.page.waitForTimeout(1000);
+        if (await locatorOwner.getByText('Connections', { exact: true }).isVisible().catch(() => false)
+            && await locatorOwner.getByText('Return', { exact: true }).isVisible().catch(() => false)) {
+            break;
+        }
+        const clickedId = await locatorOwner.locator('[data-testid]').evaluateAll((elements) => {
+            const isVisible = (element: Element) => {
+                const rect = element.getBoundingClientRect();
+                return rect.width > 0 && rect.height > 0;
+            };
+            const candidates = elements.filter((element) => {
+                const id = element.getAttribute('data-testid') || '';
+                return isVisible(element) && (id.startsWith('empty-node-add-button') || id.startsWith('link-add-button'));
+            });
+            const target = candidates.find((element) => (element.getAttribute('data-testid') || '').startsWith('empty-node-add-button')) || candidates[0];
+            if (!target) {
+                return '';
+            }
+            for (const type of ['pointerdown', 'mousedown', 'mouseup', 'click']) {
+                target.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true, view: window }));
+            }
+            return target.getAttribute('data-testid') || '';
+        });
+        await page.page.waitForTimeout(1000);
+        if (await locatorOwner.getByText('Connections', { exact: true }).isVisible().catch(() => false)
+            && await locatorOwner.getByText('Return', { exact: true }).isVisible().catch(() => false)) {
+            break;
+        }
+        if (attempt === 9) {
+            throw new Error(`Node panel did not open after clicking diagram add button "${clickedId}"`);
+        }
+    }
+    await expect(locatorOwner.getByText('Connections', { exact: true })).toBeVisible({ timeout: 30000 });
+    await expect(locatorOwner.getByText('Control', { exact: true })).toBeVisible({ timeout: 30000 });
+    await locatorOwner.getByText('Return', { exact: true }).click({ force: true });
+    await expect(locatorOwner.getByText('Return value.', { exact: true })).toBeVisible({ timeout: 30000 });
+    await locatorOwner.locator('[data-testid="ex-editor-expression"]').click({ force: true });
+    await locatorOwner.getByRole('button', { name: 'Open Helper Panel' }).click({ force: true });
+    await expect(locatorOwner.getByText('Inputs', { exact: true })).toBeVisible({ timeout: 30000 });
+    await locatorOwner.getByText('Inputs', { exact: true }).click({ force: true });
+    await expect(locatorOwner.getByText('payload', { exact: true })).toBeVisible({ timeout: 30000 });
+    await locatorOwner.getByText('payload', { exact: true }).click({ force: true });
+    await expect.poll(async () => locatorOwner.locator('[data-testid="ex-editor-expression"] .cm-content').evaluate((element) => element.textContent)).toBe('payload');
+    await locatorOwner.locator('[data-testid="ex-editor-expression"] .cm-content').click({ force: true });
+    await page.page.keyboard.press(process.platform === 'darwin' ? 'Meta+A' : 'Control+A');
+    await page.page.keyboard.type('{key: string `uploads/${name}`, size: payload.content.length()}');
+    await locatorOwner.getByRole('button', { name: 'Close Helper Panel' }).click({ force: true }).catch(() => {});
+    await locatorOwner.getByText('Return value.', { exact: true }).click({ force: true }).catch(() => {});
+    await locatorOwner.getByRole('button', { name: 'Save' }).click({ force: true });
+    await expect(locatorOwner.getByText(/uploads\/\\$\\{name\\}|uploads/).first()).toBeVisible({ timeout: 60000 });
+    await expect.poll(() => FileUtils.readProjectFile('main.bal')).toContain('return {key: string `uploads/${name}`, size: payload.content.length()};');
+}
+
+export default function createTests() {
+    test.describe.serial('HTTP Upload Tests', {}, async () => {
+        initTest();
+
+        test('HTTP Upload creates POST resource and verifies endpoint', async () => {
+            await addArtifact('HTTP Service', 'http-service-card');
+            const artifactWebView = await switchToIFrame(BI_INTEGRATOR_LABEL, page.page);
+            if (!artifactWebView) {
+                throw new Error(BI_WEBVIEW_NOT_FOUND_ERROR);
+            }
+
+            const form = new Form(page.page, BI_INTEGRATOR_LABEL, artifactWebView);
+            await form.switchToFormView(false, artifactWebView);
+            await form.fill({
+                values: {
+                    'Service Base Path*': {
+                        type: 'input',
+                        value: '/',
+                    },
+                },
+            });
+            await form.submit('Create');
+
+            await artifactWebView.getByRole('button', { name: /Add Resource/i }).first().click({ force: true });
+            await clickVisibleText(artifactWebView, 'POST');
+
+            const resourcePathInput = artifactWebView.getByRole('textbox', { name: /Resource Path/i }).or(
+                artifactWebView.locator('[data-testid="resource-path-input"]').or(
+                    artifactWebView.locator('input[placeholder*="path/foo"]')
+                )
+            );
+            await resourcePathInput.first().waitFor({ timeout: 10000 });
+            await resourcePathInput.first().fill('upload');
+            await clickVisibleText(artifactWebView, 'Save');
+
+            await artifactWebView.locator('[data-testid="bi-diagram-canvas"]').waitFor({ timeout: 30000 });
+            await expect(artifactWebView.getByText('upload', { exact: true }).first()).toBeVisible({ timeout: 30000 });
+
+            await configureUploadResourceIO(artifactWebView);
+            await addReturnNodeFromDiagram(artifactWebView);
+            await FileUtils.openProjectFileInEditor('main.bal');
+
+            await page.page.keyboard.press(process.platform === 'darwin' ? 'Meta+Shift+P' : 'Control+Shift+P');
+            await page.page.waitForTimeout(500);
+            await page.page.keyboard.type('Run Integration');
+            await page.page.keyboard.press('Enter');
+
+            const result = await waitForEndpoint('http://localhost:9090/upload?name=probe.txt', 120000);
+            expect([200, 201]).toContain(result.status);
+            expect(result.body).toContain('uploads/probe.txt');
+            expect(result.body).toContain('"size":5');
+        });
+    });
+}

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/api-integration/http-upload.spec.ts
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/api-integration/http-upload.spec.ts
@@ -86,7 +86,7 @@ async function addReturnNodeFromDiagram(locatorOwner: ReturnType<typeof switchTo
     logStep('Add Return node from diagram');
     for (let attempt = 0; attempt < 10; attempt++) {
         const addButton = locatorOwner.locator('[data-testid="empty-node-add-button-1"]').first();
-        if (await addButton.isVisible({ timeout: 1000 }).catch(() => false)) {
+        if (await addButton.waitFor({ state: 'visible', timeout: 1000 }).then(() => true, () => false)) {
             await addButton.hover({ force: true }).catch(() => {});
             await addButton.click({ force: true, timeout: 3000 }).catch(() => {});
         }
@@ -139,7 +139,7 @@ async function addReturnNodeFromDiagram(locatorOwner: ReturnType<typeof switchTo
     await locatorOwner.getByRole('button', { name: 'Close Helper Panel' }).click({ force: true }).catch(() => {});
     await locatorOwner.getByText('Return value.', { exact: true }).click({ force: true }).catch(() => {});
     await locatorOwner.getByRole('button', { name: 'Save' }).click({ force: true });
-    await expect(locatorOwner.getByText(/uploads\/\\$\\{name\\}|uploads/).first()).toBeVisible({ timeout: 60000 });
+    await expect(locatorOwner.getByText(/uploads\/\$\{name\}|uploads/).first()).toBeVisible({ timeout: 60000 });
     await expect.poll(() => FileUtils.readProjectFile('main.bal')).toContain('return {key: string `uploads/${name}`, size: payload.content.length()};');
 }
 

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/api-integration/http-upload.spec.ts
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/api-integration/http-upload.spec.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 import { expect, test } from '@playwright/test';
-import { addArtifact, BI_INTEGRATOR_LABEL, BI_WEBVIEW_NOT_FOUND_ERROR, initTest, page } from '../utils/helpers';
+import { addArtifact, BI_INTEGRATOR_LABEL, BI_WEBVIEW_NOT_FOUND_ERROR, initTest, logStep, page } from '../utils/helpers';
 import { switchToIFrame, Form } from '@wso2/playwright-vscode-tester';
 import { FileUtils } from '../utils/helpers/fileSystem';
 
@@ -59,6 +59,7 @@ async function clickButtonText(locatorOwner: ReturnType<typeof switchToIFrame> e
 }
 
 async function configureUploadResourceIO(locatorOwner: ReturnType<typeof switchToIFrame> extends Promise<infer T> ? NonNullable<T> : never) {
+    logStep('Configure upload resource query parameter and payload');
     await locatorOwner.getByRole('button', { name: /Configure/i }).click({ force: true });
     await expect(locatorOwner.getByText('Resource Configuration', { exact: true })).toBeVisible({ timeout: 30000 });
 
@@ -82,6 +83,7 @@ async function configureUploadResourceIO(locatorOwner: ReturnType<typeof switchT
 }
 
 async function addReturnNodeFromDiagram(locatorOwner: ReturnType<typeof switchToIFrame> extends Promise<infer T> ? NonNullable<T> : never) {
+    logStep('Add Return node from diagram');
     for (let attempt = 0; attempt < 10; attempt++) {
         const addButton = locatorOwner.locator('[data-testid="empty-node-add-button-1"]').first();
         if (await addButton.isVisible({ timeout: 1000 }).catch(() => false)) {
@@ -146,6 +148,7 @@ export default function createTests() {
         initTest();
 
         test('HTTP Upload creates POST resource and verifies endpoint', async () => {
+            logStep('Create HTTP Service artifact');
             await addArtifact('HTTP Service', 'http-service-card');
             const artifactWebView = await switchToIFrame(BI_INTEGRATOR_LABEL, page.page);
             if (!artifactWebView) {
@@ -164,6 +167,7 @@ export default function createTests() {
             });
             await form.submit('Create');
 
+            logStep('Add POST /upload resource');
             await artifactWebView.getByRole('button', { name: /Add Resource/i }).first().click({ force: true });
             await clickVisibleText(artifactWebView, 'POST');
 
@@ -181,6 +185,8 @@ export default function createTests() {
 
             await configureUploadResourceIO(artifactWebView);
             await addReturnNodeFromDiagram(artifactWebView);
+
+            logStep('Run integration');
             await FileUtils.openProjectFileInEditor('main.bal');
 
             await page.page.keyboard.press(process.platform === 'darwin' ? 'Meta+Shift+P' : 'Control+Shift+P');
@@ -188,6 +194,7 @@ export default function createTests() {
             await page.page.keyboard.type('Run Integration');
             await page.page.keyboard.press('Enter');
 
+            logStep('Verify upload endpoint response');
             const result = await waitForEndpoint('http://localhost:9090/upload?name=probe.txt', 120000);
             expect([200, 201]).toContain(result.status);
             expect(result.body).toContain('uploads/probe.txt');

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/api-integration/http-upload.spec.ts
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/api-integration/http-upload.spec.ts
@@ -189,10 +189,7 @@ export default function createTests() {
             logStep('Run integration');
             await FileUtils.openProjectFileInEditor('main.bal');
 
-            await page.page.keyboard.press(process.platform === 'darwin' ? 'Meta+Shift+P' : 'Control+Shift+P');
-            await page.page.waitForTimeout(500);
-            await page.page.keyboard.type('Run Integration');
-            await page.page.keyboard.press('Enter');
+            await page.executePaletteCommand('BI.project.run');
 
             logStep('Verify upload endpoint response');
             const result = await waitForEndpoint('http://localhost:9090/upload?name=probe.txt', 120000);

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/automation/flow-nodes.spec.ts
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/automation/flow-nodes.spec.ts
@@ -50,8 +50,15 @@ async function dismissHelperPanel() {
 async function saveForm(webview: Frame) {
     await dismissHelperPanel();
     await webview.getByRole('button', { name: 'Save' }).last().click({ force: true });
+    await webview.getByText(/Saving\.\.\./).waitFor({ state: 'hidden', timeout: 60000 }).catch(async (error) => {
+        const panelText = await webview.getByTestId('side-panel').innerText({ timeout: 1000 }).catch(() => '');
+        throw new Error(`Flow node form did not finish saving.\n${panelText}\n${error}`);
+    });
+    await webview.getByTestId('side-panel').waitFor({ state: 'hidden', timeout: 60000 }).catch(async (error) => {
+        const panelText = await webview.getByTestId('side-panel').innerText({ timeout: 1000 }).catch(() => '');
+        throw new Error(`Flow node form did not close after saving.\n${panelText}\n${error}`);
+    });
     await webview.locator('[data-testid="bi-diagram-canvas"]').waitFor({ state: 'visible', timeout: 60000 });
-    await webview.getByRole('button', { name: 'Save' }).waitFor({ state: 'hidden', timeout: 30000 }).catch(() => { });
     await page.page.waitForTimeout(1000);
 }
 
@@ -109,7 +116,7 @@ async function clickNextDiagramPlus(webview: Frame) {
 
         const candidates = elements.filter((element) => {
             const id = element.getAttribute('data-testid') || '';
-            return id.startsWith('link-add-button-') || id.startsWith('empty-node-add-button-');
+            return id.startsWith('link-add-button') || id.startsWith('empty-node-add-button');
         });
         const target = candidates.find((element) => (element.getAttribute('data-testid') || '').startsWith('empty-node-add-button'))
             || candidates[candidates.length - 2]

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/automation/flow-nodes.spec.ts
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/automation/flow-nodes.spec.ts
@@ -173,7 +173,7 @@ export default function createTests() {
                     'msg': {
                         type: 'cmEditor',
                         value: 'flow started',
-                        additionalProps: { switchMode: 'primary-mode', clickLabel: true, window: page.page }
+                        additionalProps: { switchMode: 'primary-mode', clickLabel: true, window: global.window }
                     }
                 }
             });
@@ -214,7 +214,7 @@ export default function createTests() {
                     'msg': {
                         type: 'cmEditor',
                         value: 'string `initial ${count} ${msg}`',
-                        additionalProps: { switchMode: 'primary-mode', clickLabel: true, window: page.page }
+                        additionalProps: { switchMode: 'primary-mode', clickLabel: true, window: global.window }
                     }
                 }
             });
@@ -246,7 +246,7 @@ export default function createTests() {
                     'msg': {
                         type: 'cmEditor',
                         value: 'sample error log',
-                        additionalProps: { switchMode: 'primary-mode', clickLabel: true, window: page.page }
+                        additionalProps: { switchMode: 'primary-mode', clickLabel: true, window: global.window }
                     }
                 }
             });
@@ -261,7 +261,7 @@ export default function createTests() {
                     'msg': {
                         type: 'cmEditor',
                         value: 'sample warn log',
-                        additionalProps: { switchMode: 'primary-mode', clickLabel: true, window: page.page }
+                        additionalProps: { switchMode: 'primary-mode', clickLabel: true, window: global.window }
                     }
                 }
             });

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/automation/flow-nodes.spec.ts
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/automation/flow-nodes.spec.ts
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { expect, test, Frame } from '@playwright/test';
+import { addArtifact, BI_INTEGRATOR_LABEL, BI_WEBVIEW_NOT_FOUND_ERROR, initTest, page } from '../utils/helpers';
+import { Form, switchToIFrame } from '@wso2/playwright-vscode-tester';
+import { Diagram, SidePanel } from '../utils/pages';
+import { FileUtils } from '../utils/helpers/fileSystem';
+
+const EXPECTED_SOURCE = [
+    'int count = 1',
+    'string msg = "started"',
+    'log:printInfo',
+    'log:printDebug',
+    'if count > 10',
+    'else',
+];
+
+function expectSourceFragments(source: string) {
+    const missing = EXPECTED_SOURCE.filter((expected) => !source.includes(expected));
+    expect(missing, `Missing source fragments:\n${missing.join('\n')}`).toEqual([]);
+}
+
+async function dismissHelperPanel() {
+    await page.page.keyboard.press('Escape');
+    await page.page.waitForTimeout(300);
+    await page.page.keyboard.press('Escape');
+    await page.page.waitForTimeout(300);
+}
+
+async function saveForm(webview: Frame) {
+    await dismissHelperPanel();
+    await webview.getByRole('button', { name: 'Save' }).last().click({ force: true });
+    await webview.locator('[data-testid="bi-diagram-canvas"]').waitFor({ state: 'visible', timeout: 60000 });
+    await page.page.waitForTimeout(1000);
+}
+
+export default function createTests() {
+    test.describe.serial('Automation Flow Nodes Tests', {}, async () => {
+        initTest();
+
+        test('Flow Nodes builds Statement and Control nodes from diagram', async () => {
+            await addArtifact('Automation', 'automation');
+
+            const artifactWebView = await switchToIFrame(BI_INTEGRATOR_LABEL, page.page, 30000);
+            if (!artifactWebView) {
+                throw new Error(BI_WEBVIEW_NOT_FOUND_ERROR);
+            }
+
+            await artifactWebView.getByRole('heading', { name: /Create New Automation/i }).waitFor({ timeout: 10000 });
+            await artifactWebView.getByRole('button', { name: 'Create' }).click();
+            await artifactWebView.locator('[data-testid="bi-diagram-canvas"]').waitFor({ state: 'visible', timeout: 30000 });
+
+            const diagram = new Diagram(page.page);
+            await diagram.init();
+            const sidePanel = new SidePanel(artifactWebView, page.page);
+            const form = new Form(page.page, BI_INTEGRATOR_LABEL, artifactWebView);
+
+            await diagram.clickAddButtonByIndex(1);
+            await sidePanel.init();
+            await sidePanel.expandSection('Logging');
+            await sidePanel.clickNode('Log Info');
+            await form.switchToFormView(false, artifactWebView);
+            await form.fill({
+                values: {
+                    'msg': {
+                        type: 'cmEditor',
+                        value: 'flow started',
+                        additionalProps: { switchMode: 'primary-mode', clickLabel: true, window: page.page }
+                    }
+                }
+            });
+            await saveForm(artifactWebView);
+
+            await diagram.clickHoverAddButtonByIndex(1);
+            await sidePanel.init();
+            await sidePanel.clickNode('Declare Variable');
+            await form.switchToFormView(false, artifactWebView);
+            await form.fill({
+                values: {
+                    'Name*Name of the variable': { type: 'input', value: 'count' },
+                    'Type': { type: 'textarea', value: 'int', additionalProps: { clickLabel: true } },
+                    'expression': { type: 'cmEditor', value: '1', additionalProps: { clickLabel: true } }
+                }
+            });
+            await saveForm(artifactWebView);
+
+            await diagram.clickHoverAddButtonByIndex(2);
+            await sidePanel.init();
+            await sidePanel.clickNode('Declare Variable');
+            await form.switchToFormView(false, artifactWebView);
+            await form.fill({
+                values: {
+                    'Name*Name of the variable': { type: 'input', value: 'msg' },
+                    'Type': { type: 'textarea', value: 'string', additionalProps: { clickLabel: true } },
+                    'expression': { type: 'cmEditor', value: '"started"', additionalProps: { clickLabel: true } }
+                }
+            });
+            await saveForm(artifactWebView);
+
+            await diagram.clickHoverAddButtonByIndex(3);
+            await sidePanel.init();
+            await sidePanel.expandSection('Logging');
+            await sidePanel.clickNode('Log Debug');
+            await form.switchToFormView(false, artifactWebView);
+            await form.fill({
+                values: {
+                    'msg': {
+                        type: 'cmEditor',
+                        value: 'string `initial ${count} ${msg}`',
+                        additionalProps: { switchMode: 'primary-mode', clickLabel: true, window: page.page }
+                    }
+                }
+            });
+            await saveForm(artifactWebView);
+
+            await diagram.clickHoverAddButtonByIndex(4);
+            await sidePanel.init();
+            await sidePanel.expandSection('Control');
+            await sidePanel.clickNode('If');
+            await form.switchToFormView(false, artifactWebView);
+            await form.fill({
+                values: {
+                    'branch-0': { type: 'cmEditor', value: 'count > 10', additionalProps: { clickLabel: true } }
+                }
+            });
+            await artifactWebView.getByText('Add Else Block', { exact: true }).click({ force: true });
+            await saveForm(artifactWebView);
+
+            expectSourceFragments(FileUtils.readProjectFile('automation.bal'));
+        });
+    });
+}

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/automation/flow-nodes.spec.ts
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/automation/flow-nodes.spec.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 import { expect, test, Frame } from '@playwright/test';
-import { addArtifact, BI_INTEGRATOR_LABEL, BI_WEBVIEW_NOT_FOUND_ERROR, initTest, page } from '../utils/helpers';
+import { addArtifact, BI_INTEGRATOR_LABEL, BI_WEBVIEW_NOT_FOUND_ERROR, initTest, logStep, page } from '../utils/helpers';
 import { Form, switchToIFrame } from '@wso2/playwright-vscode-tester';
 import { Diagram, SidePanel } from '../utils/pages';
 import { FileUtils } from '../utils/helpers/fileSystem';
@@ -28,6 +28,11 @@ const EXPECTED_SOURCE = [
     'log:printDebug',
     'if count > 10',
     'else',
+    'match count',
+    '1 =>',
+    'log:printError("sample error log")',
+    'log:printWarn("sample warn log")',
+    'while count < 3',
 ];
 
 function expectSourceFragments(source: string) {
@@ -46,7 +51,85 @@ async function saveForm(webview: Frame) {
     await dismissHelperPanel();
     await webview.getByRole('button', { name: 'Save' }).last().click({ force: true });
     await webview.locator('[data-testid="bi-diagram-canvas"]').waitFor({ state: 'visible', timeout: 60000 });
+    await webview.getByRole('button', { name: 'Save' }).waitFor({ state: 'hidden', timeout: 30000 }).catch(() => { });
     await page.page.waitForTimeout(1000);
+}
+
+async function selectNode(sidePanel: SidePanel, nodeTitle: string, sectionTitle?: string) {
+    await sidePanel.init();
+    if (sectionTitle) {
+        await sidePanel.expandSection(sectionTitle);
+    }
+    await sidePanel.clickNode(nodeTitle);
+}
+
+async function fillFirstCodeMirror(webview: Frame, value: string) {
+    await fillCodeMirror(webview, value, 0);
+}
+
+async function fillCodeMirror(webview: Frame, value: string, index: number) {
+    await webview.evaluate(({ text, editorIndex }) => {
+        const panel = document.querySelector('[data-testid="side-panel"]');
+        const editors = [...(panel || document).querySelectorAll('.cm-content')] as Array<HTMLElement & { cmView?: { view?: any } }>;
+        const visibleEditors = editors.filter((editor) => {
+            const rect = editor.getBoundingClientRect();
+            return rect.width > 0 && rect.height > 0;
+        });
+        const editor = visibleEditors[editorIndex];
+        const view = editor?.cmView?.view;
+        if (!view) {
+            throw new Error('CodeMirror editor not found');
+        }
+        view.focus();
+        view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: text } });
+    }, { text: value, editorIndex: index });
+}
+
+async function clickLinkButtonText(webview: Frame, text: string) {
+    const linkText = webview.getByText(text, { exact: true }).first();
+    await linkText.waitFor({ state: 'visible', timeout: 10000 });
+    await linkText.evaluate((element) => {
+        const clickable = element.closest('button, vscode-button, a, [role="button"]') || element;
+        clickable.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
+    });
+}
+
+async function clickNextDiagramPlus(webview: Frame) {
+    await webview.locator('[data-testid="bi-diagram-canvas"]').waitFor({ state: 'visible', timeout: 30000 });
+    const clickedId = await webview.locator('[data-testid]').evaluateAll((elements) => {
+        const links = elements.filter((element) => {
+            const id = element.getAttribute('data-testid') || '';
+            return id.startsWith('diagram-link-');
+        });
+        for (const link of links) {
+            for (const type of ['pointerover', 'mouseover', 'mouseenter', 'pointerenter']) {
+                link.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true, view: window }));
+            }
+        }
+
+        const candidates = elements.filter((element) => {
+            const id = element.getAttribute('data-testid') || '';
+            return id.startsWith('link-add-button-') || id.startsWith('empty-node-add-button-');
+        });
+        const target = candidates.find((element) => (element.getAttribute('data-testid') || '').startsWith('empty-node-add-button'))
+            || candidates[candidates.length - 2]
+            || candidates[candidates.length - 1];
+        if (!target) {
+            return '';
+        }
+        for (const type of ['pointerover', 'mouseover', 'mouseenter', 'pointerenter']) {
+            target.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true, view: window }));
+        }
+        for (const type of ['pointerdown', 'mousedown', 'mouseup', 'click']) {
+            target.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true, view: window }));
+        }
+        return target.getAttribute('data-testid') || '';
+    });
+
+    await webview.getByTestId('side-panel').waitFor({ state: 'visible', timeout: 30000 });
+    if (!clickedId) {
+        throw new Error('No diagram add button was available');
+    }
 }
 
 export default function createTests() {
@@ -54,6 +137,7 @@ export default function createTests() {
         initTest();
 
         test('Flow Nodes builds Statement and Control nodes from diagram', async () => {
+            logStep('Create Automation artifact');
             await addArtifact('Automation', 'automation');
 
             const artifactWebView = await switchToIFrame(BI_INTEGRATOR_LABEL, page.page, 30000);
@@ -70,10 +154,9 @@ export default function createTests() {
             const sidePanel = new SidePanel(artifactWebView, page.page);
             const form = new Form(page.page, BI_INTEGRATOR_LABEL, artifactWebView);
 
+            logStep('Add Log Info node');
             await diagram.clickAddButtonByIndex(1);
-            await sidePanel.init();
-            await sidePanel.expandSection('Logging');
-            await sidePanel.clickNode('Log Info');
+            await selectNode(sidePanel, 'Log Info', 'Logging');
             await form.switchToFormView(false, artifactWebView);
             await form.fill({
                 values: {
@@ -86,9 +169,9 @@ export default function createTests() {
             });
             await saveForm(artifactWebView);
 
+            logStep('Add int count Declare Variable node');
             await diagram.clickHoverAddButtonByIndex(1);
-            await sidePanel.init();
-            await sidePanel.clickNode('Declare Variable');
+            await selectNode(sidePanel, 'Declare Variable');
             await form.switchToFormView(false, artifactWebView);
             await form.fill({
                 values: {
@@ -99,9 +182,9 @@ export default function createTests() {
             });
             await saveForm(artifactWebView);
 
+            logStep('Add string msg Declare Variable node');
             await diagram.clickHoverAddButtonByIndex(2);
-            await sidePanel.init();
-            await sidePanel.clickNode('Declare Variable');
+            await selectNode(sidePanel, 'Declare Variable');
             await form.switchToFormView(false, artifactWebView);
             await form.fill({
                 values: {
@@ -112,10 +195,9 @@ export default function createTests() {
             });
             await saveForm(artifactWebView);
 
+            logStep('Add Log Debug node');
             await diagram.clickHoverAddButtonByIndex(3);
-            await sidePanel.init();
-            await sidePanel.expandSection('Logging');
-            await sidePanel.clickNode('Log Debug');
+            await selectNode(sidePanel, 'Log Debug', 'Logging');
             await form.switchToFormView(false, artifactWebView);
             await form.fill({
                 values: {
@@ -128,19 +210,61 @@ export default function createTests() {
             });
             await saveForm(artifactWebView);
 
+            logStep('Add If node with Else block');
             await diagram.clickHoverAddButtonByIndex(4);
-            await sidePanel.init();
-            await sidePanel.expandSection('Control');
-            await sidePanel.clickNode('If');
+            await selectNode(sidePanel, 'If', 'Control');
+            await form.switchToFormView(false, artifactWebView);
+            await fillFirstCodeMirror(artifactWebView, 'count > 10');
+            await clickLinkButtonText(artifactWebView, 'Add Else Block');
+            await artifactWebView.getByText('Remove Else Block', { exact: true }).waitFor({ state: 'visible', timeout: 10000 });
+            await saveForm(artifactWebView);
+
+            logStep('Add Match node');
+            await clickNextDiagramPlus(artifactWebView);
+            await selectNode(sidePanel, 'Match', 'Control');
+            await form.switchToFormView(false, artifactWebView);
+            await fillCodeMirror(artifactWebView, 'count', 0);
+            await fillCodeMirror(artifactWebView, '1', 1);
+            await saveForm(artifactWebView);
+
+            logStep('Add Log Error node');
+            await clickNextDiagramPlus(artifactWebView);
+            await selectNode(sidePanel, 'Log Error', 'Logging');
             await form.switchToFormView(false, artifactWebView);
             await form.fill({
                 values: {
-                    'branch-0': { type: 'cmEditor', value: 'count > 10', additionalProps: { clickLabel: true } }
+                    'msg': {
+                        type: 'cmEditor',
+                        value: 'sample error log',
+                        additionalProps: { switchMode: 'primary-mode', clickLabel: true, window: page.page }
+                    }
                 }
             });
-            await artifactWebView.getByText('Add Else Block', { exact: true }).click({ force: true });
             await saveForm(artifactWebView);
 
+            logStep('Add Log Warn node');
+            await clickNextDiagramPlus(artifactWebView);
+            await selectNode(sidePanel, 'Log Warn', 'Logging');
+            await form.switchToFormView(false, artifactWebView);
+            await form.fill({
+                values: {
+                    'msg': {
+                        type: 'cmEditor',
+                        value: 'sample warn log',
+                        additionalProps: { switchMode: 'primary-mode', clickLabel: true, window: page.page }
+                    }
+                }
+            });
+            await saveForm(artifactWebView);
+
+            logStep('Add While node');
+            await clickNextDiagramPlus(artifactWebView);
+            await selectNode(sidePanel, 'While', 'Control');
+            await form.switchToFormView(false, artifactWebView);
+            await fillFirstCodeMirror(artifactWebView, 'count < 3');
+            await saveForm(artifactWebView);
+
+            logStep('Verify generated automation.bal source');
             expectSourceFragments(FileUtils.readProjectFile('automation.bal'));
         });
     });

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/automation/flow-nodes.spec.ts
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/automation/flow-nodes.spec.ts
@@ -101,6 +101,9 @@ async function clickLinkButtonText(webview: Frame, text: string) {
     });
 }
 
+// Add buttons only appear on hover and are not stable Playwright targets; synthetic
+// mouse events via evaluateAll are used because standard hover()+click() does not
+// reliably trigger the diagram's React event handlers for these SVG overlay nodes.
 async function clickNextDiagramPlus(webview: Frame) {
     await webview.locator('[data-testid="bi-diagram-canvas"]').waitFor({ state: 'visible', timeout: 30000 });
     const clickedId = await webview.locator('[data-testid]').evaluateAll((elements) => {

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/test.list.ts
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/test.list.ts
@@ -40,6 +40,7 @@ async function withTimeout<T>(operation: Promise<T>, timeoutMs: number, timeoutM
 }
 
 import automation from './automation/automation.spec';
+import automationFlowNodes from './automation/flow-nodes.spec';
 import automationRun from './automation-run/automation-run.spec';
 import automationDebug from './automation-debug/automation-debug.spec';
 import expressionEditor from './expression-editor/expression-editor.spec';
@@ -110,6 +111,7 @@ test.describe('Ballerina E2E Group 1', { tag: '@group1' }, async () => {
 
     // <----Automation Test---->
     test.describe(automation);
+    test.describe(automationFlowNodes);
 
     // <----Automation Run Test---->
     test.describe(automationRun);

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/test.list.ts
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/test.list.ts
@@ -45,6 +45,7 @@ import automationDebug from './automation-debug/automation-debug.spec';
 import expressionEditor from './expression-editor/expression-editor.spec';
 
 import httpService from './api-integration/http-service.spec';
+import httpUpload from './api-integration/http-upload.spec';
 import aiChatService from './api-integration/ai-chat-service.spec';
 import graphqlService from './api-integration/graphql-service.spec';
 import tcpService from './api-integration/tcp-service.spec';
@@ -118,6 +119,7 @@ test.describe('Ballerina E2E Group 1', { tag: '@group1' }, async () => {
 
     // <----Integration as API Test---->
     test.describe(httpService);
+    test.describe(httpUpload);
 
     // <----Event Integration Test---->
     test.describe(kafkaIntegration);

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/utils/helpers/fileSystem.ts
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/utils/helpers/fileSystem.ts
@@ -29,6 +29,10 @@ export namespace FileUtils {
         fs.writeFileSync(filePath, content);
     }
 
+    export function readProjectFile(fileName: FileType) {
+        return fs.readFileSync(path.join(newProjectPath, fileName), 'utf8');
+    }
+
     /**
      * Opens a project file in the VS Code editor via Quick Open.
      * This triggers `textDocument/didOpen` to the language server,

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/utils/helpers/index.ts
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/utils/helpers/index.ts
@@ -42,5 +42,8 @@ export { addArtifact, enableICP } from './artifacts';
 // Re-export from verification
 export { verifyGeneratedSource } from './verification';
 
+// Re-export from progress
+export { logStep } from './progress';
+
 // Re-export constants
 export { BI_INTEGRATOR_LABEL, BI_WEBVIEW_NOT_FOUND_ERROR, DEFAULT_PROJECT_NAME, DEFAULT_PROJECT_FOLDER_NAME, BI_SIDEBAR_VIEW_ID } from './constants';

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/utils/helpers/progress.ts
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/utils/helpers/progress.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export function logStep(step: string) {
+    console.log(`  ➜ ${step}`);
+}

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/utils/helpers/setup.ts
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/utils/helpers/setup.ts
@@ -156,8 +156,8 @@ function getVsCodeProfileName(): string {
 }
 
 function resolveBallerinaVsixPath(): string {
-    const searchFolders = [extensionsFolder, repoRootExtensionsFolder].filter((folder) => fs.existsSync(folder));
-    const findVsixFiles = () => searchFolders.flatMap((folder) => fs.readdirSync(folder)
+    const candidateFolders = [extensionsFolder, repoRootExtensionsFolder];
+    const findVsixFiles = () => candidateFolders.filter((folder) => fs.existsSync(folder)).flatMap((folder) => fs.readdirSync(folder)
         .filter((file) => /^ballerina-.*\.vsix$/i.test(file) && !/^ballerina-integrator-/i.test(file))
         .map((file) => ({
             file,
@@ -178,7 +178,7 @@ function resolveBallerinaVsixPath(): string {
     }
 
     if (ballerinaVsixFiles.length === 0) {
-        throw new Error(`No local Ballerina VSIX found in: ${searchFolders.join(', ')} after running "rush build -t ballerina".`);
+        throw new Error(`No local Ballerina VSIX found in: ${candidateFolders.join(', ')} after running "rush build -t ballerina".`);
     }
 
     return ballerinaVsixFiles[0].fullPath;

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/utils/helpers/setup.ts
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/utils/helpers/setup.ts
@@ -31,6 +31,7 @@ export const dataFolder = path.join(__dirname, '..', '..', '..', 'data');
 /** Template package committed with tests (minimal Ballerina project to copy). */
 const emptyProjectPath = path.join(__dirname, '..', '..', 'data', 'empty_project');
 export const extensionsFolder = path.join(__dirname, '..', '..', '..', '..', 'vsix');
+const repoRootExtensionsFolder = path.join(__dirname, '..', '..', '..', '..', '..', '..', '..');
 const vscodeVersion = 'latest';
 const baseVsCodeProfileName = process.env.BI_E2E_PROFILE_NAME ?? `bi-test-profile-${process.pid}`;
 let vscodeLaunchAttempt = 0;
@@ -155,17 +156,29 @@ function getVsCodeProfileName(): string {
 }
 
 function resolveBallerinaVsixPath(): string {
-    const ballerinaVsixFiles = fs.readdirSync(extensionsFolder)
-        .filter((file) => /^ballerina-.*\.vsix$/i.test(file))
+    const searchFolders = [extensionsFolder, repoRootExtensionsFolder].filter((folder) => fs.existsSync(folder));
+    const findVsixFiles = () => searchFolders.flatMap((folder) => fs.readdirSync(folder)
+        .filter((file) => /^ballerina-.*\.vsix$/i.test(file) && !/^ballerina-integrator-/i.test(file))
         .map((file) => ({
             file,
-            fullPath: path.join(extensionsFolder, file),
-            mtime: fs.statSync(path.join(extensionsFolder, file)).mtimeMs,
-        }))
+            fullPath: path.join(folder, file),
+            mtime: fs.statSync(path.join(folder, file)).mtimeMs,
+        })))
         .sort((a, b) => b.mtime - a.mtime);
 
+    let ballerinaVsixFiles = findVsixFiles();
     if (ballerinaVsixFiles.length === 0) {
-        throw new Error(`No ballerina VSIX found in: ${extensionsFolder}`);
+        console.log('No local Ballerina VSIX found; running "rush build -t ballerina"');
+        execSync('rush build -t ballerina', {
+            cwd: repoRootExtensionsFolder,
+            stdio: 'inherit',
+            timeout: 60 * 60 * 1000,
+        });
+        ballerinaVsixFiles = findVsixFiles();
+    }
+
+    if (ballerinaVsixFiles.length === 0) {
+        throw new Error(`No local Ballerina VSIX found in: ${searchFolders.join(', ')} after running "rush build -t ballerina".`);
     }
 
     return ballerinaVsixFiles[0].fullPath;

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/utils/pages/SidePanel.ts
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/utils/pages/SidePanel.ts
@@ -37,10 +37,12 @@ export class SidePanel {
      * @param nodeTitle - Title of the node to click. This can be found via the title attribute of the node.
      */
     public async clickNode(nodeTitle: string): Promise<void> {
+        const isVisibleWithin = (locator: Locator, timeout: number) =>
+            locator.waitFor({ state: 'visible', timeout }).then(() => true, () => false);
         let nodeContainer = this.getLocator().getByText(nodeTitle, { exact: true }).last();
-        if (!await nodeContainer.isVisible({ timeout: 3000 }).catch(() => false)) {
+        if (!await isVisibleWithin(nodeContainer, 3000)) {
             const search = this.getLocator().locator('input[placeholder*="Search"], input[type="text"]').first();
-            if (await search.isVisible({ timeout: 5000 }).catch(() => false)) {
+            if (await isVisibleWithin(search, 5000)) {
                 await search.fill(nodeTitle);
                 await this._page.waitForTimeout(1200);
                 nodeContainer = this.getLocator().getByText(nodeTitle, { exact: true }).last();

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/utils/pages/SidePanel.ts
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/utils/pages/SidePanel.ts
@@ -37,7 +37,16 @@ export class SidePanel {
      * @param nodeTitle - Title of the node to click. This can be found via the title attribute of the node.
      */
     public async clickNode(nodeTitle: string): Promise<void> {
-        const nodeContainer = this.getLocator().getByText(nodeTitle, { exact: true });
+        let nodeContainer = this.getLocator().getByText(nodeTitle, { exact: true }).last();
+        if (!await nodeContainer.isVisible({ timeout: 3000 }).catch(() => false)) {
+            const search = this.getLocator().locator('input[placeholder*="Search"], input[type="text"]').first();
+            if (await search.isVisible({ timeout: 5000 }).catch(() => false)) {
+                await search.fill(nodeTitle);
+                await this._page.waitForTimeout(1200);
+                nodeContainer = this.getLocator().getByText(nodeTitle, { exact: true }).last();
+            }
+        }
+        await nodeContainer.waitFor({ state: 'visible', timeout: 30000 });
         await nodeContainer.click();
     }
 

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/FlowDiagram/index.tsx
@@ -2882,7 +2882,7 @@ export function BIFlowDiagram(props: BIFlowDiagramProps) {
             breakpointInfo,
             readOnly: showProgressSpinner || showProgressIndicator || hasDraft || selectedNodeId !== undefined,
             overlay: {
-                visible: selectedNodeId !== undefined,
+                visible: selectedNodeId !== undefined || hasDraft,
                 onClickOverlay: handleOnCloseSidePanel,
             },
             isUserAuthenticated,

--- a/workspaces/ballerina/bi-diagram/src/components/Diagram.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/Diagram.tsx
@@ -19,7 +19,7 @@
 import React, { useState, useEffect, memo } from "react";
 import { DiagramEngine, DiagramModel } from "@projectstorm/react-diagrams";
 import { cloneDeep } from "lodash";
-import { NavigationWrapperCanvasWidget } from "@wso2/ui-toolkit";
+import { NavigationWrapperCanvasWidget } from "./DiagramNavigationWrapper/NavigationWrapperCanvasWidget";
 
 import {
     clearDiagramZoomAndPosition,
@@ -355,6 +355,12 @@ export function Diagram(props: DiagramProps) {
         return node;
     };
 
+    const getDraftNode = (nodes: NodeModel[]): NodeModel | undefined =>
+        nodes.find((node) => node.getType() === NodeTypes.DRAFT_NODE);
+
+    const getFocusedNode = (nodes: NodeModel[]): NodeModel | undefined =>
+        getActiveBreakpointNode(nodes) || getDraftNode(nodes);
+
     return (
         <>
             <Controls engine={diagramEngine} />
@@ -364,7 +370,7 @@ export function Diagram(props: DiagramProps) {
                     <DiagramCanvas>
                         <NavigationWrapperCanvasWidget
                             diagramEngine={diagramEngine}
-                            focusedNode={getActiveBreakpointNode(diagramModel.getNodes() as NodeModel[])}
+                            focusedNode={getFocusedNode(diagramModel.getNodes() as NodeModel[])}
                         />
                     </DiagramCanvas>
                 </DiagramContextProvider>

--- a/workspaces/ballerina/bi-diagram/src/components/DiagramNavigationWrapper/NavigationWrapperCanvasWidget.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/DiagramNavigationWrapper/NavigationWrapperCanvasWidget.tsx
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React, { useEffect } from "react";
+import { flushSync } from "react-dom";
+
+import { DiagramEngine, NodeModel } from "@projectstorm/react-diagrams";
+import { CustomCanvasWidget } from "@wso2/ui-toolkit";
+
+interface NavigationWrapperCanvasProps {
+    diagramEngine: DiagramEngine;
+    className?: string;
+    focusedNode?: NodeModel;
+    disableZoom?: boolean;
+    disableMouseEvents?: boolean;
+    overflow?: string;
+    cursor?: string;
+}
+
+export function NavigationWrapperCanvasWidget(props: NavigationWrapperCanvasProps) {
+    const { diagramEngine, focusedNode, className } = props;
+    const focusedNodeId = focusedNode?.getID();
+
+    useEffect(() => {
+        if (!focusedNode) {
+            return;
+        }
+        const raf = requestAnimationFrame(() => {
+            focusToNode(focusedNode, diagramEngine.getModel().getZoomLevel(), diagramEngine);
+        });
+        return () => cancelAnimationFrame(raf);
+        // Only re-focus when the focused node's identity actually changes.
+        // The node object is recreated on every diagram redraw; using its id
+        // keeps a single animation per logical focus change.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [diagramEngine, focusedNodeId]);
+
+    return (
+        <CustomCanvasWidget
+            engine={diagramEngine as any}
+            className={className}
+            disableZoom={props.disableZoom}
+            disableMouseEvents={props.disableMouseEvents}
+            overflow={props.overflow}
+            cursor={props.cursor}
+        />
+    );
+}
+
+const FOCUS_DURATION_MS = 350;
+
+function focusToNode(node: NodeModel, currentZoomLevel: number, diagramEngine: DiagramEngine) {
+    const canvas = diagramEngine?.getCanvas() as HTMLElement | undefined;
+    const canvasBounds = canvas?.getBoundingClientRect();
+    const nodeBounds = node?.getBoundingBox();
+    if (!canvas || !canvasBounds || !nodeBounds) {
+        return;
+    }
+
+    const model = diagramEngine.getModel();
+    const zoomOffset = currentZoomLevel / 100;
+    const targetX = canvasBounds.width / 2 - (nodeBounds.getTopLeft().x + nodeBounds.getWidth() / 2) * zoomOffset;
+    const targetY = canvasBounds.height / 2 - (nodeBounds.getTopLeft().y + nodeBounds.getHeight() / 2) * zoomOffset;
+
+    const startX = model.getOffsetX();
+    const startY = model.getOffsetY();
+    const deltaX = targetX - startX;
+    const deltaY = targetY - startY;
+    if (Math.abs(deltaX) < 1 && Math.abs(deltaY) < 1) {
+        return;
+    }
+
+    // GPU-accelerated CSS pan: translate the canvas root, then reconcile model
+    // offset once when the transition ends. This avoids per-frame
+    // repaintCanvas() calls (which re-route links and desync nodes vs. links).
+    canvas.style.transition = "none";
+    canvas.style.transform = "translate(0px, 0px)";
+    // Force the browser to commit the reset before applying the transition.
+    void canvas.offsetWidth;
+    canvas.style.transition = `transform ${FOCUS_DURATION_MS}ms ease-in-out`;
+    canvas.style.transform = `translate(${deltaX}px, ${deltaY}px)`;
+
+    const finalize = () => {
+        canvas.removeEventListener("transitionend", finalize);
+        clearTimeout(fallback);
+        // Reset CustomCanvasWidget's `isMouseClicked` flag so the inner
+        // transform layer does NOT add `transition: transform 0.5s` when we
+        // commit the new model offset.
+        canvas.dispatchEvent(new MouseEvent("mousemove", { bubbles: true }));
+        // flushSync forces React to commit the inner-layer transform update
+        // synchronously, BEFORE we reset the outer translate. Without this,
+        // React 18 batches the repaint until after this task ends, so the
+        // browser paints one frame with outer=0 + inner=start (snap back to
+        // origin) before the inner offset commits.
+        flushSync(() => {
+            model.setOffset(targetX, targetY);
+            diagramEngine.repaintCanvas();
+        });
+        canvas.style.transition = "none";
+        canvas.style.transform = "translate(0px, 0px)";
+    };
+    canvas.addEventListener("transitionend", finalize, { once: true });
+    // Fallback in case `transitionend` is missed (tab backgrounded etc.).
+    const fallback = setTimeout(finalize, FOCUS_DURATION_MS + 100);
+}

--- a/workspaces/common-libs/playwright-vscode-tester/src/components/Form.ts
+++ b/workspaces/common-libs/playwright-vscode-tester/src/components/Form.ts
@@ -214,10 +214,24 @@ export class Form {
 
                             cmEditor = containerDiv.locator('.cm-editor');
                             await cmEditor.waitFor();
-                            const editorInput = cmEditor.locator('div[contenteditable="true"]');
-                            await editorInput.waitFor();
-                            await editorInput.click({ clickCount: 3 }); // Focus and select for replacement
-                            await editorInput.fill(data.value);
+                            // Use view.dispatch to update CodeMirror state directly — Playwright's
+                            // fill() on contenteditable doesn't reliably trigger CM6's onChange handler.
+                            const dispatched = await containerDiv.evaluate((container, text) => {
+                                const cmContent = container.querySelector('.cm-content');
+                                if (!cmContent) return false;
+                                const view = (cmContent as any).cmView?.view;
+                                if (!view) return false;
+                                view.focus();
+                                view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: text } });
+                                return true;
+                            }, data.value);
+                            if (!dispatched) {
+                                // Fallback: direct DOM fill if view reference is unavailable
+                                const editorInput = cmEditor.locator('div[contenteditable="true"]');
+                                await editorInput.waitFor();
+                                await editorInput.click({ clickCount: 3 });
+                                await editorInput.fill(data.value);
+                            }
                         }
                         break;
                     }

--- a/workspaces/common-libs/playwright-vscode-tester/src/components/Form.ts
+++ b/workspaces/common-libs/playwright-vscode-tester/src/components/Form.ts
@@ -216,15 +216,20 @@ export class Form {
                             await cmEditor.waitFor();
                             // Use view.dispatch to update CodeMirror state directly — Playwright's
                             // fill() on contenteditable doesn't reliably trigger CM6's onChange handler.
-                            const dispatched = await containerDiv.evaluate((container, text) => {
-                                const cmContent = container.querySelector('.cm-content');
-                                if (!cmContent) return false;
-                                const view = (cmContent as any).cmView?.view;
-                                if (!view) return false;
-                                view.focus();
-                                view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: text } });
-                                return true;
-                            }, data.value);
+                            let dispatched = false;
+                            try {
+                                dispatched = await containerDiv.evaluate((container, text) => {
+                                    const cmContent = container.querySelector('.cm-content');
+                                    if (!cmContent) return false;
+                                    const view = (cmContent as any).cmView?.view;
+                                    if (!view) return false;
+                                    view.focus();
+                                    view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: text } });
+                                    return true;
+                                }, data.value);
+                            } catch (e) {
+                                console.warn('cmEditor view.dispatch failed, falling back to DOM fill:', e);
+                            }
                             if (!dispatched) {
                                 // Fallback: direct DOM fill if view reference is unavailable
                                 const editorInput = cmEditor.locator('div[contenteditable="true"]');

--- a/workspaces/common-libs/ui-toolkit/src/index.ts
+++ b/workspaces/common-libs/ui-toolkit/src/index.ts
@@ -16,6 +16,7 @@
  * under the License.
  */
 export * from './components/DiagramNavigationWrapper/NavigationWrapperCanvasWidget';
+export * from './components/DiagramNavigationWrapper/CustomCanvasWidget';
 export * from './components/AutoComplete/AutoComplete';
 export * from './components/ProgressIndicator/ProgressIndicator';
 export { Stepper } from './components/Stepper/Stepper';


### PR DESCRIPTION
## Summary

Adds `ballerina-e2e-writer`, an agent-facing skill and authoring harness for creating Ballerina extension E2E tests more easily.

The harness lets an AI agent iterate through a VS Code user flow with the same `@wso2/playwright-vscode-tester` launch path used by the committed Playwright suite, then promote the proven flow into the normal `e2e-playwright-tests` tests.

## Changes

- Adds `.agents/skills/ballerina-e2e-writer/SKILL.md` for future agents authoring Ballerina extension E2E coverage.
- Adds `.agents/skills/ballerina-e2e-writer/USER_GUIDE.md` with the user flow and prompt samples for requesting new E2E tests.
- Adds an `e2e-authoring` daemon, prelude helpers, and step runner for scenario discovery/debugging.
- Adds a pilot HTTP upload scenario and promotes it into the Playwright E2E suite.
- Reuses the existing local Ballerina VSIX setup and WSO2 Integrator prerequisite install behavior.
- Keeps selector guidance focused on `data-testid`, stable roles, and stable accessible names instead of generated Emotion class names.

## Verification

- `pnpm run test-compile`
- `bash e2e-test/e2e-authoring/scripts/run-steps.sh http-upload e2e-test/e2e-authoring/scenarios/http-upload/steps`
- `npm run e2e-test -- --grep "HTTP Upload"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live IDE-backed E2E authoring daemon and step runner for authoring/promoting tests
  * New automated E2E suites for flow-node authoring and HTTP upload integration
  * Smooth diagram navigation with focused-node centering and improved canvas transitions

* **Documentation**
  * Skill docs and user guide detailing the authoring → promote → verify workflow and example commands

* **Utilities**
  * New test helpers, verification utilities, CLI harness, and progress logging

* **Chore**
  * Gitignore adjusted to allow command config under the ignored directory

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/vscode-extensions/pull/2223)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->