### PR TITLE
Fix crash when projects array is empty in agent tool registry

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tool-registry.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tool-registry.ts
@@ -100,7 +100,7 @@ export function createToolRegistry(opts: ToolRegistryOptions) {
         [CONNECTOR_GENERATOR_TOOL]: createConnectorGeneratorTool(
             eventHandler,
             tempProjectPath,
-            projects[0].projectName,
+            projects[0]?.projectName,
             modifiedFiles
         ),
         [CONFIG_COLLECTOR_TOOL]: createConfigCollectorTool(


### PR DESCRIPTION
Fixes https://github.com/wso2/product-integrator/issues/1508

- Fix "Cannot read properties of undefined (reading 'projectName')" thrown from tool-registry.ts when the workspace has no packages
- Use optional chaining at `projects[0]?.projectName` — `createConnectorGeneratorTool` already accepts an optional `projectName` and falls back to `"project"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI agent tool stability by fixing a potential initialization error that could occur when no projects are available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/vscode-extensions/pull/2252?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->