### PR TITLE
Fix interpolations breaking token rendering in prompt editor

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/CodeUtils.ts
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/CodeUtils.ts
@@ -18,7 +18,13 @@
 
 import { StateEffect, StateField, RangeSet, Transaction, SelectionRange, Annotation } from "@codemirror/state";
 import { WidgetType, Decoration, ViewPlugin, EditorView, ViewUpdate } from "@codemirror/view";
-import { filterCompletionsByPrefixAndType, getParsedExpressionTokens, detectTokenPatterns, ParsedToken } from "./utils";
+import {
+    filterCompletionsByPrefixAndType,
+    getParsedExpressionTokens,
+    detectTokenPatterns,
+    getTokenIndicesInClosedExpressionRanges,
+    ParsedToken
+} from "./utils";
 import { HELPER_PANE_WIDTH } from "./constants";
 import { defaultKeymap, historyKeymap } from "@codemirror/commands";
 import { CompletionItem, FnSignatureDocumentation } from "@wso2/ui-toolkit";
@@ -294,23 +300,7 @@ export const iterateTokenStream = (
         }
     }
 
-    // Tokens inside an unclosed ${ are orphans; the LSP treats following text as expression context
-    const insideClosedRange = new Set<number>();
-    let pending: number[] = [];
-    let isOpen = false;
-    for (let i = 0; i < tokens.length; i++) {
-        const type = tokens[i].type;
-        if (type === TokenType.START_EVENT) {
-            pending = [];
-            isOpen = true;
-        } else if (type === TokenType.END_EVENT && isOpen) {
-            pending.forEach(idx => insideClosedRange.add(idx));
-            pending = [];
-            isOpen = false;
-        } else if (isOpen) {
-            pending.push(i);
-        }
-    }
+    const insideClosedRange = getTokenIndicesInClosedExpressionRanges(tokens);
 
     for (let i = 0; i < tokens.length; i++) {
         const token = tokens[i];

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/CodeUtils.ts
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/CodeUtils.ts
@@ -294,6 +294,24 @@ export const iterateTokenStream = (
         }
     }
 
