### PR TITLE
Fix incorrect time being displayed in eval history viewer

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/test-manager/rpc-manager.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/test-manager/rpc-manager.ts
@@ -288,13 +288,15 @@ export class TestServiceManagerRpcManager implements TestManagerServiceAPI {
         }
         const [, year, month, day, hour, minute, second, ms] = match;
         return new Date(
-            parseInt(year),
-            parseInt(month) - 1,
-            parseInt(day),
-            parseInt(hour),
-            parseInt(minute),
-            parseInt(second),
-            parseInt(ms)
+            Date.UTC(
+                parseInt(year),
+                parseInt(month) - 1,
+                parseInt(day),
+                parseInt(hour),
+                parseInt(minute),
+                parseInt(second),
+                parseInt(ms)
+            )
         );
     }
 


### PR DESCRIPTION
## Purpose

Fixes https://github.com/wso2/product-integrator/issues/1464

- Evaluation history timestamps were parsed from report filenames as local time but the filenames represent UTC, so the displayed times were off by the user's UTC offset.
- Fixes `parseDateFromFilename` in the test-manager RPC to construct the Date via `Date.UTC(...)`, producing a correct UTC instant. The frontend's existing `toLocaleString(undefined, ...)` then renders it in the user's local timezone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timezone interpretation for evaluation report filenames to use UTC instead of local time, ensuring accurate timestamp representation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/vscode-extensions/pull/2231)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->