### PR TITLE
Make AI chat input placeholder dynamic by mode and chat state

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -225,7 +225,7 @@ const AIChat: React.FC = () => {
     const [currentFileArray, setCurrentFileArray] = useState<SourceFile[]>([]);
     const [codeContext, setCodeContext] = useState<CodeContext | undefined>(undefined);
     const [footerSuggestedCommandTemplates, setFooterSuggestedCommandTemplates] = useState<AIPanelPrompt[] | undefined>(undefined);
-    const [footerInputPlaceholder, setFooterInputPlaceholder] = useState("Describe your integration...");
+    const [footerInputPlaceholder, setFooterInputPlaceholder] = useState<string | null>(null);
 
     const [migrationSession, setMigrationSession] = useState<ActiveMigrationSession | null>(null);
     const [isMigrationEnhancementRunning, setIsMigrationEnhancementRunning] = useState(false);
@@ -296,7 +296,7 @@ const AIChat: React.FC = () => {
                             const textPrompt = defaultPrompt;
                             setAgentMode(defaultPrompt.planMode ? AgentMode.Plan : AgentMode.Edit);
                             setFooterSuggestedCommandTemplates(textPrompt.suggestedCommandTemplates);
-                            setFooterInputPlaceholder(textPrompt.inputPlaceholder ?? "Describe your integration...");
+                            setFooterInputPlaceholder(textPrompt.inputPlaceholder ?? null);
 
                             if (defaultPrompt.autoSubmit && defaultPrompt.text.trim().length > 0) {
                                 void handleSend({
@@ -307,7 +307,7 @@ const AIChat: React.FC = () => {
                             }
                         } else {
                             setFooterSuggestedCommandTemplates(undefined);
-                            setFooterInputPlaceholder("Describe your integration...");
+                            setFooterInputPlaceholder(null);
                         }
 
                         aiChatInputRef.current?.setInputContent(defaultPrompt);
@@ -2188,7 +2188,14 @@ const AIChat: React.FC = () => {
                                 handleAttachmentSelection: handleAttachmentSelection,
                             }}
                             suggestedCommandTemplates={footerSuggestedCommandTemplates}
-                            inputPlaceholder={footerInputPlaceholder}
+                            inputPlaceholder={
+                                footerInputPlaceholder ??
+                                (agentMode === AgentMode.Plan
+                                    ? "Describe what you'd like to plan and build…"
+                                    : messages.length === 0
+                                        ? "Describe the change you'd like to make…"
+                                        : "Describe what to change next…")
+                            }
                             onSend={handleSend}
                             onStop={handleStop}
                             isLoading={isLoading}


### PR DESCRIPTION
- Replace the static "Describe your integration..." placeholder in the Copilot chat input with one that adapts to mode and chat state.
- Plan mode (any message): "Describe what you'd like to plan and build…"
- Edit mode, new chat: "Describe the change you'd like to make…"
- Edit mode, follow-up message: "Describe what to change next…"
- Continue to honour `inputPlaceholder` overrides from text-type `AIPanelPrompt` entry-point command templates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI Chat input placeholder text handling to support backend-driven configuration, with dynamic fallback behavior based on agent mode and conversation state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/vscode-extensions/pull/2265?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->