### PR TITLE
Add CONNECTION fieldType and inline create-connection overlay

### DIFF
--- a/workspaces/ballerina/ballerina-core/src/interfaces/bi.ts
+++ b/workspaces/ballerina/ballerina-core/src/interfaces/bi.ts
@@ -70,6 +70,11 @@ export type FunctionNode = {
     returning: boolean;
 };
 
+export type AllowedConnector = {
+    codedata: CodeData;
+    addNewConnectionLabel: string;
+};
+
 export type Metadata = {
     label: string;
     description: string;
@@ -78,6 +83,7 @@ export type Metadata = {
     draft?: boolean; // for diagram draft nodes
     data?: NodeMetadata | ParentMetadata;
     functionKind?: string;
+    connectors?: AllowedConnector[];
 };
 
 export type NodeMetadata = {
@@ -173,7 +179,8 @@ export type FormFieldInputType = "TEXT" |
     "CONDITIONAL_FIELDS" |
     "DOC_TEXT" |
     "ADVANCE_PARAM_LIST" |
-    "GROUP_SECTION"
+    "GROUP_SECTION" |
+    "CONNECTION"
     ;
 
 export interface BaseType {

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/ConnectionEditor/ConnectionEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/ConnectionEditor/ConnectionEditor.tsx
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useEffect, useState } from "react";
+import styled from "@emotion/styled";
+import { Codicon, LinkButton } from "@wso2/ui-toolkit";
+import { AllowedConnector, CodeData } from "@wso2/ballerina-core";
+
+import { FormField } from "../../Form/types";
+import { useFormContext } from "../../../context";
+import { capitalize } from "../utils";
+import { ConnectionSelectEditor, ConnectorFilter } from "../MultiModeExpressionEditor/ConnectionSelectEditor/ConnectionSelectEditor";
+import { CreateConnectionOverlay } from "./CreateConnectionOverlay";
+
+interface ConnectionEditorProps {
+    field: FormField;
+}
+
+const Container = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    width: 100%;
+`;
+
+const Label = styled.label`
+    font-size: 13px;
+    color: var(--vscode-editor-foreground);
+`;
+
+const Required = styled.span`
+    color: var(--vscode-errorForeground);
+    margin-left: 2px;
+`;
+
+const Description = styled.div`
+    font-size: 12px;
+    color: var(--vscode-descriptionForeground);
+`;
+
+const AddButtons = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    margin-top: 6px;
+`;
+
+export const ConnectionEditor: React.FC<ConnectionEditorProps> = ({ field }) => {
+    const { form } = useFormContext();
+    const { register, setValue, watch } = form;
+    const [activeConnector, setActiveConnector] = useState<AllowedConnector | null>(null);
+
+    useEffect(() => {
+        register(field.key, {
+            required: !field.optional,
+            value: field.value ?? "",
+        });
+    }, [field.key]);
+
+    const value = (watch(field.key) ?? field.value ?? "") as string;
+    const connectors: AllowedConnector[] = field.metadata?.connectors ?? [];
+    const connectorFilters: ConnectorFilter[] | undefined = connectors.length > 0
+        ? connectors.map(c => ({ module: c.codedata?.module, object: c.codedata?.object }))
+        : undefined;
+
+    const handleChange = (val: string) => {
+        setValue(field.key, val, { shouldDirty: true, shouldValidate: true });
+        field.onValueChange?.(val);
+    };
+
+    const handleSaved = (variableName: string) => {
+        setActiveConnector(null);
+        setValue(field.key, variableName, { shouldDirty: true, shouldValidate: true });
+        field.onValueChange?.(variableName);
+    };
+
+    return (
+        <Container>
+            <Label htmlFor={field.key}>
+                {capitalize(field.label)}
+                {!field.optional && <Required>*</Required>}
+            </Label>
+            {field.documentation && <Description>{field.documentation}</Description>}
+            <ConnectionSelectEditor
+                value={value}
+                field={field}
+                onChange={(val) => handleChange(val)}
+                connectorFilters={connectorFilters}
+            />
+            {connectors.length > 0 && (
+                <AddButtons>
+                    {connectors.map((c, i) => (
+                        <LinkButton
+                            key={`${c.codedata?.module}-${c.codedata?.object}-${i}`}
+                            onClick={() => setActiveConnector(c)}
+                            sx={{ padding: "4px 6px", margin: 0, fontSize: "13px" }}
+                        >
+                            <Codicon name="add" />
+                            {c.addNewConnectionLabel}
+                        </LinkButton>
+                    ))}
+                </AddButtons>
+            )}
+            {activeConnector && (
+                <CreateConnectionOverlay
+                    connector={activeConnector.codedata as CodeData}
+                    title={activeConnector.addNewConnectionLabel}
+                    onClose={() => setActiveConnector(null)}
+                    onSaved={handleSaved}
+                />
+            )}
+        </Container>
+    );
+};

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/ConnectionEditor/CreateConnectionOverlay.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/ConnectionEditor/CreateConnectionOverlay.tsx
@@ -1,0 +1,185 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useEffect, useRef, useState } from "react";
+import styled from "@emotion/styled";
+import { Codicon, Overlay, ProgressRing, ThemeColors, Typography } from "@wso2/ui-toolkit";
+import { useRpcContext } from "@wso2/ballerina-rpc-client";
+import { CodeData, FlowNode } from "@wso2/ballerina-core";
+
+import { Form } from "../../Form";
+import { FormField, FormValues } from "../../Form/types";
+import { useFormContext } from "../../../context";
+import { convertConfig } from "../../../utils/convertConfig";
+
+interface CreateConnectionOverlayProps {
+    connector: CodeData;
+    title: string;
+    onClose: () => void;
+    onSaved: (variableName: string) => void;
+}
+
+const Backdrop = styled.div`
+    position: fixed;
+    inset: 0;
+    z-index: 2000;
+`;
+
+const PanelContainer = styled.div`
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: min(560px, 100%);
+    background: var(--vscode-sideBar-background);
+    border-left: 1px solid ${ThemeColors.OUTLINE_VARIANT};
+    z-index: 2001;
+    display: flex;
+    flex-direction: column;
+    box-shadow: -2px 0 12px rgba(0, 0, 0, 0.2);
+`;
+
+const Header = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 16px;
+    border-bottom: 1px solid ${ThemeColors.OUTLINE_VARIANT};
+`;
+
+const CloseButton = styled.button`
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    padding: 4px;
+    color: var(--vscode-editor-foreground);
+    display: flex;
+    align-items: center;
+
+    &:hover { color: var(--vscode-button-hoverBackground); }
+`;
+
+const Body = styled.div`
+    flex: 1;
+    overflow-y: auto;
+`;
+
+const Centered = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 32px;
+`;
+
+export const CreateConnectionOverlay: React.FC<CreateConnectionOverlayProps> = ({ connector, title, onClose, onSaved }) => {
+    const { rpcClient } = useRpcContext();
+    const { targetLineRange, fileName } = useFormContext();
+    const flowNodeRef = useRef<FlowNode | null>(null);
+    const [fields, setFields] = useState<FormField[] | null>(null);
+    const [saving, setSaving] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+        rpcClient.getBIDiagramRpcClient().getNodeTemplate({
+            position: targetLineRange?.startLine,
+            filePath: fileName,
+            id: { ...connector, node: "NEW_CONNECTION" } as CodeData,
+        }).then((res) => {
+            if (cancelled) return;
+            flowNodeRef.current = res.flowNode;
+            // Skip hidden auto-managed props from the form view.
+            setFields(convertConfig(res.flowNode.properties, ["checkError"]));
+        }).catch((e) => {
+            if (!cancelled) setError(`Failed to load connector form: ${e?.message ?? e}`);
+        });
+        return () => { cancelled = true; };
+    }, [rpcClient, connector, fileName]);
+
+    const handleSubmit = async (data: FormValues) => {
+        const flowNode = flowNodeRef.current;
+        if (!flowNode) return;
+        setSaving(true);
+        setError(null);
+        try {
+            // Write form values back onto the flowNode template.
+            for (const key of Object.keys(data)) {
+                const prop = (flowNode.properties as any)[key];
+                if (prop) {
+                    prop.value = data[key];
+                }
+            }
+
+            const visualizerLocation = await rpcClient.getVisualizerLocation();
+            const connectionsFilePath = visualizerLocation.documentUri || visualizerLocation.projectPath || fileName;
+
+            const response: any = await rpcClient.getBIDiagramRpcClient().getSourceCode({
+                filePath: connectionsFilePath,
+                flowNode,
+                isConnector: true,
+            });
+
+            const artifacts = response?.artifacts as Array<{ name: string; isNew: boolean }> | undefined;
+            const newConnection = artifacts?.find((a) => a.isNew) ?? artifacts?.[0];
+            if (!newConnection?.name) {
+                setError("Connection saved but no new artifact was returned");
+                setSaving(false);
+                return;
+            }
+            onSaved(newConnection.name);
+        } catch (e: any) {
+            setError(e?.message ?? String(e));
+            setSaving(false);
+        }
+    };
+
+    return (
+        <>
+            <Overlay sx={{ background: ThemeColors.SURFACE_CONTAINER, opacity: 0.4, zIndex: 2000 }} />
+            <Backdrop onClick={onClose} />
+            <PanelContainer onClick={(e) => e.stopPropagation()}>
+                <Header>
+                    <Typography variant="h3">{title}</Typography>
+                    <CloseButton aria-label="Close" onClick={onClose}>
+                        <Codicon name="close" />
+                    </CloseButton>
+                </Header>
+                <Body>
+                    {error && (
+                        <div style={{ padding: "12px 16px", color: "var(--vscode-errorForeground)" }}>{error}</div>
+                    )}
+                    {!fields ? (
+                        <Centered><ProgressRing /></Centered>
+                    ) : (
+                        <Form
+                            formFields={fields}
+                            targetLineRange={targetLineRange}
+                            fileName={fileName}
+                            submitText={saving ? "Saving..." : "Save"}
+                            cancelText="Cancel"
+                            onSubmit={handleSubmit}
+                            onCancelForm={onClose}
+                            nestedForm
+                            disableSaveButton={saving}
+                        />
+                    )}
+                </Body>
+            </PanelContainer>
+        </>
+    );
+};

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/EditorFactory.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/EditorFactory.tsx
@@ -53,6 +53,7 @@ import { ArgManagerEditor } from "../ParamManager/ArgManager";
 import { DependentTypeEditor } from "./DependentTypeEditor";
 import { FieldFactory } from "./FieldFactory";
 import { GroupSectionEditor } from "./GroupSectionEditor";
