### PR TITLE
Update changelogs for BI 1.10.0 and Ballerina 5.12.0 release

### DIFF
--- a/workspaces/ballerina/ballerina-extension/CHANGELOG.md
+++ b/workspaces/ballerina/ballerina-extension/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the **Ballerina** extension will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
 
-## [5.12.0](https://github.com/wso2/vscode-extensions/compare/ballerina-5.8.2...ballerina-integrator-1.10.0) - 2026-05-16
+## [5.12.0](https://github.com/wso2/vscode-extensions/compare/ballerina-5.8.2...ballerina-integrator-1.10.0) - 2026-05-18
 
 ### Added
 

--- a/workspaces/ballerina/ballerina-extension/CHANGELOG.md
+++ b/workspaces/ballerina/ballerina-extension/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the **Ballerina** extension will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
 
-## [Unreleased]
+## [5.12.0](https://github.com/wso2/vscode-extensions/compare/ballerina-5.8.2...ballerina-integrator-1.10.0) - 2026-05-15
 
 ### Added
 

--- a/workspaces/ballerina/ballerina-extension/CHANGELOG.md
+++ b/workspaces/ballerina/ballerina-extension/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the **Ballerina** extension will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
 
-## [5.12.0](https://github.com/wso2/vscode-extensions/compare/ballerina-5.8.2...ballerina-integrator-1.10.0) - 2026-05-15
+## [5.12.0](https://github.com/wso2/vscode-extensions/compare/ballerina-5.8.2...ballerina-integrator-1.10.0) - 2026-05-16
 
 ### Added
 

--- a/workspaces/bi/bi-extension/CHANGELOG.md
+++ b/workspaces/bi/bi-extension/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
-## [1.10.0](https://github.com/wso2/vscode-extensions/compare/ballerina-integrator-1.7.0...ballerina-integrator-1.10.0) - 2026-05-16
+## [1.10.0](https://github.com/wso2/vscode-extensions/compare/ballerina-integrator-1.7.0...ballerina-integrator-1.10.0) - 2026-05-18
 
 ### Deprecated
 

--- a/workspaces/bi/bi-extension/CHANGELOG.md
+++ b/workspaces/bi/bi-extension/CHANGELOG.md
@@ -10,11 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Deprecated
 
-- **Extension Deprecation Notice** — This extension will be officially deprecated in the next release. All features are migrating to the unified **WSO2 Integrator** extension.
+- **Extension Deprecation Notice** — This extension will be officially deprecated in the next release. All features are migrating to the unified [**WSO2 Integrator**](https://marketplace.visualstudio.com/items?itemName=WSO2.wso2-integrator) extension.
 
 ### Added
 
-- **Automatic Upgrade & Migration Path** — Transition to the new extension is fully automated. The new [**WSO2 Integrator**](https://marketplace.visualstudio.com/items?itemName=WSO2.wso2-integrator) extension will be automatically installed in your VS Code.
+- **Automatic Upgrade & Migration Path** — Transition to the new extension is fully automated. The new **WSO2 Integrator** extension will be automatically installed in your VS Code.
 - **Manual Installation Fallback** — If the automatic lifecycle migration is blocked by your local environment, you can manually install the new extension from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=WSO2.wso2-integrator).
 - **Persist Database Support** — Added support for persist database workflows in BI, including multiple database connections.
 - **Library Projects** — Added end-to-end support for library projects, including creation improvements, new overview page, `lib.bal` validator import, publishing to Ballerina Central, and deployment enforcement when deploying workspaces to Devant.

--- a/workspaces/bi/bi-extension/CHANGELOG.md
+++ b/workspaces/bi/bi-extension/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+### Deprecated
+
+- **Extension Deprecation Notice** — This extension will be officially deprecated in the next release. All features are migrating to the unified **WSO2 Integrator** extension.
+
+### Changed
+
+- **Automatic Upgrade & Migration Path** — Transition to the new extension is fully automated. The new **WSO2 Integrator** extension will be automatically installed in your VS Code.
+- **Manual Installation Fallback** — If the automatic lifecycle migration is blocked by your local environment, you can manually install the new extension from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=WSO2.wso2-integrator).
+
+
+## [1.10.0](https://github.com/wso2/vscode-extensions/compare/ballerina-integrator-1.7.0...ballerina-integrator-1.10.0) - 2026-05-15
+
 ### Added
 
 - **Persist Database Support** — Added support for persist database workflows in BI, including multiple database connections.

