### PR TITLE
Enhance FlowNodeForm to enrich cloned node properties

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FlowNodeForm/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FlowNodeForm/index.tsx
@@ -754,6 +754,23 @@ export const FlowNodeForm = forwardRef<FormExpressionEditorRef, FlowNodeFormProp
 
     const mergeFormDataWithFlowNode = (data: FormValues, targetLineRange: LineRange, dirtyFields?: any): FlowNode => {
         const clonedNode = cloneDeep(node);
+
+        // When a template is available, enrich the cloned node's properties with the
+        // template's property structure before saving. This ensures that properties
+        // with null values (e.g. the expression on a bare `return;`) are replaced with
+        // fully-formed Property objects so that updateNodeProperties can set their values.
+        if (nodeFormTemplate) {
+            const formProperties = getFormProperties(clonedNode);
+            const formTemplateProperties = getFormProperties(nodeFormTemplate);
+            const enrichedProperties = enrichFormTemplatePropertiesWithValues(formProperties, formTemplateProperties);
+
+            if (clonedNode.branches?.at(0)?.properties) {
+                clonedNode.branches[0].properties = enrichedProperties;
+            } else {
+                clonedNode.properties = enrichedProperties;
+            }
+        }
+
         // Create updated node with new line range
         const updatedNode = createNodeWithUpdatedLineRange(clonedNode, targetLineRange);
 


### PR DESCRIPTION
## Purpose

When editing an existing node whose properties contain \`null\` entries (e.g. a bare \`return;\` whose \`expression\` property is \`null\`), the form's save path cloned the raw node and passed it to \`updateNodeProperties\`. That function skips \`null\` property values (\`if (expression)\` guard), so any value the user typed was silently dropped and never sent to the Language Server.

Related issue: https://github.com/wso2/product-integrator/issues/1498

https://github.com/user-attachments/assets/91d847de-647c-4a05-9cab-97de1d645ea0


## Goals

Ensure that editing any node via the BI FlowDiagram form panel correctly persists the entered values, even when the original node in the flow model has \`null\` property entries.

## UI Component Development
> Specify the reason if following are not followed.
- [x] Added reusable UI components to the ui-toolkit. Follow the [intructions](./workspaces/common-libs/ui-toolkit/README.md) when adding the componenent.
- [x] Use ui-toolkit components wherever possible. Run `npm run storybook` from the root directory to view current components.
- [x] Matches with the native VSCode look and feel.

## Manage Icons
> Specify the reason if following are not followed.
- [x] Added Icons to the font-wso2-vscode. Follow the [instructions](./workspaces/common-libs/font-wso2-vscode/README.md).

## User stories

Editing a bare \`return;\` statement in the BI FlowDiagram panel now correctly saves the expression value entered by the user.

## Release note

Fixed a bug where saving a form edit for nodes with null property entries (e.g. a bare \`return;\`) silently discarded the entered value.

## Documentation

N/A — internal behaviour fix with no user-facing API or UI change beyond the bug being resolved.

## Training

N/A

## Certification

N/A

## Marketing

N/A

## Automation tests

- Unit tests: N/A — the fix is in a React component's internal save function; covered by manual verification.
- Integration tests: Manually verified by opening a bare \`return;\` node in the BI FlowDiagram panel, entering an expression, and confirming the source file is updated correctly after Save.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? yes
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

N/A

## Migrations (if applicable)

N/A

## Test environment

- macOS, Node 20, VS Code 1.95+

## Learning

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Flow node forms now populate template-defined properties before applying form data, fixing cases where form updates didn't save for nodes with missing property structures.

* **Chores**
  * Updated package override configuration to ensure consistent dependency resolution for protobuf handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/vscode-extensions/pull/2235)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->