+    // Tokens inside an unclosed ${ are orphans; the LSP treats following text as expression context
+    const insideClosedRange = new Set<number>();
+    let pending: number[] = [];
+    let isOpen = false;
+    for (let i = 0; i < tokens.length; i++) {
+        const type = tokens[i].type;
+        if (type === TokenType.START_EVENT) {
+            pending = [];
+            isOpen = true;
+        } else if (type === TokenType.END_EVENT && isOpen) {
+            pending.forEach(idx => insideClosedRange.add(idx));
+            pending = [];
+            isOpen = false;
+        } else if (isOpen) {
+            pending.push(i);
+        }
+    }
+
     for (let i = 0; i < tokens.length; i++) {
         const token = tokens[i];
 
@@ -313,6 +331,11 @@ export const iterateTokenStream = (
 
         // Skip START_EVENT and END_EVENT tokens
         if (token.type === TokenType.START_EVENT || token.type === TokenType.END_EVENT) {
+            continue;
+        }
+
+        // Skip orphan tokens sitting inside an unclosed ${
+        if (!insideClosedRange.has(i)) {
             continue;
         }
 

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/components/ChipExpressionEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/components/ChipExpressionEditor.tsx
@@ -371,6 +371,7 @@ export const ChipExpressionEditorComponent = (props: ChipExpressionEditorCompone
             }
             return;
         }
+        let cancelled = false;
         const updateEditorState = async () => {
             const currentDoc = viewRef.current!.state.doc.toString();
             const isExternalUpdate = serializedValue !== currentDoc;
@@ -386,6 +387,10 @@ export const ChipExpressionEditorComponent = (props: ChipExpressionEditorCompone
                 props.fileName,
                 startLine !== undefined ? startLine : undefined
             );
+
+            // Drop stale responses where the value changed mid-await
+            if (cancelled) return;
+
             const prefixCorrectedTokenStream = tokenStream
                 ? correctTokenStreamPositions(
                     tokenStream,
@@ -411,6 +416,7 @@ export const ChipExpressionEditorComponent = (props: ChipExpressionEditorCompone
             setIsValueResolving(false);
         };
         updateEditorState();
+        return () => { cancelled = true; };
     }, [props.value, props.fileName, props.targetLineRange?.startLine, isTokenUpdateScheduled]);
 
     useEffect(() => {

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/utils.ts
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/ChipExpressionEditor/utils.ts
@@ -174,6 +174,28 @@ export const getParsedExpressionTokens = (tokens: number[], value: string): Pars
     return tokenObjects;
 }
 
+// Returns the set of token indices that sit inside a properly closed ${...} range.
+// Tokens inside an unclosed ${ are orphans; the LSP treats following text as expression context.
+export const getTokenIndicesInClosedExpressionRanges = (tokens: ParsedToken[]): Set<number> => {
+    const insideClosedRange = new Set<number>();
+    let pending: number[] = [];
+    let isOpen = false;
+    for (let i = 0; i < tokens.length; i++) {
+        const type = tokens[i].type;
+        if (type === TokenType.START_EVENT) {
+            pending = [];
+            isOpen = true;
+        } else if (type === TokenType.END_EVENT && isOpen) {
+            pending.forEach(idx => insideClosedRange.add(idx));
+            pending = [];
+            isOpen = false;
+        } else if (isOpen) {
+            pending.push(i);
+        }
+    }
+    return insideClosedRange;
+}
+
 export const getWordBeforeCursorPosition = (textBeforeCursor: string): string => {
     const match = textBeforeCursor.match(/\b\w+$/);
     const lastMatch = match ? match[match.length - 1] : "";

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/RichTextTemplateEditor/RichTextTemplateEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/RichTextTemplateEditor/RichTextTemplateEditor.tsx
@@ -519,6 +519,10 @@ export const RichTextTemplateEditor: React.FC<RichTextTemplateEditorProps> = ({
                 fileName,
                 startLine !== undefined ? startLine : undefined
             );
+            
+            if (editorView.state.doc.textContent !== plainText) {
+                return;
+            }
 
             updateChipTokens(editorView, {
                 tokens,

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/RichTextTemplateEditor/plugins/chipPlugin.ts
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/RichTextTemplateEditor/plugins/chipPlugin.ts
@@ -303,6 +303,24 @@ function replaceTextWithChips(
         }
     }
 
+    // Tokens inside an unclosed ${ are orphans; the LSP treats following text as expression context
+    const insideClosedRange = new Set<number>();
+    let pending: number[] = [];
+    let isOpen = false;
+    for (let i = 0; i < tokens.length; i++) {
+        const type = tokens[i].type;
+        if (type === TokenType.START_EVENT) {
+            pending = [];
+            isOpen = true;
+        } else if (type === TokenType.END_EVENT && isOpen) {
+            pending.forEach(idx => insideClosedRange.add(idx));
+            pending = [];
+            isOpen = false;
+        } else if (isOpen) {
+            pending.push(i);
+        }
+    }
+
     // Collect individual token chip nodes
     for (let i = 0; i < tokens.length; i++) {
         const token = tokens[i];
@@ -314,6 +332,11 @@ function replaceTextWithChips(
 
         // Skip START_EVENT and END_EVENT tokens
         if (token.type === TokenType.START_EVENT || token.type === TokenType.END_EVENT) {
+            continue;
+        }
+
+        // Skip orphan tokens sitting inside an unclosed ${
+        if (!insideClosedRange.has(i)) {
             continue;
         }
 

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/RichTextTemplateEditor/plugins/chipPlugin.ts
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/MultiModeExpressionEditor/RichTextTemplateEditor/plugins/chipPlugin.ts
@@ -23,6 +23,7 @@ import { tableNodes } from 'prosemirror-tables';
 import {
     getParsedExpressionTokens,
     detectTokenPatterns,
+    getTokenIndicesInClosedExpressionRanges,
     ParsedToken
 } from '../../ChipExpressionEditor/utils';
 import {
@@ -303,23 +304,7 @@ function replaceTextWithChips(
         }
     }
 
-    // Tokens inside an unclosed ${ are orphans; the LSP treats following text as expression context
-    const insideClosedRange = new Set<number>();
-    let pending: number[] = [];
-    let isOpen = false;
-    for (let i = 0; i < tokens.length; i++) {
-        const type = tokens[i].type;
-        if (type === TokenType.START_EVENT) {
-            pending = [];
-            isOpen = true;
-        } else if (type === TokenType.END_EVENT && isOpen) {
-            pending.forEach(idx => insideClosedRange.add(idx));
-            pending = [];
-            isOpen = false;
-        } else if (isOpen) {
-            pending.push(i);
-        }
-    }
+    const insideClosedRange = getTokenIndicesInClosedExpressionRanges(tokens);
 
     // Collect individual token chip nodes
     for (let i = 0; i < tokens.length; i++) {


### PR DESCRIPTION
## Purpose

Fixes https://github.com/wso2/product-integrator/issues/1566

This PR fixes `${}` syntax breaking the token rendering in prompts when using the prompt editor.

https://github.com/user-attachments/assets/865db51b-1bc1-4648-bf2e-13e08caa1089

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced expression editor reliability by preventing stale token data from being applied during rapid editing changes
  * Improved handling of incomplete expressions to ensure accurate token display

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/vscode-extensions/pull/2245)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->