### PR TITLE
Fix stale completion list after accepting completion + dot in expression editor

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FlowNodeForm/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FlowNodeForm/index.tsx
@@ -1009,6 +1009,13 @@ export const FlowNodeForm = forwardRef<FormExpressionEditorRef, FlowNodeFormProp
         [debouncedGetVisibleTypes]
     );
 
+    useEffect(() => {
+        return () => {
+            debouncedRetrieveCompletions.cancel();
+            debouncedGetVisibleTypes.cancel();
+        };
+    }, [debouncedRetrieveCompletions, debouncedGetVisibleTypes]);
+
     const extractArgsFromFunction = async (value: string, property: ExpressionProperty, cursorPosition: number) => {
         const { lineOffset, charOffset } = calculateExpressionOffsets(value, cursorPosition);
         // Merge the latest imports from formImportsRef to avoid stale field.imports when a

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FlowNodeForm/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FlowNodeForm/index.tsx
@@ -307,10 +307,15 @@ export const FlowNodeForm = forwardRef<FormExpressionEditorRef, FlowNodeFormProp
     /* Expression editor related state and ref variables */
     const prevCompletionFetchText = useRef<string>("");
     const [completions, setCompletions] = useState<CompletionItem[]>([]);
+    const completionsRef = useRef<CompletionItem[]>([]);
     const [filteredCompletions, setFilteredCompletions] = useState<CompletionItem[]>([]);
     const [types, setTypes] = useState<CompletionItem[]>([]);
+    const typesRef = useRef<CompletionItem[]>([]);
     const [filteredTypes, setFilteredTypes] = useState<CompletionItem[]>([]);
     const expressionOffsetRef = useRef<number>(0); // To track the expression offset on adding import statements
+
+    useEffect(() => { completionsRef.current = completions; }, [completions]);
+    useEffect(() => { typesRef.current = types; }, [types]);
 
     const { addModal, closeModal, popModal } = useModalStack()
 
@@ -833,12 +838,14 @@ export const FlowNodeForm = forwardRef<FormExpressionEditorRef, FlowNodeFormProp
                 const { parentContent, currentContent } = value
                     .slice(0, offset)
                     .match(EXPRESSION_EXTRACTION_REGEX)?.groups ?? {};
+                const cachedCompletions = completionsRef.current;
                 if (
-                    completions.length > 0 &&
+                    cachedCompletions.length > 0 &&
                     !triggerCharacter &&
+                    parentContent !== undefined &&
                     parentContent === prevCompletionFetchText.current
                 ) {
-                    expressionCompletions = completions
+                    expressionCompletions = cachedCompletions
                         .filter((completion) => {
                             const lowerCaseText = currentContent.toLowerCase();
                             const lowerCaseLabel = completion.label.toLowerCase();
@@ -894,7 +901,7 @@ export const FlowNodeForm = forwardRef<FormExpressionEditorRef, FlowNodeFormProp
             },
             250
         ),
-        [rpcClient, completions, fileName, targetLineRange, node]
+        [rpcClient, fileName, targetLineRange, node]
     );
 
     const handleRetrieveCompletions = useCallback(
@@ -921,8 +928,8 @@ export const FlowNodeForm = forwardRef<FormExpressionEditorRef, FlowNodeFormProp
                 fetchReferenceTypes: boolean,
                 valueTypeConstraint?: string
             ) => {
-                let visibleTypes: CompletionItem[] = types;
-                if (!types.length) {
+                let visibleTypes: CompletionItem[] = typesRef.current;
+                if (!visibleTypes.length) {
                     const searchResponse = await rpcClient.getBIDiagramRpcClient().search({
                         filePath: fileName,
                         position: targetLineRange,
@@ -992,7 +999,7 @@ export const FlowNodeForm = forwardRef<FormExpressionEditorRef, FlowNodeFormProp
             },
             250
         ),
-        [rpcClient, types, fileName, targetLineRange]
+        [rpcClient, fileName, targetLineRange]
     );
 
     const handleGetVisibleTypes = useCallback(

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FlowNodeForm/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/Forms/FlowNodeForm/index.tsx
@@ -1009,12 +1009,18 @@ export const FlowNodeForm = forwardRef<FormExpressionEditorRef, FlowNodeFormProp
         [debouncedGetVisibleTypes]
     );
 
+    const debouncedRetrieveCompletionsRef = useRef(debouncedRetrieveCompletions);
+    const debouncedGetVisibleTypesRef = useRef(debouncedGetVisibleTypes);
     useEffect(() => {
-        return () => {
-            debouncedRetrieveCompletions.cancel();
-            debouncedGetVisibleTypes.cancel();
-        };
-    }, [debouncedRetrieveCompletions, debouncedGetVisibleTypes]);
+        debouncedRetrieveCompletionsRef.current = debouncedRetrieveCompletions;
+    }, [debouncedRetrieveCompletions]);
+    useEffect(() => {
+        debouncedGetVisibleTypesRef.current = debouncedGetVisibleTypes;
+    }, [debouncedGetVisibleTypes]);
+    useEffect(() => () => {
+        debouncedRetrieveCompletionsRef.current.cancel();
+        debouncedGetVisibleTypesRef.current.cancel();
+    }, []);
 
     const extractArgsFromFunction = async (value: string, property: ExpressionProperty, cursorPosition: number) => {
         const { lineOffset, charOffset } = calculateExpressionOffsets(value, cursorPosition);


### PR DESCRIPTION
## Summary


https://github.com/user-attachments/assets/0282618c-a1e5-441f-8f34-14ea0357febd



- Stabilize the debounced completion and visible-type fetchers in `FlowNodeForm` by reading mutable state through refs instead of capturing it in `useCallback` deps, eliminating overlapping debounce timers that overwrote results with stale closures
- Guard the cache-hit branch against the `undefined === ""` edge case so the first completion request after a trigger character is always sent to the LS

## Test plan
- [x] Open a BI flow, edit an `if` Condition expression
- [x] Type `pay`, accept `payload` from the popup, then press `.` - member completions (`changedData`, `metadata`, map methods) appear
- [x] Type `payload.` manually - member completions still appear
- [ ] Chain dots (`payload.metadata?.`) - each step shows the correct member list
- [ ] Switch between fields and confirm no stale completions leak between properties

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved expression editor reliability in flow node forms by ensuring completion suggestions and type information remain accurate and up-to-date during editing sessions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/vscode-extensions/pull/2242)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->