### PR TITLE
Refresh eval history view on new runs

### DIFF
--- a/workspaces/ballerina/ballerina-core/src/rpc-types/test-manager/rpc-type.ts
+++ b/workspaces/ballerina/ballerina-core/src/rpc-types/test-manager/rpc-type.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 import { GetTestFunctionRequest, GetTestFunctionResponse, AddOrUpdateTestFunctionRequest } from "../../interfaces/extended-lang-client";
-import { RequestType } from "vscode-messenger-common";
+import { NotificationType, RequestType } from "vscode-messenger-common";
 import { SourceUpdateResponse } from "../service-designer/interfaces";
 
 const _preFix = "test-manager";
@@ -183,4 +183,9 @@ export interface RestoreGitSnapshotResponse {
 
 export const restoreGitSnapshot: RequestType<RestoreGitSnapshotRequest, RestoreGitSnapshotResponse> =
     { method: `${_preFix}/restoreGitSnapshot` };
+
+// Broadcast when a new evaluation report has been written to disk, so open
+// Evaluation History panels can re-fetch instead of requiring a reopen.
+export const evaluationHistoryUpdated: NotificationType<void> =
+    { method: `${_preFix}/evaluationHistoryUpdated` };
 

--- a/workspaces/ballerina/ballerina-extension/src/RPCLayer.ts
+++ b/workspaces/ballerina/ballerina-extension/src/RPCLayer.ts
@@ -19,7 +19,8 @@
 import { WebviewView, WebviewPanel, window } from 'vscode';
 import { Messenger } from 'vscode-messenger';
 import { StateMachine } from './stateMachine';
-import { stateChanged, getVisualizerLocation, VisualizerLocation, projectContentUpdated, aiStateChanged, sendAIStateEvent, popupStateChanged, getPopupVisualizerState, PopupVisualizerLocation, breakpointChanged, AIMachineEventType, ArtifactData, onArtifactUpdatedNotification, onArtifactUpdatedRequest, currentThemeChanged, AIMachineSendableEvent, checkpointCaptured, CheckpointCapturedPayload, promptUpdated, approvalOverlayState, ApprovalOverlayState, onIdentifierUpdated, ProjectStructureArtifactResponse, runningServicesChanged, RunningServiceInfo } from '@wso2/ballerina-core';
+import { stateChanged, getVisualizerLocation, VisualizerLocation, projectContentUpdated, aiStateChanged, sendAIStateEvent, popupStateChanged, getPopupVisualizerState, PopupVisualizerLocation, breakpointChanged, AIMachineEventType, ArtifactData, onArtifactUpdatedNotification, onArtifactUpdatedRequest, currentThemeChanged, AIMachineSendableEvent, checkpointCaptured, CheckpointCapturedPayload, promptUpdated, approvalOverlayState, ApprovalOverlayState, onIdentifierUpdated, ProjectStructureArtifactResponse, runningServicesChanged, RunningServiceInfo, evaluationHistoryUpdated } from '@wso2/ballerina-core';
+import { EvaluationHistoryWebview } from './views/evaluation-history/webview';
 import { VisualizerWebview } from './views/visualizer/webview';
 import { registerVisualizerRpcHandlers } from './rpc-managers/visualizer/rpc-handler';
 import { registerLangClientRpcHandlers } from './rpc-managers/lang-client/rpc-handler';
@@ -238,4 +239,8 @@ export function notifyOnIdentifierUpdated(artifacts: ProjectStructureArtifactRes
 
 export function sendAgentChangedNotification(agentName: string) {
     RPCLayer._messenger.sendNotification(activeAgentChanged, { type: 'webview', webviewType: 'ballerina.agent-chat-panel' }, agentName);
+}
+
+export function notifyEvaluationHistoryUpdated() {
+    RPCLayer._messenger.sendNotification(evaluationHistoryUpdated, { type: 'webview', webviewType: EvaluationHistoryWebview.viewType });
 }

--- a/workspaces/ballerina/ballerina-extension/src/features/test-explorer/runner.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/test-explorer/runner.ts
@@ -27,6 +27,7 @@ import { constructDebugConfig } from "../debugger";
 const fs = require('fs');
 import path from 'path';
 import { EvaluationReportWebview } from '../../views/evaluation-report/webview';
+import { notifyEvaluationHistoryUpdated } from '../../RPCLayer';
 import { captureGitState, createSnapshot, pinSnapshot, ensureEvalReportsGitignored } from '../../utils/git-utils';
 import { quoteShellPath } from '../../utils/config';
 
@@ -193,6 +194,8 @@ async function handleEvalReport(run: TestRun, testItems: TestItem[], timeElapsed
     } catch (error) {
         console.error('Error processing evaluation report:', error);
     }
+
+    notifyEvaluationHistoryUpdated();
 
     try {
         await openEvaluationReport(reportPath);

--- a/workspaces/ballerina/ballerina-rpc-client/src/BallerinaRpcClient.ts
+++ b/workspaces/ballerina/ballerina-rpc-client/src/BallerinaRpcClient.ts
@@ -69,7 +69,8 @@ import {
     webToolToggle,
     WebToolToggle,
     runningServicesChanged,
-    RunningServiceInfo
+    RunningServiceInfo,
+    evaluationHistoryUpdated
 } from "@wso2/ballerina-core";
 import { LangClientRpcClient } from "./rpc-clients/lang-client/rpc-client";
 import { LibraryBrowserRpcClient } from "./rpc-clients/library-browser/rpc-client";
@@ -110,6 +111,7 @@ export class BallerinaRpcClient {
     private _identifierUpdatedCallbacks = new Set<(response: ProjectStructureArtifactResponse[]) => void>();
     private _runningServicesChangedCallbacks = new Set<(services: RunningServiceInfo[]) => void>();
     private _projectContentUpdatedCallbacks = new Set<(state: boolean) => void>();
+    private _evaluationHistoryUpdatedCallbacks = new Set<() => void>();
 
     constructor() {
         this.messenger = new Messenger(vscode);
@@ -141,6 +143,9 @@ export class BallerinaRpcClient {
         });
         this.messenger.onNotification(projectContentUpdated, (state: boolean) => {
             this._projectContentUpdatedCallbacks.forEach((callback) => callback(state));
+        });
+        this.messenger.onNotification(evaluationHistoryUpdated, () => {
+            this._evaluationHistoryUpdatedCallbacks.forEach((callback) => callback());
         });
     }
 
@@ -244,6 +249,13 @@ export class BallerinaRpcClient {
         this._projectContentUpdatedCallbacks.add(callback);
         return () => {
             this._projectContentUpdatedCallbacks.delete(callback);
+        };
+    }
+
+    onEvaluationHistoryUpdated(callback: () => void): () => void {
+        this._evaluationHistoryUpdatedCallbacks.add(callback);
+        return () => {
+            this._evaluationHistoryUpdatedCallbacks.delete(callback);
         };
     }
 

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/AIEvaluationForm/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/AIEvaluationForm/index.tsx
@@ -741,7 +741,7 @@ export function AIEvaluationForm(props: TestFunctionDefProps) {
                             },
                             types: [{ fieldType: "SLIDER", selected: false }],
                             originalName: "minPassRate",
-                            value: "1.0",
+                            value: "0.9",
                             optional: true,
                             editable: true,
                             advanced: false

--- a/workspaces/ballerina/ballerina-visualizer/src/views/EvaluationHistory/EvaluationHistory.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/EvaluationHistory/EvaluationHistory.tsx
@@ -202,21 +202,23 @@ export function EvaluationHistory() {
         setProjectPath(resolvedProjectPath);
 
         let cancelled = false;
+        let latestFetchId = 0;
         const fetchHistory = (isInitial: boolean) => {
+            const fetchId = ++latestFetchId;
             rpcClient
                 .getTestManagerRpcClient()
                 .getEvaluationHistory({ projectPath: resolvedProjectPath })
                 .then((response) => {
-                    if (cancelled) { return; }
+                    if (cancelled || fetchId !== latestFetchId) { return; }
                     setData(response.data);
-                    if (isInitial) { setLoading(false); }
+                    setLoading(false);
                 })
                 .catch(() => {
-                    if (cancelled) { return; }
+                    if (cancelled || fetchId !== latestFetchId) { return; }
                     if (isInitial) {
                         setData({ tests: [], totalRunFiles: 0, projectNames: [] });
-                        setLoading(false);
                     }
+                    setLoading(false);
                 });
         };
 

--- a/workspaces/ballerina/ballerina-visualizer/src/views/EvaluationHistory/EvaluationHistory.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/EvaluationHistory/EvaluationHistory.tsx
@@ -198,20 +198,35 @@ export function EvaluationHistory() {
 
     useEffect(() => {
         const container = document.getElementById("webview-container");
-        const projectPath = container?.getAttribute("data-project-path") ?? "";
-        setProjectPath(projectPath);
+        const resolvedProjectPath = container?.getAttribute("data-project-path") ?? "";
+        setProjectPath(resolvedProjectPath);
 
-        rpcClient
-            .getTestManagerRpcClient()
-            .getEvaluationHistory({ projectPath })
-            .then((response) => {
-                setData(response.data);
-                setLoading(false);
-            })
-            .catch(() => {
-                setData({ tests: [], totalRunFiles: 0, projectNames: [] });
-                setLoading(false);
-            });
+        let cancelled = false;
+        const fetchHistory = (isInitial: boolean) => {
+            rpcClient
+                .getTestManagerRpcClient()
+                .getEvaluationHistory({ projectPath: resolvedProjectPath })
+                .then((response) => {
+                    if (cancelled) { return; }
+                    setData(response.data);
+                    if (isInitial) { setLoading(false); }
+                })
+                .catch(() => {
+                    if (cancelled) { return; }
+                    if (isInitial) {
+                        setData({ tests: [], totalRunFiles: 0, projectNames: [] });
+                        setLoading(false);
+                    }
+                });
+        };
+
+        fetchHistory(true);
+        const unsubscribe = rpcClient.onEvaluationHistoryUpdated(() => fetchHistory(false));
+
+        return () => {
+            cancelled = true;
+            unsubscribe();
+        };
     }, []);
 
     if (loading) {

--- a/workspaces/ballerina/ballerina-visualizer/src/views/EvaluationHistory/RunHistoryTable.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/EvaluationHistory/RunHistoryTable.tsx
@@ -243,8 +243,6 @@ const NoReport = styled.span`
 const CodeChangesCell = styled.td`
     white-space: nowrap;
     font-size: 11px;
-    display: flex;
-    align-items: center;
 `;
 
 const StateLabel = styled.span<{ isDirty: boolean }>`
@@ -346,7 +344,7 @@ export function RunHistoryTable({ runs, projectPath }: RunHistoryTableProps) {
                                         {hasGitData && (
                                             <CodeChangesCell>
                                                 {run.gitState?.commitSha ? (
-                                                    <>
+                                                    <div style={{ display: "flex", alignItems: "center" }}>
                                                         <StateLabel
                                                             isDirty={run.gitState.isDirty}
                                                             title={
@@ -363,7 +361,7 @@ export function RunHistoryTable({ runs, projectPath }: RunHistoryTableProps) {
                                                         >
                                                             View changes
                                                         </ViewBtn>
-                                                    </>
+                                                    </div>
                                                 ) : (
                                                     <NoReport>&mdash;</NoReport>
                                                 )}


### PR DESCRIPTION
## Purpose

Fixes https://github.com/wso2/product-integrator/issues/1567

This PR adds support for the evaluations history page to auto refresh when new eval runs are completed.


https://github.com/user-attachments/assets/522f8e60-d4f6-4f7c-a8a0-45d1f4432a6a
