### PR TITLE
fix: use optional field access in helper pane drill-down

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/DocumentConfig.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/DocumentConfig.tsx
@@ -120,7 +120,7 @@ export const DocumentConfig = ({ onChange, onClose, targetLineRange, filteredCom
         }
         return mimeTypeVariable.trim();
     }, [mimeTypeMode, mimeTypeLiteral, mimeTypeVariable]);
-    const { breadCrumbSteps, navigateToNext, navigateToBreadcrumb, getCurrentNavigationPath } = useHelperPaneNavigation(`${documentType.charAt(0).toUpperCase() + documentType.slice(1)} Document`);
+    const { breadCrumbSteps, navigateToNext, navigateToBreadcrumb, getCurrentNavigationPath, getLeafSeparator } = useHelperPaneNavigation(`${documentType.charAt(0).toUpperCase() + documentType.slice(1)} Document`);
     const { addModal, closeModal } = useModalStack();
 
     const { field, triggerCharacters } = useFieldContext();
@@ -128,8 +128,8 @@ export const DocumentConfig = ({ onChange, onClose, targetLineRange, filteredCom
     // Use navigation path for completions instead of currentValue
     const navigationPath = useMemo(() => getCurrentNavigationPath(), [breadCrumbSteps]);
     const completionContext = useMemo(() =>
-        navigationPath ? navigationPath + '.' : (currentValue ?? ''),
-        [navigationPath, currentValue]
+        navigationPath ? navigationPath + getLeafSeparator() : (currentValue ?? ''),
+        [navigationPath, currentValue, breadCrumbSteps]
     );
 
     useEffect(() => {
@@ -222,8 +222,8 @@ export const DocumentConfig = ({ onChange, onClose, targetLineRange, filteredCom
         const labelDescription = item.labelDetails?.description || "";
         const typeInfo = description || labelDescription;
 
-        // Build full path from navigation
-        const fullPath = navigationPath ? `${navigationPath}.${value}` : value;
+        // Build full path from navigation; use ?. when the parent step is optional
+        const fullPath = navigationPath ? `${navigationPath}${getLeafSeparator()}${value}` : value;
 
         // Check if the variable is already an AI document type
         const isAIDocumentType = AI_DOCUMENT_TYPES.some(type => typeInfo.includes(type));
@@ -251,8 +251,9 @@ export const DocumentConfig = ({ onChange, onClose, targetLineRange, filteredCom
         }
     };
 
-    const handleVariablesMoreIconClick = (value: string) => {
-        navigateToNext(value, navigationPath);
+    const handleVariablesMoreIconClick = (item: CompletionItem) => {
+        const typeDetail = item?.labelDetails?.detail || item?.description;
+        navigateToNext(item.label, navigationPath, typeDetail);
     };
 
     const handleBreadCrumbItemClicked = (step: BreadCrumbStep) => {
@@ -425,7 +426,7 @@ export const DocumentConfig = ({ onChange, onClose, targetLineRange, filteredCom
                                                 <VariableItem
                                                     key={opt.label}
                                                     item={opt}
-                                                    onItemSelect={(val) => setMimeTypeVariable(navigationPath ? `${navigationPath}.${val}` : val)}
+                                                    onItemSelect={(val) => setMimeTypeVariable(navigationPath ? `${navigationPath}${getLeafSeparator()}${val}` : val)}
                                                     onMoreIconClick={() => { }}
                                                     hideArrow={true}
                                                 />

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/Inputs.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/Inputs.tsx
@@ -87,7 +87,7 @@ export const Inputs = (props: InputsPageProps) => {
     const [searchValue, setSearchValue] = useState<string>("");
     const [isLoading, setIsLoading] = useState<boolean>(true);
     const [showContent, setShowContent] = useState<boolean>(false);
-    const { breadCrumbSteps, navigateToNext, navigateToNextArray, updateLastStepArrayIndex, navigateToBreadcrumb, isAtRoot, getCurrentNavigationPath } = useHelperPaneNavigation("Inputs");
+    const { breadCrumbSteps, navigateToNext, navigateToNextArray, updateLastStepArrayIndex, navigateToBreadcrumb, isAtRoot, getCurrentNavigationPath, getLeafSeparator } = useHelperPaneNavigation("Inputs");
 
     const currentStep = breadCrumbSteps[breadCrumbSteps.length - 1];
     const isInArrayContext = !isAtRoot() && currentStep?.isArrayAccess === true;
@@ -114,8 +114,8 @@ export const Inputs = (props: InputsPageProps) => {
     // Use navigation path for completions instead of currentValue
     const navigationPath = useMemo(() => getCurrentNavigationPath(), [breadCrumbSteps]);
     const completionContext = useMemo(() =>
-        navigationPath ? navigationPath + '.' : (currentValue || ''),
-        [navigationPath, currentValue]
+        navigationPath ? navigationPath + getLeafSeparator() : (currentValue || ''),
+        [navigationPath, currentValue, breadCrumbSteps]
     );
 
     useEffect(() => {
@@ -180,17 +180,17 @@ export const Inputs = (props: InputsPageProps) => {
     };
 
     const handleItemSelect = (value: string) => {
-        // Build full path from navigation
-        const fullPath = navigationPath ? `${navigationPath}.${value}` : value;
+        // Build full path from navigation; use ?. when the parent step is optional
+        const fullPath = navigationPath ? `${navigationPath}${getLeafSeparator()}${value}` : value;
         onChange(fullPath, false);
     }
 
     const handleInputsMoreIconClick = (item: CompletionItem) => {
         const typeDetail = item?.labelDetails?.detail || item?.description;
         if (isArrayOfObjectsType(typeDetail)) {
-            navigateToNextArray(item.label, navigationPath, 0);
+            navigateToNextArray(item.label, navigationPath, 0, typeDetail);
         } else {
-            navigateToNext(item.label, navigationPath);
+            navigateToNext(item.label, navigationPath, typeDetail);
         }
     }
 

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/Variables.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/Views/Variables.tsx
@@ -56,7 +56,7 @@ type VariablesPageProps = {
 export type VariableItemProps = {
     item: CompletionItem;
     onItemSelect: (value: string, item: CompletionItem) => void;
-    onMoreIconClick: (value: string) => void;
+    onMoreIconClick: (item: CompletionItem) => void;
     hideArrow?: boolean;
 }
 
@@ -86,7 +86,7 @@ export const VariableItem = ({ item, onItemSelect, onMoreIconClick, hideArrow }:
         <HelperPaneListItem
             onClick={() => onItemSelect(item.label, item)}
             endAction={endAction}
-            onClickEndAction={() => onMoreIconClick(item.label)}
+            onClickEndAction={() => onMoreIconClick(item)}
         >
             {mainContent}
         </HelperPaneListItem>
@@ -101,7 +101,7 @@ export const Variables = (props: VariablesPageProps) => {
     const [showContent, setShowContent] = useState<boolean>(false);
     const newNodeNameRef = useRef<string>("");
     const [projectPathUri, setProjectPathUri] = useState<string>();
-    const { breadCrumbSteps, navigateToNext, navigateToBreadcrumb, isAtRoot, getCurrentNavigationPath } = useHelperPaneNavigation("Variables");
+    const { breadCrumbSteps, navigateToNext, navigateToBreadcrumb, isAtRoot, getCurrentNavigationPath, getLeafSeparator } = useHelperPaneNavigation("Variables");
     const { addModal, closeModal } = useModalStack()
 
     const { field, triggerCharacters } = useFieldContext();
@@ -112,9 +112,9 @@ export const Variables = (props: VariablesPageProps) => {
         return path;
     }, [breadCrumbSteps]);
     const completionContext = useMemo(() => {
-        const context = navigationPath ? navigationPath + '.' : (currentValue ?? '');
+        const context = navigationPath ? navigationPath + getLeafSeparator() : (currentValue ?? '');
         return context;
-    }, [navigationPath, currentValue]);
+    }, [navigationPath, currentValue, breadCrumbSteps]);
 
     useEffect(() => {
         getProjectInfo()
@@ -206,8 +206,8 @@ export const Variables = (props: VariablesPageProps) => {
     };
 
     const handleItemSelect = (value: string, _item?: CompletionItem) => {
-        // Build full path from navigation
-        const fullPath = navigationPath ? `${navigationPath}.${value}` : value;
+        // Build full path from navigation; use ?. when the parent step is optional
+        const fullPath = navigationPath ? `${navigationPath}${getLeafSeparator()}${value}` : value;
         onChange(fullPath, false);
     }
 
@@ -227,8 +227,9 @@ export const Variables = (props: VariablesPageProps) => {
             />, POPUP_IDS.VARIABLE, "New Variable", 600);
         onClose && onClose();
     }
-    const handleVariablesMoreIconClick = (value: string) => {
-        navigateToNext(value, navigationPath);
+    const handleVariablesMoreIconClick = (item: CompletionItem) => {
+        const typeDetail = item?.labelDetails?.detail || item?.description;
+        navigateToNext(item.label, navigationPath, typeDetail);
     }
 
     const handleBreadCrumbItemClicked = (step: BreadCrumbStep) => {

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/hooks/useHelperPaneNavigation.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/hooks/useHelperPaneNavigation.tsx
@@ -27,7 +27,15 @@ export type BreadCrumbStep = {
     stepType?: string;
 }
 
-const isOptionalType = (t?: string) => !!t && t.trim().endsWith('?');
+// Ballerina renders optionality either as a trailing `?` (e.g. `string?`,
+// `ChangeEventMetadata?`, `(A|B)?`) or as a union with nil written out
+// (e.g. `string|()`, `Foo | ( )`). Detect both forms.
+const NIL_UNION_RE = /\|\s*\(\s*\)$/;
+const isOptionalType = (t?: string) => {
+    if (!t) return false;
+    const s = t.trim();
+    return s.endsWith('?') || NIL_UNION_RE.test(s);
+};
 const joinSep = (prevStepType?: string) => (isOptionalType(prevStepType) ? '?.' : '.');
 
 export const useHelperPaneNavigation = (initialLabel: string) => {

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/hooks/useHelperPaneNavigation.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/HelperPaneNew/hooks/useHelperPaneNavigation.tsx
@@ -27,6 +27,9 @@ export type BreadCrumbStep = {
     stepType?: string;
 }
 
+const isOptionalType = (t?: string) => !!t && t.trim().endsWith('?');
+const joinSep = (prevStepType?: string) => (isOptionalType(prevStepType) ? '?.' : '.');
+
 export const useHelperPaneNavigation = (initialLabel: string) => {
     const [breadCrumbSteps, setBreadCrumbSteps] = useState<BreadCrumbStep[]>([{
         label: initialLabel,
@@ -34,7 +37,8 @@ export const useHelperPaneNavigation = (initialLabel: string) => {
     }]);
 
     const navigateToNext = (value: string, currentValue: string, stepType?: string) => {
-        const separator = currentValue ? '.' : '';
+        const lastStep = breadCrumbSteps[breadCrumbSteps.length - 1];
+        const separator = currentValue ? joinSep(lastStep?.stepType) : '';
         const newBreadCrumSteps = [...breadCrumbSteps, {
             label: value,
             replaceText: currentValue + separator + value,
@@ -43,15 +47,17 @@ export const useHelperPaneNavigation = (initialLabel: string) => {
         setBreadCrumbSteps(newBreadCrumSteps);
     };
 
-    const navigateToNextArray = (value: string, currentValue: string, index: number) => {
-        const separator = currentValue ? '.' : '';
+    const navigateToNextArray = (value: string, currentValue: string, index: number, stepType?: string) => {
+        const lastStep = breadCrumbSteps[breadCrumbSteps.length - 1];
+        const separator = currentValue ? joinSep(lastStep?.stepType) : '';
         const indexedValue = `${value}[${index}]`;
         const newBreadCrumSteps = [...breadCrumbSteps, {
             label: indexedValue,
             replaceText: currentValue + separator + indexedValue,
             isArrayAccess: true,
             arrayIndex: index,
-            fieldName: value
+            fieldName: value,
+            stepType
         }];
         setBreadCrumbSteps(newBreadCrumSteps);
     };
@@ -64,7 +70,7 @@ export const useHelperPaneNavigation = (initialLabel: string) => {
 
         const parentStep = steps[steps.length - 2];
         const parentPath = parentStep.replaceText;
-        const separator = parentPath ? '.' : '';
+        const separator = parentPath ? joinSep(parentStep.stepType) : '';
         const newReplaceText = parentPath + separator + lastStep.fieldName + '[' + index + ']';
 
         steps[steps.length - 1] = {
@@ -91,6 +97,9 @@ export const useHelperPaneNavigation = (initialLabel: string) => {
 
     const getCurrentNavigationPath = getCurrentPath;
 
+    const getLeafSeparator = () =>
+        joinSep(breadCrumbSteps[breadCrumbSteps.length - 1]?.stepType);
+
     return {
         breadCrumbSteps,
         navigateToNext,
@@ -99,6 +108,7 @@ export const useHelperPaneNavigation = (initialLabel: string) => {
         navigateToBreadcrumb,
         isAtRoot,
         getCurrentPath,
-        getCurrentNavigationPath
+        getCurrentNavigationPath,
+        getLeafSeparator
     };
 };


### PR DESCRIPTION
## Summary


https://github.com/user-attachments/assets/e2ea5f92-d033-46e6-af19-760964e30102



- Helper pane drill-down (Inputs, Variables, and DocumentConfig views) now inserts `?.` instead of `.` between segments when the parent field's type is optional, e.g. `payload.metadata?.entityName` when `metadata: ChangeEventMetadata?`, or `payload.sheetData?.name` when `sheetData: SheetData?`.
- Each breadcrumb step now records the type of the value it represents (`stepType`), and `useHelperPaneNavigation` derives the separator from the previous step's `stepType` via a shared `getLeafSeparator()` helper. The same helper is used for the LS completion-context prefix so child completions of an optional record are requested with `?.`.
- Optional detection covers both rendering forms Ballerina uses: trailing `?` (e.g. `string?`, `ChangeEventMetadata?`, `(A|B)?`) and union with nil written out (e.g. `string|()`, `Foo | ( )`).
- `VariableItem.onMoreIconClick` was widened from `(label: string)` to `(item: CompletionItem)` so the type string is reachable at the drill-down site. The only other consumer of `VariableItem` is `DocumentConfig.tsx`, updated in the same commit. `Configurables.tsx` has no record drill-down and is unchanged.

## Related Issues
Fixed https://github.com/wso2-enterprise/integration-product-management/issues/828

## Test plan
- [x] Inputs view: drill `Inputs > payload > metadata > entityName` on a salesforce trigger payload; inserted expression is `payload.metadata?.entityName`, no field-access diagnostic.
- [x] Variables view: with a local `Payload` record containing `SheetData sheetData?`, drill `Variables > payload > sheetData > name`; inserted expression is `payload.sheetData?.name`, no field-access diagnostic.
- [ ] Variables view, non-optional path: drill `Variables > payload > leadData > Name` (non-optional); inserted expression is `payload.leadData.Name`, plain `.`.
- [ ] Drill into an array-of-objects field, step the index, then select a leaf — `?.` only appears where a parent is optional; `[i]` is unaffected.
- [ ] Click an intermediate breadcrumb, drill again — path rebuilds with the correct separators.
- [ ] DocumentConfig view: select a variable inside an optional document record; path uses `?.` at the optional parent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation path handling for optional-chaining scenarios in the helper pane
  * Enhanced navigation flow when selecting array-type items
  * Ensured consistent path construction and behavior during item selection

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/vscode-extensions/pull/2240)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->