### PR TITLE
Improve ConfigCollector with remove, rename, and per-field skip

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/config-collector.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/config-collector.ts
@@ -31,6 +31,8 @@ import {
     readExistingConfigValues,
     removeConfigKeys,
     renameConfigKeys,
+    isPlaceholderValue,
+    computeCollectStatus,
 } from "../../../../utils/toml-utils";
 import { resolveContained, resolvePackageBasePath } from "./path-utils";
 import { getOrgPackageName } from "../../../../utils/config";
@@ -85,8 +87,31 @@ export interface ConfigCollectorResult {
     success: boolean;
     message: string;
     status?: Record<string, "filled" | "missing">;
+    userSkipped?: string[];
     error?: string;
     errorCode?: string;
+}
+
+interface SubmissionAnalysis {
+    provided: Record<string, string>;
+    notProvided: string[];
+}
+
+function classifySubmission(
+    variables: ConfigVariable[],
+    submitted: Record<string, string>
+): SubmissionAnalysis {
+    const provided: Record<string, string> = {};
+    const notProvided: string[] = [];
+    for (const variable of variables) {
+        const raw = submitted[variable.name];
+        if (raw && raw.trim()) {
+            provided[variable.name] = raw;
+        } else {
+            notProvided.push(variable.name);
+        }
+    }
+    return { provided, notProvided };
 }
 
 export interface ConfigCollectorPaths {
@@ -161,7 +186,8 @@ Operation Modes:
 1. COLLECT: Collect configuration values from the user
    - ALWAYS provide 'variables' — never call collect without them
    - Call ONLY immediately before running or testing the project — never during code writing
-   - Shows a form; nothing is written until the user confirms. If skipped, no file is created or modified
+   - Shows a form; nothing is written until the user confirms. If the whole collection is cancelled, no file is created or modified
+   - User may skip individual fields. The result message and 'userSkipped' field list the names not provided; decide whether to call collect again or proceed
    - Pre-populates from existing Config.toml if it exists
    - When running tests, use isTestConfig: true — this is the only collect call needed; writes to tests/Config.toml after user confirms
    - For workspace projects, you MUST pass packagePath so the file is written inside the target package (not the workspace root)
@@ -219,7 +245,7 @@ function analyzeExistingConfig(
 
     for (const name of variableNames) {
         const value = existingValues[name];
-        if (value && !value.startsWith('${')) {
+        if (value && !isPlaceholderValue(value)) {
             filledCount++;
         } else {
             placeholderCount++;
@@ -459,8 +485,16 @@ async function handleCollectMode(
         };
     }
 
-    // Write actual configuration values to determined config path
-    writeConfigValuesToConfig(configPath, userResponse.configValues!, enrichedVariables, orgName, packageName);
+    // Split provided values from skipped names; only write what the user actually filled.
+    const { provided, notProvided } = classifySubmission(enrichedVariables, userResponse.configValues!);
+
+    // Skipped names that had a non-placeholder existing value are preserved silently on disk;
+    // the agent only needs to know about the ones truly missing from Config.toml.
+    const skippedNew = notProvided.filter(
+        name => !existingValues[name] || isPlaceholderValue(existingValues[name])
+    );
+
+    writeConfigValuesToConfig(configPath, provided, enrichedVariables, orgName, packageName);
 
     // Track modified file for syncing to workspace.
     // Path is relative to tempProjectPath, so prefix with packagePath for workspace projects.
@@ -474,10 +508,10 @@ async function handleCollectMode(
         }
     }
 
-    // Convert to status metadata (filled/missing) - NEVER return actual values to agent
-    const statusMetadata = createStatusMetadata(userResponse.configValues!);
+    // Status reflects post-write Config.toml: "filled" includes preserved existing values.
+    const statusMetadata = computeCollectStatus(enrichedVariables, provided, existingValues);
 
-    // Clear values from memory
+    // Clear values from memory; NEVER return actual values to agent
     userResponse.configValues = undefined;
 
     // Success - configuration values were collected and written
@@ -492,10 +526,16 @@ async function handleCollectMode(
         isTestConfig,
     });
 
+    const userNote = userResponse.comment ? ". User note: " + userResponse.comment : "";
+    const message = skippedNew.length > 0
+        ? `Saved ${Object.keys(provided).length} configuration value(s) to ${configFileName}. User did not provide: [${skippedNew.join(", ")}]. These values are NOT in Config.toml. Ballerina will error at runtime until they are set. Call collect again to prompt the user, or proceed if the next step does not require them${userNote}`
+        : `Successfully collected ${Object.keys(provided).length} configuration value(s) and saved to ${configFileName}${userNote}`;
+
     return {
         success: true,
-        message: `Successfully collected ${enrichedVariables.length} configuration value(s) and saved to ${configFileName}${userResponse.comment ? ". User note: " + userResponse.comment : ""}`,
+        message,
         status: statusMetadata,
+        ...(skippedNew.length > 0 ? { userSkipped: skippedNew } : {}),
     };
 }
 

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/config-collector.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/config-collector.ts
@@ -187,7 +187,7 @@ Operation Modes:
    - ALWAYS provide 'variables' — never call collect without them
    - Call ONLY immediately before running or testing the project — never during code writing
    - Shows a form; nothing is written until the user confirms. If the whole collection is cancelled, no file is created or modified
-   - User may skip individual fields. The result message and 'userSkipped' field list the names not provided; decide whether to call collect again or proceed
+   - User may skip individual fields ('userSkipped' lists them). Do not re-prompt immediately. Only ask once more later if a value is truly needed for the run; if the user skips again, stop calling collect and tell them in chat what is missing
    - Pre-populates from existing Config.toml if it exists
    - When running tests, use isTestConfig: true — this is the only collect call needed; writes to tests/Config.toml after user confirms
    - For workspace projects, you MUST pass packagePath so the file is written inside the target package (not the workspace root)
@@ -479,7 +479,7 @@ async function handleCollectMode(
 
         return {
             success: false,
-            message: `User skipped configuration collection${userResponse.comment ? ": " + userResponse.comment : ""}. You can ask user to provide values later using collect mode.`,
+            message: `User cancelled configuration collection${userResponse.comment ? ": " + userResponse.comment : ""}.`,
             error: `User skipped${userResponse.comment ? ": " + userResponse.comment : ""}`,
             errorCode: "USER_CANCELLED",
         };
@@ -528,8 +528,8 @@ async function handleCollectMode(
 
     const userNote = userResponse.comment ? ". User note: " + userResponse.comment : "";
     const message = skippedNew.length > 0
-        ? `Saved ${Object.keys(provided).length} configuration value(s) to ${configFileName}. User did not provide: [${skippedNew.join(", ")}]. These values are NOT in Config.toml. Ballerina will error at runtime until they are set. Call collect again to prompt the user, or proceed if the next step does not require them${userNote}`
-        : `Successfully collected ${Object.keys(provided).length} configuration value(s) and saved to ${configFileName}${userNote}`;
+        ? `Saved ${Object.keys(provided).length} value(s) to ${configFileName}. User skipped: [${skippedNew.join(", ")}]${userNote}`
+        : `Saved ${Object.keys(provided).length} configuration value(s) to ${configFileName}${userNote}`;
 
     return {
         success: true,

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/config-collector.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/config-collector.ts
@@ -23,11 +23,14 @@ import { CopilotEventHandler } from "../../utils/events";
 import { approvalManager } from "../../state/ApprovalManager";
 import {
     ConfigVariable,
+    ConfigKeyRename,
     getAllConfigStatus,
     validateVariableName,
     writeConfigValuesToConfig,
     createStatusMetadata,
     readExistingConfigValues,
+    removeConfigKeys,
+    renameConfigKeys,
 } from "../../../../utils/toml-utils";
 import { resolveContained, resolvePackageBasePath } from "./path-utils";
 import { getOrgPackageName } from "../../../../utils/config";
@@ -45,13 +48,20 @@ const ConfigVariableSchema = z.object({
     secret: z.boolean().optional().describe("Mark as true for sensitive values (API keys, passwords, tokens) to render as a masked input"),
 });
 
+const ConfigKeyRenameSchema = z.object({
+    from: z.string().describe("Current variable name in Config.toml"),
+    to: z.string().describe("New variable name — must match the renamed configurable identifier in source"),
+});
+
 const ConfigCollectorSchema = z.object({
-    mode: z.enum(["collect", "check"]).describe("Operation mode"),
+    mode: z.enum(["collect", "check", "remove", "rename"]).describe("Operation mode"),
     filePath: z.string().optional().describe("Path to config file (for check mode)"),
-    variables: z.array(ConfigVariableSchema).optional().describe("Configuration variables"),
+    variables: z.array(ConfigVariableSchema).optional().describe("Configuration variables (collect mode)"),
     variableNames: z.array(z.string()).optional().describe(
-        "Variable names to verify in check mode. " +
-        "Omit to discover ALL existing variable names in the file — useful when you want to reuse names that are already there."
+        "Variable names — used by 'check' (verify; omit to list all) and 'remove' (keys to delete)."
+    ),
+    renames: z.array(ConfigKeyRenameSchema).optional().describe(
+        "Rename pairs for 'rename' mode. The 'to' name must already exist as a configurable in source."
     ),
     isTestConfig: z.boolean().optional().describe("Set to true when collecting configuration for tests. Tool will automatically read from Config.toml and write to tests/Config.toml"),
     packagePath: z.string().optional().describe(
@@ -62,10 +72,11 @@ const ConfigCollectorSchema = z.object({
 });
 
 interface ConfigCollectorInput {
-    mode: "collect" | "check";
+    mode: "collect" | "check" | "remove" | "rename";
     filePath?: string;
     variables?: ConfigVariable[];
     variableNames?: string[];
+    renames?: ConfigKeyRename[];
     isTestConfig?: boolean;
     packagePath?: string;
 }
@@ -166,6 +177,12 @@ Operation Modes:
    - Example (workspace): { mode: "check", packagePath: "pkg1" }
    - Returns: { status: { dbPassword: "filled", apiKey: "missing" } }
 
+3. REMOVE: Delete keys from Config.toml.
+
+4. RENAME: Rename keys in Config.toml, preserving values. Rename the configurable in source first — the 'to' name must already match a source declaration.
+
+Prefer REMOVE/RENAME over adding a dummy configurable to suppress unused-key errors.
+
 VARIABLE NAMING:
 Use camelCase names that match exactly the Ballerina configurable identifier. The name is written as-is to Config.toml.
 
@@ -257,6 +274,24 @@ export async function ConfigCollectorTool(
                     input.filePath,
                     paths,
                     input.isTestConfig,
+                    input.packagePath
+                );
+
+            case "remove":
+                return await handleRemoveMode(
+                    input.variableNames,
+                    paths,
+                    input.isTestConfig,
+                    modifiedFiles,
+                    input.packagePath
+                );
+
+            case "rename":
+                return await handleRenameMode(
+                    input.renames,
+                    paths,
+                    input.isTestConfig,
+                    modifiedFiles,
                     input.packagePath
                 );
 
@@ -526,6 +561,157 @@ async function handleCheckMode(
             `filled: [${filledNames.join(", ") || "none"}], ` +
             `missing: [${missingNames.join(", ") || "none"}]`,
         status,
+    };
+}
+
+async function handleRemoveMode(
+    variableNames: string[] | undefined,
+    paths: ConfigCollectorPaths,
+    isTestConfig: boolean | undefined,
+    modifiedFiles: string[] | undefined,
+    packagePath: string | undefined
+): Promise<ConfigCollectorResult> {
+    if (!variableNames || variableNames.length === 0) {
+        return createErrorResult(
+            "NO_VARIABLES",
+            "No variable names provided to remove. Pass 'variableNames' with the keys to delete from Config.toml."
+        );
+    }
+    for (const name of variableNames) {
+        if (!validateVariableName(name)) {
+            return createErrorResult(
+                "INVALID_VARIABLE_NAME",
+                `Invalid variable name: ${name}. Use camelCase alphanumeric names (e.g., apiKey).`
+            );
+        }
+    }
+
+    const packageBasePath = resolvePackageBasePath(paths.tempPath, packagePath);
+    const { orgName, packageName } = getOrgPackageName(packageBasePath);
+    if (!orgName || !packageName) {
+        return createErrorResult(
+            "MISSING_PACKAGE_INFO",
+            "Ballerina.toml is missing or does not declare both 'org' and 'name' under [package]. Cannot scope Config.toml to the correct section."
+        );
+    }
+
+    const configPath = getConfigPath(packageBasePath, isTestConfig);
+    const configFileName = getConfigFileName(isTestConfig);
+
+    if (!fs.existsSync(configPath)) {
+        return {
+            success: true,
+            message: `${configFileName} does not exist — nothing to remove.`,
+        };
+    }
+
+    const { removed, notFound } = removeConfigKeys(configPath, variableNames, orgName, packageName);
+
+    if (removed.length > 0 && modifiedFiles) {
+        const relativeConfigPath = packagePath
+            ? path.join(packagePath, configFileName)
+            : configFileName;
+        if (!modifiedFiles.includes(relativeConfigPath)) {
+            modifiedFiles.push(relativeConfigPath);
+        }
+    }
+
+    console.log(`[ConfigCollector] remove ${configFileName} — removed: [${removed.join(", ") || "none"}], not found: [${notFound.join(", ") || "none"}]`);
+
+    const parts: string[] = [];
+    if (removed.length > 0) { parts.push(`removed: [${removed.join(", ")}]`); }
+    if (notFound.length > 0) { parts.push(`not found: [${notFound.join(", ")}]`); }
+
+    return {
+        success: true,
+        message: `${configFileName} — ${parts.join(", ") || "no changes"}`,
+    };
+}
+
+async function handleRenameMode(
+    renames: ConfigKeyRename[] | undefined,
+    paths: ConfigCollectorPaths,
+    isTestConfig: boolean | undefined,
+    modifiedFiles: string[] | undefined,
+    packagePath: string | undefined
+): Promise<ConfigCollectorResult> {
+    if (!renames || renames.length === 0) {
+        return createErrorResult(
+            "NO_RENAMES",
+            "No rename pairs provided. Pass 'renames' as an array of { from, to } objects."
+        );
+    }
+    for (const { from, to } of renames) {
+        if (!validateVariableName(from) || !validateVariableName(to)) {
+            return createErrorResult(
+                "INVALID_VARIABLE_NAME",
+                `Invalid variable name in rename pair: ${from} → ${to}. Use camelCase alphanumeric names.`
+            );
+        }
+    }
+
+    const packageBasePath = resolvePackageBasePath(paths.tempPath, packagePath);
+    const { orgName, packageName } = getOrgPackageName(packageBasePath);
+    if (!orgName || !packageName) {
+        return createErrorResult(
+            "MISSING_PACKAGE_INFO",
+            "Ballerina.toml is missing or does not declare both 'org' and 'name' under [package]. Cannot scope Config.toml to the correct section."
+        );
+    }
+
+    // The target name must exist in source — the agent should have renamed the
+    // configurable declaration and saved before calling rename.
+    const sourceTypes = await getConfigurableTypesFromSource(packageBasePath, orgName, packageName);
+    if (sourceTypes === null) {
+        return createErrorResult(
+            "LS_UNAVAILABLE",
+            "Language server is unavailable or failed to respond. Wait a moment and retry."
+        );
+    }
+    const unknownTargets = renames.filter(r => !(r.to in sourceTypes));
+    if (unknownTargets.length > 0) {
+        return createErrorResult(
+            "UNKNOWN_CONFIGURABLE",
+            `Target names not declared in source: ${unknownTargets.map(r => r.to).join(", ")}. ` +
+            `Available in source: ${Object.keys(sourceTypes).join(", ") || "none"}. ` +
+            `Rename the configurable in your .bal files and save first, then retry.`
+        );
+    }
+
+    const configPath = getConfigPath(packageBasePath, isTestConfig);
+    const configFileName = getConfigFileName(isTestConfig);
+
+    if (!fs.existsSync(configPath)) {
+        return createErrorResult(
+            "FILE_NOT_FOUND",
+            `${configFileName} does not exist — nothing to rename. Use collect mode to create entries for the new names.`
+        );
+    }
+
+    const { renamed, skipped } = renameConfigKeys(configPath, renames, orgName, packageName);
+
+    if (renamed.length > 0 && modifiedFiles) {
+        const relativeConfigPath = packagePath
+            ? path.join(packagePath, configFileName)
+            : configFileName;
+        if (!modifiedFiles.includes(relativeConfigPath)) {
+            modifiedFiles.push(relativeConfigPath);
+        }
+    }
+
+    console.log(`[ConfigCollector] rename ${configFileName} — renamed: [${renamed.map(r => `${r.from}->${r.to}`).join(", ") || "none"}], skipped: [${skipped.map(s => `${s.from}->${s.to}`).join(", ") || "none"}]`);
+
+    const parts: string[] = [];
+    if (renamed.length > 0) {
+        parts.push(`renamed: [${renamed.map(r => `${r.from}→${r.to}`).join(", ")}]`);
+    }
+    if (skipped.length > 0) {
+        parts.push(`skipped: [${skipped.map(s => `${s.from}→${s.to} (${s.reason})`).join(", ")}]`);
+    }
+
+    return {
+        success: renamed.length > 0,
+        message: `${configFileName} — ${parts.join(", ") || "no changes"}`,
     };
 }
 

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/config-collector.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/config-collector.ts
@@ -446,7 +446,8 @@ async function handleCollectMode(
         variables.map(v => v.name)
     );
 
-    console.log(`[ConfigCollector] ${isTestConfig ? 'Test' : 'Main'} configuration: ${analysis.filledCount} filled`);
+    const configFileName = getConfigFileName(isTestConfig);
+    console.log(`[ConfigCollector] collect requested=${enrichedVariables.length} preFilled=${analysis.filledCount} file=${configFileName}`);
 
     // Determine the message to show to user
     const userMessage = isTestConfig
@@ -469,6 +470,7 @@ async function handleCollectMode(
     );
 
     if (!userResponse.provided) {
+        console.log(`[ConfigCollector] collect cancelled file=${configFileName}`);
         eventHandler({
             type: "configuration_collection_event",
             requestId,
@@ -494,12 +496,15 @@ async function handleCollectMode(
         name => !existingValues[name] || isPlaceholderValue(existingValues[name])
     );
 
+    const providedCount = Object.keys(provided).length;
+    const preservedCount = notProvided.length - skippedNew.length;
+    console.log(`[ConfigCollector] collect saved=${providedCount} skippedNew=${skippedNew.length} preserved=${preservedCount} requested=${enrichedVariables.length} file=${configFileName}`);
+
     writeConfigValuesToConfig(configPath, provided, enrichedVariables, orgName, packageName);
 
     // Track modified file for syncing to workspace.
     // Path is relative to tempProjectPath, so prefix with packagePath for workspace projects.
     if (modifiedFiles) {
-        const configFileName = getConfigFileName(isTestConfig);
         const relativeConfigPath = packagePath
             ? path.join(packagePath, configFileName)
             : configFileName;
@@ -514,8 +519,6 @@ async function handleCollectMode(
     // Clear values from memory; NEVER return actual values to agent
     userResponse.configValues = undefined;
 
-    // Success - configuration values were collected and written
-    const configFileName = getConfigFileName(isTestConfig);
     eventHandler({
         type: "configuration_collection_event",
         requestId,
@@ -528,8 +531,8 @@ async function handleCollectMode(
 
     const userNote = userResponse.comment ? ". User note: " + userResponse.comment : "";
     const message = skippedNew.length > 0
-        ? `Saved ${Object.keys(provided).length} value(s) to ${configFileName}. User skipped: [${skippedNew.join(", ")}]${userNote}`
-        : `Saved ${Object.keys(provided).length} configuration value(s) to ${configFileName}${userNote}`;
+        ? `Saved ${providedCount} value(s) to ${configFileName}. User skipped: [${skippedNew.join(", ")}]${userNote}`
+        : `Saved ${providedCount} configuration value(s) to ${configFileName}${userNote}`;
 
     return {
         success: true,
@@ -592,12 +595,12 @@ async function handleCheckMode(
     const filledNames = Object.entries(status).filter(([, s]) => s === "filled").map(([n]) => n);
     const missingNames = Object.entries(status).filter(([, s]) => s === "missing").map(([n]) => n);
 
-    console.log(`[ConfigCollector] check ${configFileName} — filled: [${filledNames.join(", ") || "none"}], missing: [${missingNames.join(", ") || "none"}]`);
+    console.log(`[ConfigCollector] check ${configFileName} filled=${filledNames.length} missing=${missingNames.length}`);
 
     return {
         success: true,
         message:
-            `${configFileName} — ` +
+            `${configFileName}: ` +
             `filled: [${filledNames.join(", ") || "none"}], ` +
             `missing: [${missingNames.join(", ") || "none"}]`,
         status,
@@ -641,7 +644,7 @@ async function handleRemoveMode(
     if (!fs.existsSync(configPath)) {
         return {
             success: true,
-            message: `${configFileName} does not exist — nothing to remove.`,
+            message: `${configFileName} does not exist; nothing to remove.`,
         };
     }
 
@@ -656,7 +659,7 @@ async function handleRemoveMode(
         }
     }
 
-    console.log(`[ConfigCollector] remove ${configFileName} — removed: [${removed.join(", ") || "none"}], not found: [${notFound.join(", ") || "none"}]`);
+    console.log(`[ConfigCollector] remove ${configFileName} removed=${removed.length} notFound=${notFound.length}`);
 
     const parts: string[] = [];
     if (removed.length > 0) { parts.push(`removed: [${removed.join(", ")}]`); }
@@ -664,7 +667,7 @@ async function handleRemoveMode(
 
     return {
         success: true,
-        message: `${configFileName} — ${parts.join(", ") || "no changes"}`,
+        message: `${configFileName}: ${parts.join(", ") || "no changes"}`,
     };
 }
 
@@ -724,7 +727,7 @@ async function handleRenameMode(
     if (!fs.existsSync(configPath)) {
         return createErrorResult(
             "FILE_NOT_FOUND",
-            `${configFileName} does not exist — nothing to rename. Use collect mode to create entries for the new names.`
+            `${configFileName} does not exist; nothing to rename. Use collect mode to create entries for the new names.`
         );
     }
 
@@ -739,19 +742,19 @@ async function handleRenameMode(
         }
     }
 
-    console.log(`[ConfigCollector] rename ${configFileName} — renamed: [${renamed.map(r => `${r.from}->${r.to}`).join(", ") || "none"}], skipped: [${skipped.map(s => `${s.from}->${s.to}`).join(", ") || "none"}]`);
+    console.log(`[ConfigCollector] rename ${configFileName} renamed=${renamed.length} skipped=${skipped.length}`);
 
     const parts: string[] = [];
     if (renamed.length > 0) {
-        parts.push(`renamed: [${renamed.map(r => `${r.from}→${r.to}`).join(", ")}]`);
+        parts.push(`renamed: [${renamed.map(r => `${r.from} -> ${r.to}`).join(", ")}]`);
     }
     if (skipped.length > 0) {
-        parts.push(`skipped: [${skipped.map(s => `${s.from}→${s.to} (${s.reason})`).join(", ")}]`);
+        parts.push(`skipped: [${skipped.map(s => `${s.from} -> ${s.to} (${s.reason})`).join(", ")}]`);
     }
 
     return {
         success: renamed.length > 0,
-        message: `${configFileName} — ${parts.join(", ") || "no changes"}`,
+        message: `${configFileName}: ${parts.join(", ") || "no changes"}`,
     };
 }
 

--- a/workspaces/ballerina/ballerina-extension/src/utils/toml-utils.ts
+++ b/workspaces/ballerina/ballerina-extension/src/utils/toml-utils.ts
@@ -25,6 +25,10 @@ export interface ConfigVariable {
     secret?: boolean;
 }
 
+export function isPlaceholderValue(value: string | undefined | null): boolean {
+    return typeof value === "string" && /^\$\{[^}]+\}$/.test(value);
+}
+
 function readTomlSection(
     configPath: string,
     orgName: string,
@@ -188,6 +192,21 @@ export function createStatusMetadata(
     const status: Record<string, "filled" | "missing"> = {};
     for (const [key, value] of Object.entries(configValues)) {
         status[key] = value && value.trim() !== "" ? "filled" : "missing";
+    }
+    return status;
+}
+
+// "filled" when we just wrote a value OR a non-placeholder existing value was preserved.
+export function computeCollectStatus(
+    variables: ConfigVariable[],
+    provided: Record<string, string>,
+    existingValues: Record<string, string>
+): Record<string, "filled" | "missing"> {
+    const status: Record<string, "filled" | "missing"> = {};
+    for (const { name } of variables) {
+        const wrote = name in provided && provided[name].trim() !== "";
+        const preserved = !wrote && !!existingValues[name] && !isPlaceholderValue(existingValues[name]);
+        status[name] = wrote || preserved ? "filled" : "missing";
     }
     return status;
 }

--- a/workspaces/ballerina/ballerina-extension/src/utils/toml-utils.ts
+++ b/workspaces/ballerina/ballerina-extension/src/utils/toml-utils.ts
@@ -191,3 +191,105 @@ export function createStatusMetadata(
     }
     return status;
 }
+
+export interface ConfigKeyRename {
+    from: string;
+    to: string;
+}
+
+export function removeConfigKeys(
+    configPath: string,
+    keys: string[],
+    orgName: string,
+    packageName: string
+): { removed: string[]; notFound: string[] } {
+    if (!fs.existsSync(configPath)) {
+        return { removed: [], notFound: [...keys] };
+    }
+
+    let config: Record<string, any>;
+    try {
+        config = parse(fs.readFileSync(configPath, "utf-8")) as Record<string, any>;
+    } catch (error) {
+        console.error(`[TOML Utils] Error reading config for key removal:`, error);
+        throw error;
+    }
+
+    const section = config[orgName]?.[packageName];
+    if (!section || typeof section !== "object") {
+        return { removed: [], notFound: [...keys] };
+    }
+
+    const removed: string[] = [];
+    const notFound: string[] = [];
+    for (const key of keys) {
+        if (key in section && typeof section[key] !== "object") {
+            delete section[key];
+            removed.push(key);
+        } else {
+            notFound.push(key);
+        }
+    }
+
+    if (removed.length > 0) {
+        fs.writeFileSync(configPath, stringify(config), "utf-8");
+        console.log(`[TOML Utils] Removed ${removed.length} key(s) from Config.toml`);
+    }
+    return { removed, notFound };
+}
+
+export function renameConfigKeys(
+    configPath: string,
+    renames: ConfigKeyRename[],
+    orgName: string,
+    packageName: string
+): { renamed: ConfigKeyRename[]; skipped: { from: string; to: string; reason: string }[] } {
+    if (!fs.existsSync(configPath)) {
+        return {
+            renamed: [],
+            skipped: renames.map(r => ({ ...r, reason: "Config.toml not found" })),
+        };
+    }
+
+    let config: Record<string, any>;
+    try {
+        config = parse(fs.readFileSync(configPath, "utf-8")) as Record<string, any>;
+    } catch (error) {
+        console.error(`[TOML Utils] Error reading config for key rename:`, error);
+        throw error;
+    }
+
+    const section = config[orgName]?.[packageName];
+    if (!section || typeof section !== "object") {
+        return {
+            renamed: [],
+            skipped: renames.map(r => ({ ...r, reason: `[${orgName}.${packageName}] section not found` })),
+        };
+    }
+
+    const renamed: ConfigKeyRename[] = [];
+    const skipped: { from: string; to: string; reason: string }[] = [];
+    for (const { from, to } of renames) {
+        if (from === to) {
+            skipped.push({ from, to, reason: "'from' and 'to' are the same" });
+            continue;
+        }
+        if (!(from in section) || typeof section[from] === "object") {
+            skipped.push({ from, to, reason: `'${from}' not found in Config.toml` });
+            continue;
+        }
+        if (to in section) {
+            skipped.push({ from, to, reason: `target key '${to}' already exists` });
+            continue;
+        }
+        section[to] = section[from];
+        delete section[from];
+        renamed.push({ from, to });
+    }
+
+    if (renamed.length > 0) {
+        fs.writeFileSync(configPath, stringify(config), "utf-8");
+        console.log(`[TOML Utils] Renamed ${renamed.length} key(s) in Config.toml`);
+    }
+    return { renamed, skipped };
+}

--- a/workspaces/ballerina/ballerina-extension/src/utils/toml-utils.ts
+++ b/workspaces/ballerina/ballerina-extension/src/utils/toml-utils.ts
@@ -197,14 +197,20 @@ export interface ConfigKeyRename {
     to: string;
 }
 
+function isPlainSection(value: any): value is Record<string, any> {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
 export function removeConfigKeys(
     configPath: string,
     keys: string[],
     orgName: string,
     packageName: string
 ): { removed: string[]; notFound: string[] } {
+    const uniqueKeys = Array.from(new Set(keys));
+
     if (!fs.existsSync(configPath)) {
-        return { removed: [], notFound: [...keys] };
+        return { removed: [], notFound: uniqueKeys };
     }
 
     let config: Record<string, any>;
@@ -216,14 +222,14 @@ export function removeConfigKeys(
     }
 
     const section = config[orgName]?.[packageName];
-    if (!section || typeof section !== "object") {
-        return { removed: [], notFound: [...keys] };
+    if (!isPlainSection(section)) {
+        return { removed: [], notFound: uniqueKeys };
     }
 
     const removed: string[] = [];
     const notFound: string[] = [];
-    for (const key of keys) {
-        if (key in section && typeof section[key] !== "object") {
+    for (const key of uniqueKeys) {
+        if (Object.prototype.hasOwnProperty.call(section, key)) {
             delete section[key];
             removed.push(key);
         } else {
@@ -260,29 +266,54 @@ export function renameConfigKeys(
     }
 
     const section = config[orgName]?.[packageName];
-    if (!section || typeof section !== "object") {
+    if (!isPlainSection(section)) {
         return {
             renamed: [],
             skipped: renames.map(r => ({ ...r, reason: `[${orgName}.${packageName}] section not found` })),
         };
     }
 
+    // Snapshot initial state so multi-pair renames don't chain (a→b, b→c).
+    const initialKeys = new Set(Object.keys(section));
+    const initialValues: Record<string, any> = {};
+    for (const key of initialKeys) {
+        initialValues[key] = section[key];
+    }
+
     const renamed: ConfigKeyRename[] = [];
     const skipped: { from: string; to: string; reason: string }[] = [];
+    const sourcesUsed = new Set<string>();
+    const targetsUsed = new Set<string>();
+    const toApply: ConfigKeyRename[] = [];
+
     for (const { from, to } of renames) {
         if (from === to) {
             skipped.push({ from, to, reason: "'from' and 'to' are the same" });
             continue;
         }
-        if (!(from in section) || typeof section[from] === "object") {
+        if (!initialKeys.has(from)) {
             skipped.push({ from, to, reason: `'${from}' not found in Config.toml` });
             continue;
         }
-        if (to in section) {
+        if (initialKeys.has(to)) {
             skipped.push({ from, to, reason: `target key '${to}' already exists` });
             continue;
         }
-        section[to] = section[from];
+        if (sourcesUsed.has(from)) {
+            skipped.push({ from, to, reason: `duplicate rename of '${from}'` });
+            continue;
+        }
+        if (targetsUsed.has(to)) {
+            skipped.push({ from, to, reason: `duplicate target '${to}'` });
+            continue;
+        }
+        sourcesUsed.add(from);
+        targetsUsed.add(to);
+        toApply.push({ from, to });
+    }
+
+    for (const { from, to } of toApply) {
+        section[to] = initialValues[from];
         delete section[from];
         renamed.push({ from, to });
     }

--- a/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/ConfigurationCollector/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/ConfigurationCollector/index.tsx
@@ -148,6 +148,25 @@ const ConfirmBarIcon = styled.span`
     align-items: center;
 `;
 
+const ErrorBar = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 20px;
+    background-color: ${ThemeColors.SURFACE_DIM};
+    border-top: 1px solid ${ThemeColors.ERROR};
+    color: ${ThemeColors.ERROR};
+    font-size: 12px;
+    line-height: 1.4;
+`;
+
+const ErrorBarIcon = styled.span`
+    flex-shrink: 0;
+    color: ${ThemeColors.ERROR};
+    display: inline-flex;
+    align-items: center;
+`;
+
 const FooterHint = styled.span`
     margin-right: auto;
     align-self: center;
@@ -348,12 +367,14 @@ export const ConfigurationCollector: React.FC<ConfigurationCollectorProps> = ({ 
     const [errors, setErrors] = useState<Record<string, string>>({});
     const [mode, setMode] = useState<CollectorMode>("editing");
     const [visibleFields, setVisibleFields] = useState<Record<string, boolean>>({});
+    const [submitError, setSubmitError] = useState<string | null>(null);
 
     useEffect(() => {
         setConfigValues(buildInitialValues(data));
         setVisibleFields({});
         setErrors({});
         setMode("editing");
+        setSubmitError(null);
     }, [data]);
 
     const handleInputChange = (variableName: string, value: string) => {
@@ -365,6 +386,7 @@ export const ConfigurationCollector: React.FC<ConfigurationCollectorProps> = ({ 
         });
         // Any edit invalidates the empty-fields warning; re-evaluate on next Save.
         setMode((current) => (current === "confirming" ? "editing" : current));
+        setSubmitError(null);
     };
 
     const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -385,6 +407,7 @@ export const ConfigurationCollector: React.FC<ConfigurationCollectorProps> = ({ 
 
     const submitToBackend = async () => {
         if (!data) return;
+        setSubmitError(null);
         setMode("processing");
         try {
             await rpcClient.getAiPanelRpcClient().provideConfiguration({
@@ -394,6 +417,8 @@ export const ConfigurationCollector: React.FC<ConfigurationCollectorProps> = ({ 
             onClose();
         } catch (error: any) {
             console.error("[ConfigurationCollector] Error in submitToBackend:", error);
+            const message = (error && typeof error.message === "string" && error.message) || "Failed to save configuration. Please try again.";
+            setSubmitError(message);
             setMode("editing");
         }
     };
@@ -504,6 +529,14 @@ export const ConfigurationCollector: React.FC<ConfigurationCollectorProps> = ({ 
                             Empty fields will not be saved: <b>{emptyNames.join(", ")}</b>
                         </span>
                     </ConfirmBar>
+                )}
+                {submitError && (
+                    <ErrorBar>
+                        <ErrorBarIcon>
+                            <Codicon name="error" />
+                        </ErrorBarIcon>
+                        <span>{submitError}</span>
+                    </ErrorBar>
                 )}
                 <PopupFooter>
                     {mode === "confirming" ? (

--- a/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/ConfigurationCollector/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/ConfigurationCollector/index.tsx
@@ -129,6 +129,32 @@ const FieldError = styled.div`
     color: ${ThemeColors.ERROR};
 `;
 
+const ConfirmBar = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 20px;
+    background-color: ${ThemeColors.SURFACE_DIM};
+    border-top: 1px solid ${ThemeColors.OUTLINE_VARIANT};
+    color: ${ThemeColors.ON_SURFACE_VARIANT};
+    font-size: 12px;
+    line-height: 1.4;
+`;
+
+const ConfirmBarIcon = styled.span`
+    flex-shrink: 0;
+    color: ${ThemeColors.ON_SURFACE_VARIANT};
+    display: inline-flex;
+    align-items: center;
+`;
+
+const FooterHint = styled.span`
+    margin-right: auto;
+    align-self: center;
+    font-size: 12px;
+    color: ${ThemeColors.ON_SURFACE_VARIANT};
+`;
+
 const ActionButton = styled(Button)``;
 
 const LoadingContainer = styled.div`
@@ -167,7 +193,7 @@ function getFieldConfig(type: string | undefined): FieldConfig {
             inputKind: "number",
             placeholder: "Enter integer",
             validate: (v) => {
-                if (!v.trim()) return "This field is required";
+                if (!v.trim()) return null;
                 if (isNaN(parseInt(v, 10)) || !Number.isInteger(parseFloat(v))) return "Enter a valid integer";
                 return null;
             },
@@ -178,7 +204,7 @@ function getFieldConfig(type: string | undefined): FieldConfig {
             inputKind: "number",
             placeholder: "Enter number",
             validate: (v) => {
-                if (!v.trim()) return "This field is required";
+                if (!v.trim()) return null;
                 if (isNaN(parseFloat(v))) return "Enter a valid number";
                 return null;
             },
@@ -199,8 +225,20 @@ function getFieldConfig(type: string | undefined): FieldConfig {
     return {
         inputKind: "text",
         placeholder: "Enter value",
-        validate: (v) => (!v || !v.trim() ? "This field is required" : null),
+        validate: () => null,
     };
+}
+
+function isPlaceholderValue(value: string | undefined | null): boolean {
+    return typeof value === "string" && /^\$\{[^}]+\}$/.test(value);
+}
+
+function getEmptyFieldNames(
+    variables: { name: string }[] | undefined,
+    values: Record<string, string>
+): string[] {
+    if (!variables) return [];
+    return variables.filter(v => !values[v.name] || !values[v.name].trim()).map(v => v.name);
 }
 
 // ─── ConfigField sub-component ────────────────────────────────────────────────
@@ -287,6 +325,12 @@ interface ConfigurationCollectorProps {
 
 function buildInitialValues(data: ConfigurationCollectorMetadata | undefined): Record<string, string> {
     const values: Record<string, string> = { ...(data?.existingValues ?? {}) };
+    // Hide `${VAR}` env-var placeholders so the input renders blank; the user can re-enter or leave skipped.
+    for (const name of Object.keys(values)) {
+        if (isPlaceholderValue(values[name])) {
+            values[name] = "";
+        }
+    }
     data?.variables?.forEach((v) => {
         const config = getFieldConfig(v.type);
         if (!(v.name in values) && config.defaultValue !== undefined) {
@@ -296,16 +340,20 @@ function buildInitialValues(data: ConfigurationCollectorMetadata | undefined): R
     return values;
 }
 
+type CollectorMode = "editing" | "confirming" | "processing";
+
 export const ConfigurationCollector: React.FC<ConfigurationCollectorProps> = ({ data, onClose }) => {
     const { rpcClient } = useRpcContext();
     const [configValues, setConfigValues] = useState<Record<string, string>>(buildInitialValues(data));
     const [errors, setErrors] = useState<Record<string, string>>({});
-    const [isProcessing, setIsProcessing] = useState(false);
+    const [mode, setMode] = useState<CollectorMode>("editing");
     const [visibleFields, setVisibleFields] = useState<Record<string, boolean>>({});
 
     useEffect(() => {
         setConfigValues(buildInitialValues(data));
         setVisibleFields({});
+        setErrors({});
+        setMode("editing");
     }, [data]);
 
     const handleInputChange = (variableName: string, value: string) => {
@@ -315,10 +363,12 @@ export const ConfigurationCollector: React.FC<ConfigurationCollectorProps> = ({ 
             delete next[variableName];
             return next;
         });
+        // Any edit invalidates the empty-fields warning; re-evaluate on next Save.
+        setMode((current) => (current === "confirming" ? "editing" : current));
     };
 
     const handleKeyDown = (e: React.KeyboardEvent) => {
-        if (e.key === "Enter" && !isProcessing) {
+        if (e.key === "Enter" && mode !== "processing") {
             handleSubmit();
         }
     };
@@ -333,34 +383,42 @@ export const ConfigurationCollector: React.FC<ConfigurationCollectorProps> = ({ 
         return Object.keys(newErrors).length === 0;
     };
 
-    const handleSubmit = async () => {
+    const submitToBackend = async () => {
         if (!data) return;
-
-        console.log("[ConfigurationCollector] handleSubmit called", {
-            requestId: data.requestId,
-            configurationCount: Object.keys(configValues).length,
-        });
-
-        if (!validateConfiguration()) {
-            console.log("[ConfigurationCollector] Validation failed");
-            return;
-        }
-
-        setIsProcessing(true);
-
+        setMode("processing");
         try {
-            console.log("[ConfigurationCollector] Calling provideConfiguration RPC");
             await rpcClient.getAiPanelRpcClient().provideConfiguration({
                 requestId: data.requestId,
                 configValues: configValues,
             });
-            console.log("[ConfigurationCollector] RPC call successful");
             onClose();
         } catch (error: any) {
-            console.error("[ConfigurationCollector] Error in handleSubmit:", error);
-        } finally {
-            setIsProcessing(false);
+            console.error("[ConfigurationCollector] Error in submitToBackend:", error);
+            setMode("editing");
         }
+    };
+
+    const handleSubmit = async () => {
+        if (!data || mode === "processing") return;
+
+        if (!validateConfiguration()) {
+            return;
+        }
+
+        // From confirming, Save anyway commits.
+        if (mode === "confirming") {
+            await submitToBackend();
+            return;
+        }
+
+        // From editing, show confirm step when any required-by-user value is blank.
+        const emptyNames = getEmptyFieldNames(data.variables, configValues);
+        if (emptyNames.length > 0) {
+            setMode("confirming");
+            return;
+        }
+
+        await submitToBackend();
     };
 
     const handleCancel = async () => {
@@ -377,6 +435,10 @@ export const ConfigurationCollector: React.FC<ConfigurationCollectorProps> = ({ 
         }
         onClose();
     };
+
+    const handleGoBack = () => setMode("editing");
+
+    const emptyNames = mode === "confirming" ? getEmptyFieldNames(data?.variables, configValues) : [];
 
     // Close button (X) just closes the popup without canceling configuration collection
     // User can reopen via the Configure button in the chat segment
@@ -433,17 +495,45 @@ export const ConfigurationCollector: React.FC<ConfigurationCollectorProps> = ({ 
                         ))}
                     </FormSection>
                 </PopupContent>
+                {mode === "confirming" && emptyNames.length > 0 && (
+                    <ConfirmBar>
+                        <ConfirmBarIcon>
+                            <Codicon name="warning" />
+                        </ConfirmBarIcon>
+                        <span>
+                            Empty fields will not be saved: <b>{emptyNames.join(", ")}</b>
+                        </span>
+                    </ConfirmBar>
+                )}
                 <PopupFooter>
-                    <ActionButton appearance="secondary" onClick={handleCancel} disabled={isProcessing}>
-                        Skip
-                    </ActionButton>
-                    <ActionButton
-                        appearance="primary"
-                        onClick={handleSubmit}
-                        disabled={isProcessing || !data.variables || data.variables.length === 0}
-                    >
-                        {isProcessing ? "Saving..." : "Save Configuration"}
-                    </ActionButton>
+                    {mode === "confirming" ? (
+                        <>
+                            <ActionButton appearance="secondary" onClick={handleGoBack}>
+                                Go Back
+                            </ActionButton>
+                            <ActionButton
+                                appearance="primary"
+                                onClick={handleSubmit}
+                                disabled={!data.variables || data.variables.length === 0}
+                            >
+                                Save anyway
+                            </ActionButton>
+                        </>
+                    ) : (
+                        <>
+                            <FooterHint>Leave any field blank to skip. You can fill it later.</FooterHint>
+                            <ActionButton appearance="secondary" onClick={handleCancel} disabled={mode === "processing"}>
+                                Skip
+                            </ActionButton>
+                            <ActionButton
+                                appearance="primary"
+                                onClick={handleSubmit}
+                                disabled={mode === "processing" || !data.variables || data.variables.length === 0}
+                            >
+                                {mode === "processing" ? "Saving..." : "Save Configuration"}
+                            </ActionButton>
+                        </>
+                    )}
                 </PopupFooter>
             </PopupContainer>
         </>


### PR DESCRIPTION
Fixes https://github.com/wso2/product-integrator/issues/1293

- Add REMOVE mode to ConfigCollector for deleting stale or unused keys in Config.toml
- Add RENAME mode that preserves values when a configurable is renamed in source
- Handle record-typed configurables and arrays in remove/rename; snapshot the section state so multi-pair renames do not chain
- Allow skipping individual fields in the collection form with a confirm step before partial submit
- Notify the Copilot agent which fields the user skipped so it does not re-prompt on every turn
- Add log summaries with provided / skipped / preserved counts (values are never logged)


https://github.com/user-attachments/assets/819f9962-1f40-45b1-b25e-1ba9c4a6f167


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration collector now supports removing and renaming configuration keys directly.
  * Added confirmation step when leaving required fields blank, displaying which fields will be skipped before saving.
  * Improved handling of partial configuration inputs with clearer skipped field tracking.
  * Enhanced placeholder value detection in configuration files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/vscode-extensions/pull/2259?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->