### PR TITLE
Remove handleOnTypeChange function and its references from Form component

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/src/components/Form/index.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/Form/index.tsx
@@ -656,10 +656,6 @@ export const Form = forwardRef((props: FormProps, _ref) => {
         openSubPanel(updatedSubPanel);
     };
 
-    const handleOnTypeChange = () => {
-        getVisualiableFields();
-    };
-
     const handleNewTypeSelected = (type: string | CompletionItem) => {
         handleSelectedTypeChange && handleSelectedTypeChange(type);
     }
@@ -1104,7 +1100,6 @@ export const Form = forwardRef((props: FormProps, _ref) => {
                                     autoFocus={firstEditableFieldIndex === formFields.indexOf(updatedField) && !hideSaveButton}
                                     recordTypeFields={recordTypeFields}
                                     onIdentifierEditingStateChange={handleIdentifierEditingStateChange}
-                                    handleOnTypeChange={handleOnTypeChange}
                                     setSubComponentEnabled={setIsSubComponentEnabled}
                                     handleNewTypeSelected={handleNewTypeSelected}
                                     onBlur={handleOnBlur}
@@ -1206,7 +1201,6 @@ export const Form = forwardRef((props: FormProps, _ref) => {
                                             handleOnFieldFocus={handleOnFieldFocus}
                                             recordTypeFields={recordTypeFields}
                                             onIdentifierEditingStateChange={handleIdentifierEditingStateChange}
-                                            handleOnTypeChange={handleOnTypeChange}
                                             onBlur={handleOnBlur}
                                         />
                                     </S.Row>
@@ -1246,7 +1240,6 @@ export const Form = forwardRef((props: FormProps, _ref) => {
                                     handleOnFieldFocus={handleOnFieldFocus}
                                     recordTypeFields={recordTypeFields}
                                     onIdentifierEditingStateChange={handleIdentifierEditingStateChange}
-                                    handleOnTypeChange={handleOnTypeChange}
                                     onBlur={handleOnBlur}
                                     handleFormValidation={handleFormValidation}
                                     />
@@ -1275,7 +1268,6 @@ export const Form = forwardRef((props: FormProps, _ref) => {
                                 ((open: boolean, newType?: string | NodeProperties) => handleOpenRecordEditor(open, typeField, newType))
                             }
                             handleOnFieldFocus={handleOnFieldFocus}
-                            handleOnTypeChange={handleOnTypeChange}
                             recordTypeFields={recordTypeFields}
                             onIdentifierEditingStateChange={handleIdentifierEditingStateChange}
                             handleNewTypeSelected={handleNewTypeSelected}
@@ -1291,7 +1283,6 @@ export const Form = forwardRef((props: FormProps, _ref) => {
                                 recordTypeFields={recordTypeFields}
                                 onIdentifierEditingStateChange={handleIdentifierEditingStateChange}
                                 handleNewTypeSelected={handleNewTypeSelected}
-                                handleOnTypeChange={handleOnTypeChange}
                                 onBlur={handleOnBlur}
                                 handleFormValidation={handleFormValidation}
                             />


### PR DESCRIPTION
## Purpose
> $subject, it stops double calling for the visualizable API
> Related https://github.com/wso2/product-integrator/issues/1576

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal optimization of form component logic with no impact on user-facing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/vscode-extensions/pull/2276?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->