### PR TITLE
Update daily build action with release/ballerina-5.12.x branch

### DIFF
--- a/.github/daily-build/release.properties
+++ b/.github/daily-build/release.properties
@@ -1,7 +1,7 @@
 # Config for the Ballerina daily-build workflow.
 
 # Workflow-level config. Read from the workflow/default branch before matrix expansion.
-vscodeBranches=main,release/bi-1.8.x
+vscodeBranches=main,release/ballerina-5.12.x
 
 # Per-branch config. Read by .github/workflows/daily-build-ballerina.yml after checking out each target branch.
 


### PR DESCRIPTION
## Purpose

Updates the daily build action workflow to use the new active release branch name: `release/ballerina-5.12.x`.