### PR TITLE
Fix Trivy vulnerability: protobufjs CVE-2026-45740

### DIFF
--- a/common/config/rush/.pnpmfile.cjs
+++ b/common/config/rush/.pnpmfile.cjs
@@ -52,9 +52,9 @@ module.exports = {
         if (deps['protobufjs']) {
           const currentVersion = deps['protobufjs'];
           if (currentVersion.startsWith('^8') || currentVersion.startsWith('8')) {
-            deps['protobufjs'] = '8.0.2';
+            deps['protobufjs'] = '8.2.0'; // security fix: CVE-2026-45740 (DoS via recursive JSON descriptor expansion)
           } else {
-            deps['protobufjs'] = '7.5.6';
+            deps['protobufjs'] = '7.5.8'; // security fix: CVE-2026-45740 (DoS via recursive JSON descriptor expansion)
           }
         }
         if (deps['vite']) deps['vite'] = '6.0.14';

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -642,8 +642,8 @@ importers:
         specifier: 1.0.32
         version: 1.0.32
       protobufjs:
-        specifier: 7.5.6
-        version: 7.5.6
+        specifier: 7.5.8
+        version: 7.5.8
       source-map-support:
         specifier: 0.5.21
         version: 0.5.21
@@ -21108,12 +21108,12 @@ packages:
   prosemirror-view@1.41.8:
     resolution: {integrity: sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==}
 
-  protobufjs@7.5.6:
-    resolution: {integrity: sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==}
+  protobufjs@7.5.8:
+    resolution: {integrity: sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==}
     engines: {node: '>=12.0.0'}
 
-  protobufjs@8.0.2:
-    resolution: {integrity: sha512-TNF0rhMsp+g21us9R2aj3iA7JY9pG7G/3zyRiULl6NS+AurvgQ7iWA203QcykDGSosHxMsV+K6GTR15RBWw1bA==}
+  protobufjs@8.2.0:
+    resolution: {integrity: sha512-oI+GC9iPxrQEr6wragljFKH46/r3rNsm6eg7F2fp6kBUMnf6/mesDRdBuF4gK+OyaKJ8N4C1B9s9cCeYdqFikg==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -28945,7 +28945,7 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.5.6
+      protobufjs: 7.5.8
       yargs: 17.7.2
 
   '@hapi/hoek@9.3.0': {}
@@ -30906,7 +30906,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
-      protobufjs: 8.0.2
+      protobufjs: 8.2.0
 
   '@opentelemetry/propagator-b3@2.7.1(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -52749,7 +52749,7 @@ snapshots:
       prosemirror-state: 1.4.3
       prosemirror-transform: 1.12.0
 
-  protobufjs@7.5.6:
+  protobufjs@7.5.8:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
@@ -52764,7 +52764,7 @@ snapshots:
       '@types/node': 20.19.17
       long: 5.3.2
 
-  protobufjs@8.0.2:
+  protobufjs@8.2.0:
     dependencies:
       '@types/node': 20.19.17
       long: 5.3.2

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
       "path-to-regexp": "0.1.13",
       "picomatch": "4.0.4",
       "prismjs": "1.30.0",
-      "protobufjs": "7.5.6",
+      "protobufjs": "7.5.8",
       "serialize-javascript": "7.0.5",
       "tmp": "0.2.4",
       "undici": "7.24.0",

--- a/workspaces/ballerina/ballerina-extension/package.json
+++ b/workspaces/ballerina/ballerina-extension/package.json
@@ -1453,7 +1453,7 @@
         "node-fetch": "3.3.2",
         "node-schedule": "2.1.1",
         "portfinder": "1.0.32",
-        "protobufjs": "7.5.6",
+        "protobufjs": "7.5.8",
         "source-map-support": "0.5.21",
         "unzipper": "0.12.3",
         "uuid": "14.0.0",


### PR DESCRIPTION
## Purpose
Resolves a Trivy security scan failure in the daily build caused by CVE-2026-45740 in `protobufjs`. Both affected version lines (7.x and 8.x) are present as transitive dependencies and were being pinned by `.pnpmfile.cjs` overrides to vulnerable versions.

## Goals
Upgrade pinned `protobufjs` versions to patched releases so the Trivy vulnerability scanner no longer flags this CVE and the daily build passes.

## Approach
Updated the version pins in four places:
- `common/config/rush/.pnpmfile.cjs` — `7.5.6 → 7.5.8` and `8.0.2 → 8.2.0`
- `package.json` (`pnpm.overrides`) — `7.5.6 → 7.5.8`
- `workspaces/ballerina/ballerina-extension/package.json` (direct dep) — `7.5.6 → 7.5.8`
- `common/config/rush/pnpm-lock.yaml` — updated all resolution integrity hashes and snapshot entries for both version lines

**CVE details:**
- **CVE-2026-45740** (MEDIUM) — Denial of Service via unbounded recursive JSON descriptor expansion in `protobufjs`
  - 7.x fix: `7.5.8`
  - 8.x fix: `8.2.0`
  - Affected consumers: `@grpc/proto-loader` (7.x) and `@opentelemetry/otlp-transformer` (8.x)

## Test environment
Verified via the daily build Trivy scan (CI).