### PR TITLE
test(e2e): fix Create Project test to match current integration form

### DIFF
--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/project-creation/project-creation.spec.ts
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/project-creation/project-creation.spec.ts
@@ -62,17 +62,12 @@ export default function createTests() {
 
             console.log('Filling integration create form');
 
-            const projectName = "testProject";
             const integrationName = "testIntegration";
             await form.fill({
                 values: {
                     'Integration Name*': {
                         type: 'input',
                         value: integrationName,
-                    },
-                    "Project Name*": {
-                        type: 'input',
-                        value: projectName,
                     }
                 },
             });
@@ -86,8 +81,8 @@ export default function createTests() {
             console.log('Waiting for project and BI webview');
             const testAttempt = testInfo.retry + 1;
             const artifactWebView = await getWebview(BI_INTEGRATOR_LABEL, page);
-            console.log('Waiting for project name to be visible');
-            await artifactWebView.locator(`text=${projectName}`).waitFor({ timeout: 40000 });
+            console.log('Waiting for integration name to be visible');
+            await artifactWebView.locator(`text=${integrationName}`).waitFor({ timeout: 40000 });
 
             console.log('Clicking on the integration name');
             // Click on the integration name ("testIntegration") directly from the BI webview project tree, not the project explorer


### PR DESCRIPTION
## Problem

The `Create Project` E2E test (`project-creation/project-creation.spec.ts`) fails on every retry. It was surfaced by the stable→main sync PR #2255, whose group1 e2e job timed out at:

```
TimeoutError: locator.waitFor: Timeout 40000ms exceeded.
  - waiting for locator('text=testProject') to be visible
```

This test was added to stable on 2026-04-30, but stable's last CI run was 2026-03-04, so it had never actually executed in CI until the sync.

## Root cause (confirmed via the failure recording)

The current **Create New Integration** form only renders **Integration Name** and **Select Path**; a separate *Project Name* field appears solely when "Create within a project" is enabled. The test:

1. filled a non-existent `Project Name*` field, and
2. waited for the project name `testProject` to appear in the BI view.

But with single-integration mode (the default), the created artifact is named after the **integration** (`testIntegration`), so `testProject` never appears and the 40s wait times out. The recording shows the project is created successfully as `testIntegration`.

## Fix

Fill only `Integration Name*` and wait for the integration name — which is what actually renders. The rest of the test already interacts with `text=testIntegration`.

The same fix is applied directly on the sync PR branch (#2255) to unblock it; this PR fixes the source on `stable/ballerina` so the next auto-sync does not re-introduce the broken test.