--- a/workspaces/bi/bi-extension/CHANGELOG.md
+++ b/workspaces/bi/bi-extension/CHANGELOG.md
@@ -6,20 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+## [1.10.0](https://github.com/wso2/vscode-extensions/compare/ballerina-integrator-1.7.0...ballerina-integrator-1.10.0) - 2026-05-16
+
 ### Deprecated
 
 - **Extension Deprecation Notice** — This extension will be officially deprecated in the next release. All features are migrating to the unified **WSO2 Integrator** extension.
 
-### Changed
+### Added
 
 - **Automatic Upgrade & Migration Path** — Transition to the new extension is fully automated. The new **WSO2 Integrator** extension will be automatically installed in your VS Code.
 - **Manual Installation Fallback** — If the automatic lifecycle migration is blocked by your local environment, you can manually install the new extension from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=WSO2.wso2-integrator).
-
-
-## [1.10.0](https://github.com/wso2/vscode-extensions/compare/ballerina-integrator-1.7.0...ballerina-integrator-1.10.0) - 2026-05-16
-
-### Added
-
 - **Persist Database Support** — Added support for persist database workflows in BI, including multiple database connections.
 - **Library Projects** — Added end-to-end support for library projects, including creation improvements, new overview page, `lib.bal` validator import, publishing to Ballerina Central, and deployment enforcement when deploying workspaces to Devant.
 - **BI Copilot** — Added new agent capabilities including library search/get tools, ConfigCollector, test-runner integration, plan-mode toggle, new/old review preview, telemetry insights, and support for agent evaluations.

--- a/workspaces/bi/bi-extension/CHANGELOG.md
+++ b/workspaces/bi/bi-extension/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - **Manual Installation Fallback** — If the automatic lifecycle migration is blocked by your local environment, you can manually install the new extension from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=WSO2.wso2-integrator).
 
 
-## [1.10.0](https://github.com/wso2/vscode-extensions/compare/ballerina-integrator-1.7.0...ballerina-integrator-1.10.0) - 2026-05-15
+## [1.10.0](https://github.com/wso2/vscode-extensions/compare/ballerina-integrator-1.7.0...ballerina-integrator-1.10.0) - 2026-05-16
 
 ### Added
 

--- a/workspaces/bi/bi-extension/CHANGELOG.md
+++ b/workspaces/bi/bi-extension/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Added
 
-- **Automatic Upgrade & Migration Path** — Transition to the new extension is fully automated. The new **WSO2 Integrator** extension will be automatically installed in your VS Code.
+- **Automatic Upgrade & Migration Path** — Transition to the new extension is fully automated. The new [**WSO2 Integrator**](https://marketplace.visualstudio.com/items?itemName=WSO2.wso2-integrator) extension will be automatically installed in your VS Code.
 - **Manual Installation Fallback** — If the automatic lifecycle migration is blocked by your local environment, you can manually install the new extension from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=WSO2.wso2-integrator).
 - **Persist Database Support** — Added support for persist database workflows in BI, including multiple database connections.
 - **Library Projects** — Added end-to-end support for library projects, including creation improvements, new overview page, `lib.bal` validator import, publishing to Ballerina Central, and deployment enforcement when deploying workspaces to Devant.


### PR DESCRIPTION
## Summary

- **BI extension (`workspaces/bi/bi-extension/CHANGELOG.md`)**: Added deprecation notice and automatic migration path entries under `[Unreleased]`; added `[1.10.0]` release section dated 2026-05-16.
- **Ballerina extension (`workspaces/ballerina/ballerina-extension/CHANGELOG.md`)**: Renamed `[Unreleased]` to `[5.12.0]` release section dated 2026-05-16.

## Context

The BI extension will be officially deprecated in the upcoming release. All features are migrating to the unified **WSO2 Integrator** extension, with automatic installation and seamless migration for existing users.

## Test plan

- [x] Verify BI CHANGELOG renders correctly with deprecation notice under `[Unreleased]` and `[1.10.0]` section below
- [x] Verify Ballerina CHANGELOG `[5.12.0]` section heading and link are correct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Released Ballerina extension v5.12.0 with expanded library-project workflows, enhanced Copilot capabilities, improved Data Mapper coverage, and UX/editor refinements.
  * Released BI extension v1.10.0 with migration guidance and fallback installation option via VS Code Marketplace.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/vscode-extensions/pull/2248)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->