+import { ConnectionEditor } from "./ConnectionEditor/ConnectionEditor";
 
 export interface FormFieldEditorProps {
     field: FormField;
@@ -160,6 +161,8 @@ export const EditorFactory = (props: FormFieldEditorProps) => {
                 handleNewTypeSelected={handleNewTypeSelected}
             />
         );
+    } else if (fieldInputType.fieldType === "CONNECTION" && field.editable) {
+        return <ConnectionEditor field={field} />;
     } else if (!field.items && fieldInputType.fieldType === "TYPE" && field.editable) {
         return (
             <TypeEditor

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ConnectionSelectEditor/ConnectionSelectEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ConnectionSelectEditor/ConnectionSelectEditor.tsx
@@ -23,10 +23,13 @@ import { FormField } from "../../../Form/types";
 import { ConnectionIconSelect, ConnectionSelectItem } from "../../ConnectionIconSelect";
 import { useFormContext } from "../../../../context";
 
+export type ConnectorFilter = { module?: string; object?: string };
+
 interface ConnectionSelectEditorProps {
     value: string;
     field: FormField;
     onChange: (value: string, cursorPosition: number) => void;
+    connectorFilters?: ConnectorFilter[];
 }
 
 // Cache icon URLs by module name across remounts to avoid icon flicker
@@ -61,7 +64,7 @@ function ensureValueInItems(
     ];
 }
 
-export const ConnectionSelectEditor: React.FC<ConnectionSelectEditorProps> = ({ value, field, onChange }) => {
+export const ConnectionSelectEditor: React.FC<ConnectionSelectEditorProps> = ({ value, field, onChange, connectorFilters }) => {
     const { rpcClient } = useRpcContext();
     const { targetLineRange, fileName } = useFormContext();
 
@@ -69,7 +72,21 @@ export const ConnectionSelectEditor: React.FC<ConnectionSelectEditorProps> = ({ 
     const initialItems: ConnectionSelectItem[] = field.codedata?.initialItems ?? [];
     const staticItems: ConnectionSelectItem[] = field.codedata?.staticItems ?? [];
     const cachedItems = searchNodesKind ? itemsCache.get(searchNodesKind) : undefined;
-    const resolvedItems = [...staticItems, ...(cachedItems ?? enrichWithCachedIcons(initialItems))];
+    const hasFilters = connectorFilters && connectorFilters.length > 0;
+    // Stable string key for effect deps so we re-fetch only when the filter set actually changes.
+    const filterKey = hasFilters
+        ? connectorFilters!.map((f) => `${f.module ?? ""}:${f.object ?? ""}`).join("|")
+        : "";
+    const applyConnectorFilter = (items: ConnectionSelectItem[]): ConnectionSelectItem[] => {
+        if (!hasFilters) return items;
+        return items.filter(item =>
+            connectorFilters!.some((filter) =>
+                (!filter.module || item.codedata?.module === filter.module) &&
+                (!filter.object || item.codedata?.object === filter.object)
+            )
+        );
+    };
+    const resolvedItems = applyConnectorFilter([...staticItems, ...(cachedItems ?? enrichWithCachedIcons(initialItems))]);
     const [selectItems, setSelectItems] = useState<ConnectionSelectItem[]>(
         ensureValueInItems(resolvedItems, value, searchNodesKind)
     );
@@ -104,7 +121,7 @@ export const ConnectionSelectEditor: React.FC<ConnectionSelectEditorProps> = ({ 
                     };
                 });
             itemsCache.set(searchNodesKind, items);
-            setSelectItems([...staticItems, ...items]);
+            setSelectItems(applyConnectorFilter([...staticItems, ...items]));
         }).finally(() => {
             setLoading(false);
         });
@@ -112,7 +129,7 @@ export const ConnectionSelectEditor: React.FC<ConnectionSelectEditorProps> = ({ 
 
     useEffect(() => {
         fetchItems();
-    }, [searchNodesKind, fileName]);
+    }, [searchNodesKind, fileName, filterKey]);
 
     // When value changes to something not in the current items (e.g. after creating
     // a new connection via an overlay), inject a placeholder and re-fetch

--- a/workspaces/ballerina/ballerina-side-panel/src/utils/convertConfig.ts
+++ b/workspaces/ballerina/ballerina-side-panel/src/utils/convertConfig.ts
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { NodeProperties, Property, getPrimaryInputType, isDropDownType, DropdownType } from "@wso2/ballerina-core";
+import { FormField } from "../components/Form/types";
+
+/**
+ * Minimal NodeProperties -> FormField[] converter used by the inline
+ * connection-create overlay. Intentionally narrower than the visualizer's
+ * full convertConfig — supports the property shapes a connector `init` form
+ * typically produces (primitive expressions, enums, identifier, type) but
+ * not REPEATABLE_PROPERTY, ADVANCE_PARAM_LIST, dynamicFormFields, etc.
+ */
+export function convertConfig(properties: NodeProperties, skipKeys: string[] = []): FormField[] {
+    const formFields: FormField[] = [];
+    for (const key of Object.keys(properties).sort()) {
+        if (skipKeys.includes(key)) {
+            continue;
+        }
+        const property = properties[key as keyof NodeProperties] as Property;
+        if (!property) {
+            continue;
+        }
+        formFields.push(toFormField(key, property));
+    }
+    return formFields;
+}
+
+function toFormField(key: string, property: Property): FormField {
+    return {
+        key,
+        label: property.metadata?.label || "",
+        type: getPrimaryInputType(property.types)?.fieldType ?? "",
+        optional: property.optional,
+        advanced: property.advanced,
+        placeholder: property.placeholder,
+        defaultValue: property.defaultValue as string,
+        editable: property.editable,
+        enabled: true,
+        hidden: property.hidden,
+        documentation: property.metadata?.description || "",
+        value: property.value as string,
+        items: getItems(property),
+        itemOptions: property.itemOptions,
+        diagnostics: property.diagnostics?.diagnostics || [],
+        types: property.types,
+        lineRange: property?.codedata?.lineRange,
+        metadata: property.metadata,
+        codedata: property.codedata,
+        imports: property.imports,
+    };
+}
+
+function getItems(property: Property): string[] | undefined {
+    if (property.types?.length === 1 && isDropDownType(property.types[0])) {
+        return (property.types[0] as DropdownType).options.map((option) => option.value);
+    }
+    return undefined;
+}


### PR DESCRIPTION
## Summary


https://github.com/user-attachments/assets/1f793db7-ace0-44f3-861a-91c6e68949df



- New side-panel `ConnectionEditor` renders a dropdown of existing connections (filtered by the LS-supplied `metadata.connectors` list) plus one Add button per allowed connector. Each Add button opens an inline modal over the side panel, fetches the connector's template via `getNodeTemplate`, renders `<Form>`, and on save commits via `getSourceCode` and auto-selects the new connection in the parent field — never invoking `AddConnectionWizard`.
- When `metadata.connectors` is absent the dropdown lists every connection in the project unfiltered and no Add buttons are shown.
- `ConnectionSelectEditor` switched from a single `connectorFilter` prop to an array (`connectorFilters`) so multi-connector forms get a union filter; a stable string key is used as the effect dep so refetch is triggered only when the filter set actually changes.
- New `convertConfig` util in side-panel converts `NodeProperties` → `FormField[]` for the overlay form without depending on visualizer utilities.

## Test plan
- [ ] Build: `pnpm -C workspaces/ballerina/ballerina-core build && pnpm -C workspaces/ballerina/ballerina-side-panel build`
- [ ] In the dev host, open the SAMPLE_CONNECTION node (from the matching language-server PR) and confirm:
  - "Any Connection" field lists every connection, no Add button.
  - "HTTP Connection" field is filtered to HTTP connections, single Add button opens an inline HTTP-config form.
  - "AI Connection" field is union-filtered to Mistral / Milvus, two Add buttons.
  - Saving the inline form auto-selects the new connection on the parent field.
- [ ] Regression: from the diagram's node list, click "+ Add Connection" — the standard `AddConnectionWizard` still opens on the connector catalog.

Related: wso2-enterprise/integration-engineering#1459

Depends on: ballerina-platform/ballerina-language-server#928

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a connection editor enabling users to create and select connector connections with filtering capabilities
  * Connection selection now supports filtering by connector type and module information
  * Users can create new connections on-the-fly through an integrated overlay interface without leaving the form workflow

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/vscode-extensions/pull/2238)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->