### PR TITLE
Prevent usage of backticks in output from prompt enhancer

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/features/ai/service/prompt-enhancement/prompts.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/service/prompt-enhancement/prompts.ts
@@ -86,6 +86,13 @@ You are generating a **user query** to send to an AI agent.
 - Focus on: making the query specific, clear about what's expected, and providing necessary context.
 - Preserve a conversational/request tone.
 - Do NOT add persona definitions or behavioral rules.
+- Do NOT use backticks (\`) anywhere in the output — no inline code spans or code fences.
+`;
+      break;
+    case PromptMode.DEFAULT:
+      modeDirectives = `
+### MODE: DEFAULT
+- Do NOT use backticks (\`) anywhere in the output — no inline code spans or code fences.
 `;
       break;
   }
@@ -253,6 +260,13 @@ You are enhancing a **user query** that will be sent to an AI agent.
 - Focus on: making the query specific, clear about what's expected, and providing necessary context.
 - Preserve the conversational/request tone.
 - Do NOT add persona definitions or behavioral rules — this is a user message, not a system prompt.
+- Do NOT use backticks (\`) anywhere in the output — no inline code spans or code fences.
+`;
+      break;
+    case PromptMode.DEFAULT:
+      modeDirectives = `
+### MODE: DEFAULT
+- Do NOT use backticks (\`) anywhere in the output — no inline code spans or code fences.
 `;
       break;
   }


### PR DESCRIPTION
## Purpose

Fixes https://github.com/wso2/product-integrator/issues/1565

This PR updates the system prompt for the prompt enhancer to specifically not use backticks when generating prompts as they are not supported inside raw templates in Ballerina.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined AI prompt generation to enforce stricter formatting guidelines for query and default modes. Generated responses in these modes will now exclude backtick characters, ensuring more consistent and predictable output throughout the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/vscode-extensions/pull/2243?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->