### PR TITLE
Add AGENTS.md support for project-level agent instructions

### DIFF
--- a/workspaces/mi/mi-core/src/rpc-types/agent-mode/types.ts
+++ b/workspaces/mi/mi-core/src/rpc-types/agent-mode/types.ts
@@ -162,6 +162,8 @@ export type AgentEventType =
     | "plan_approval_requested" // Agent requesting approval for plan (exit_plan_mode)
     // Compact event
     | "compact"                // Conversation was compacted (auto-summarized)
+    // Context warning event (e.g. AGENTS.md truncated to fit size limit)
+    | "context_warning"
     // Usage event
     | "usage";                 // Token usage update (emitted per step)
 
@@ -274,6 +276,8 @@ export interface AgentEvent {
     suggestedPrefixRule?: string[];
     /** Summary text for compact event */
     summary?: string;
+    /** Human-readable warning text for context_warning event (e.g. AGENTS.md truncated). */
+    warningMessage?: string;
 
     // Usage fields (for usage event)
     /** Total input tokens (input + cached) for context usage tracking */
@@ -316,7 +320,7 @@ export interface PlanApprovalRequestedEvent extends AgentEvent {
  * Frontend will convert these to UI messages with inline tool call formatting
  */
 export interface ChatHistoryEvent {
-    type: 'user' | 'assistant' | 'tool_call' | 'tool_result' | 'compact_summary' | 'undo_checkpoint' | 'checkpoint_anchor';
+    type: 'user' | 'assistant' | 'tool_call' | 'tool_result' | 'compact_summary' | 'context_warning' | 'undo_checkpoint' | 'checkpoint_anchor';
     /** Stable UI chat id for grouping a user turn and its assistant output */
     chatId?: number;
     content?: string;
@@ -333,6 +337,8 @@ export interface ChatHistoryEvent {
     checkpointAnchor?: CheckpointAnchorSummary;
     /** Assistant chat id this undo checkpoint should attach to during UI replay */
     targetChatId?: number;
+    /** Warning message body for context_warning events (e.g. AGENTS.md truncated) */
+    warningMessage?: string;
     timestamp: string;
 
     // Shell tool fields (for history display)
@@ -441,6 +447,8 @@ export interface SessionContextBlocksState {
     modePolicy?: string;
     /** sha256-16 of the canonicalized preconfigured-payloads JSON */
     payloads?: string;
+    /** sha256-16 of the (possibly truncated) AGENTS.md bytes + truncation banner inputs */
+    agentsMd?: string;
 }
 
 /**

--- a/workspaces/mi/mi-extension/src/ai-features/agent-mode/agents/main/agent.ts
+++ b/workspaces/mi/mi-extension/src/ai-features/agent-mode/agents/main/agent.ts
@@ -35,6 +35,7 @@ import { getLoginMethod, getTavilyApiKey } from '../../../auth';
 import { getSystemPrompt } from '../main/system';
 import {
     BlockInjectionStatus,
+    AGENTS_MD_MAX_BYTES,
     BlockInjectionStatuses,
     computeSessionContextBlockHashes,
     getUserPrompt,
@@ -259,6 +260,7 @@ function buildUpdatedBlocksState(
     apply('webAvailability', statuses.webAvailability, current.webAvailability);
     apply('modePolicy', statuses.modePolicy, current.modePolicy);
     apply('payloads', statuses.payloads, current.payloads);
+    apply('agentsMd', statuses.agentsMd, current.agentsMd);
     return touched ? updated : undefined;
 }
 
@@ -285,6 +287,7 @@ function logBlockInjectionDrift(
     note('webAvailability', statuses.webAvailability, previous.webAvailability, current.webAvailability);
     note('mode', statuses.modePolicy, previous.modePolicy, current.modePolicy);
     note('payloads', statuses.payloads, previous.payloads, current.payloads);
+    note('agentsMd', statuses.agentsMd, previous.agentsMd, current.agentsMd);
     if (driftedBlocks.length > 0) {
         logInfo(`[Agent] Session-context drift — re-injecting: ${driftedBlocks.join(', ')}`);
     }
@@ -619,6 +622,7 @@ export async function executeAgent(
             webAvailability: decideBlockStatus(currentBlockHashes.webAvailability, previousBlocks.webAvailability, forceFirstInjection),
             modePolicy: decideBlockStatus(currentBlockHashes.modePolicy, previousBlocks.modePolicy, forceFirstInjection),
             payloads: decideBlockStatus(currentBlockHashes.payloads, previousBlocks.payloads, forceFirstInjection),
+            agentsMd: decideBlockStatus(currentBlockHashes.agentsMd, previousBlocks.agentsMd, forceFirstInjection),
         };
         const previousMode = previousBlocks.modePolicy as AgentMode | undefined;
 
@@ -690,6 +694,22 @@ export async function executeAgent(
                     }
                     : undefined,
             });
+        }
+
+        // Surface an AGENTS.md truncation warning to the user — only when the
+        // block is actually being injected this turn (not on quiet 'omit' turns
+        // where the model already has the same truncated content), so the
+        // warning isn't repeated every turn for an unchanged-but-large file.
+        const agentsMdInjected = blockStatuses.agentsMd === 'first-injection'
+            || blockStatuses.agentsMd === 're-injection';
+        if (agentsMdInjected && sessionContextResult.snapshot.agentsMdTruncated) {
+            const originalKb = Math.round(sessionContextResult.snapshot.agentsMdOriginalSize / 1024);
+            const cappedKb = Math.round(AGENTS_MD_MAX_BYTES / 1024);
+            const warningMessage = `Your AGENTS.md is ${originalKb} KB; only the first ${cappedKb} KB is included in the model's context. Rules in the truncated portion will NOT be followed. Shorten the file or split sections out into prose to fit within ${cappedKb} KB.`;
+            if (request.chatHistoryManager) {
+                await request.chatHistoryManager.saveAgentsMdWarning(warningMessage);
+            }
+            emitEvent({ type: 'context_warning', warningMessage, content: warningMessage });
         }
 
         // Track how many messages have been saved from step.response.messages

--- a/workspaces/mi/mi-extension/src/ai-features/agent-mode/agents/main/agent.ts
+++ b/workspaces/mi/mi-extension/src/ai-features/agent-mode/agents/main/agent.ts
@@ -706,8 +706,18 @@ export async function executeAgent(
             const originalKb = Math.round(sessionContextResult.snapshot.agentsMdOriginalSize / 1024);
             const cappedKb = Math.round(AGENTS_MD_MAX_BYTES / 1024);
             const warningMessage = `Your AGENTS.md is ${originalKb} KB; only the first ${cappedKb} KB is included in the model's context. Rules in the truncated portion will NOT be followed. Shorten the file or split sections out into prose to fit within ${cappedKb} KB.`;
+            // Persistence is a non-fatal side-effect — a JSONL write failure
+            // must not abort the agent run. The warning is purely informational
+            // (the truncation banner inside the prompt block tells the model
+            // separately), so on persistence failure we still emit the live
+            // event so the user sees it this turn; only the cross-reconnect
+            // replay is sacrificed.
             if (request.chatHistoryManager) {
-                await request.chatHistoryManager.saveAgentsMdWarning(warningMessage);
+                try {
+                    await request.chatHistoryManager.saveAgentsMdWarning(warningMessage);
+                } catch (error) {
+                    logError('[Agent] Failed to persist AGENTS.md warning to history', error);
+                }
             }
             emitEvent({ type: 'context_warning', warningMessage, content: warningMessage });
         }

--- a/workspaces/mi/mi-extension/src/ai-features/agent-mode/agents/main/prompt.ts
+++ b/workspaces/mi/mi-extension/src/ai-features/agent-mode/agents/main/prompt.ts
@@ -505,7 +505,13 @@ export interface SessionContextBlockHashes {
     webAvailability: string;
     modePolicy: AgentMode;
     payloads: string | undefined;
-    /** sha256-16 of full untruncated AGENTS.md raw bytes, or `undefined` when no AGENTS.md exists. */
+    /**
+     * sha256-16 over the bytes we actually surface to the model (i.e. the
+     * possibly truncated AGENTS.md content) combined with the truncation
+     * metadata (`truncated`, `originalSize`). `undefined` when no AGENTS.md
+     * exists at the project root, which is what drives the `cleared` notice
+     * on deletion.
+     */
     agentsMd: string | undefined;
 }
 
@@ -885,6 +891,19 @@ ${list}`;
 }
 
 /**
+ * Neutralize prompt-envelope tags embedded inside user-authored content
+ * (AGENTS.md) so a malicious or accidental `</system-reminder>` or
+ * `<user_query>` can't break out of the surrounding wrapper. Replaces the
+ * angle brackets of those specific tag sequences with mathematical-angle
+ * lookalikes (U+27E8 / U+27E9): visually obvious to humans, the model can
+ * still read the surrounding text fine, but the regex/parser our envelope
+ * relies on no longer matches.
+ */
+function neutralizePromptEnvelopeTags(content: string): string {
+    return content.replace(/<(\/?)(system-reminder|user_query)>/g, '⟨$1$2⟩');
+}
+
+/**
  * Render the AGENTS.md block. The user authors `AGENTS.md` at the project
  * root to pin custom project-level instructions (analogous to CLAUDE.md for
  * Claude Code). Treat its contents as user-authored guidance that augments
@@ -904,10 +923,11 @@ The user has deleted AGENTS.md. Discard any prior project-level instructions sou
     const truncationFooter = snapshot.agentsMdTruncated
         ? `\n\n[file truncated — original size: ${Math.round(snapshot.agentsMdOriginalSize / 1024)} KB, showing first ${Math.round(AGENTS_MD_MAX_BYTES / 1024)} KB. Inform the user that their AGENTS.md exceeds the size limit and any rules beyond this point are NOT in your context.]`
         : '';
+    const safeContent = neutralizePromptEnvelopeTags(snapshot.agentsMdContent);
     return `# Project AGENTS.md${headerSuffix}
 The user has provided custom project-level instructions at AGENTS.md (project root). Follow these in addition to the system prompt; on conflict, these take precedence.
 
-${snapshot.agentsMdContent}${truncationFooter}`;
+${safeContent}${truncationFooter}`;
 }
 
 // ============================================================================

--- a/workspaces/mi/mi-extension/src/ai-features/agent-mode/agents/main/prompt.ts
+++ b/workspaces/mi/mi-extension/src/ai-features/agent-mode/agents/main/prompt.ts
@@ -33,6 +33,7 @@ import { getStateMachine } from '../../../../stateMachine';
 
 const MAX_PROJECT_STRUCTURE_FILES = 50;
 const MAX_PROJECT_STRUCTURE_CHARS = 10000;
+export const AGENTS_MD_MAX_BYTES = 30 * 1024;
 
 // ============================================================================
 // User Prompt Template
@@ -109,6 +110,12 @@ The user has opened the file {{currentlyOpenedFile}} in the IDE. This may or may
 </system-reminder>
 {{/if}}
 
+{{#if agents_md_block}}
+<system-reminder>
+{{{agents_md_block}}}
+</system-reminder>
+{{/if}}
+
 {{#if runtime_version_detection_warning}}
 <system-reminder>
 # Runtime Version Warning
@@ -179,6 +186,7 @@ export interface BlockInjectionStatuses {
     /** Plan-only. For Ask/Edit, the full policy is always rendered regardless of this status. */
     modePolicy: BlockInjectionStatus;
     payloads: BlockInjectionStatus;
+    agentsMd: BlockInjectionStatus;
 }
 
 /**
@@ -467,6 +475,15 @@ export interface SessionContextSnapshot {
      * every turn. Empty array = no `.tryout/` folder or no payload files.
      */
     tryoutPayloads: TryoutPayloadEntry[];
+    /**
+     * Raw AGENTS.md content (already truncated to AGENTS_MD_MAX_BYTES when
+     * needed). `undefined` when no AGENTS.md exists at the project root.
+     */
+    agentsMdContent: string | undefined;
+    /** True when AGENTS.md was larger than AGENTS_MD_MAX_BYTES and was cut. */
+    agentsMdTruncated: boolean;
+    /** Original (untruncated) raw byte size of AGENTS.md, or 0 when absent. */
+    agentsMdOriginalSize: number;
 }
 
 interface SessionContextWithCatalog {
@@ -488,6 +505,8 @@ export interface SessionContextBlockHashes {
     webAvailability: string;
     modePolicy: AgentMode;
     payloads: string | undefined;
+    /** sha256-16 of full untruncated AGENTS.md raw bytes, or `undefined` when no AGENTS.md exists. */
+    agentsMd: string | undefined;
 }
 
 /**
@@ -548,6 +567,49 @@ function scanTryoutPayloads(projectPath: string): TryoutPayloadEntry[] {
     }
 }
 
+/**
+ * Read `AGENTS.md` from the project root. Returns the raw content (truncated
+ * to `AGENTS_MD_MAX_BYTES` when oversized) along with the original byte size
+ * so the model and the user can both be told the file was cut. Returns
+ * `undefined` when the file is missing or unreadable — the block is then
+ * omitted entirely on the next turn (same shape as an empty `.tryout/`).
+ */
+function readAgentsMd(projectPath: string): { content: string; truncated: boolean; originalSize: number } | undefined {
+    const agentsMdPath = path.join(projectPath, 'AGENTS.md');
+    if (!fs.existsSync(agentsMdPath)) {
+        return undefined;
+    }
+    try {
+        const stat = fs.statSync(agentsMdPath);
+        if (!stat.isFile()) {
+            return undefined;
+        }
+        const originalSize = stat.size;
+        if (originalSize <= AGENTS_MD_MAX_BYTES) {
+            const content = fs.readFileSync(agentsMdPath, 'utf8');
+            return { content, truncated: false, originalSize };
+        }
+        // Oversized — read only the first AGENTS_MD_MAX_BYTES bytes. Open as
+        // a file descriptor so we don't pull the whole file into memory just
+        // to slice it.
+        const fd = fs.openSync(agentsMdPath, 'r');
+        try {
+            const buffer = Buffer.allocUnsafe(AGENTS_MD_MAX_BYTES);
+            const bytesRead = fs.readSync(fd, buffer, 0, AGENTS_MD_MAX_BYTES, 0);
+            const content = buffer.subarray(0, bytesRead).toString('utf8');
+            return { content, truncated: true, originalSize };
+        } finally {
+            fs.closeSync(fd);
+        }
+    } catch (error) {
+        logDebug(
+            `[Prompt] Failed to read AGENTS.md for project ${projectPath}: ` +
+            `${error instanceof Error ? error.message : String(error)}`
+        );
+        return undefined;
+    }
+}
+
 async function buildSessionContextSnapshot(params: SessionContextParams): Promise<SessionContextWithCatalog> {
     const isGitRepo = fs.existsSync(path.join(params.projectPath, '.git'));
     let gitBranch: string | null = null;
@@ -572,6 +634,7 @@ async function buildSessionContextSnapshot(params: SessionContextParams): Promis
     const runtimeVersion = params.runtimeVersion ?? await getRuntimeVersionFromPom(params.projectPath);
     const runtimePaths = getRuntimePaths(params.projectPath);
     const catalog = await getAvailableConnectorCatalog(params.projectPath);
+    const agentsMd = readAgentsMd(params.projectPath);
 
     return {
         snapshot: {
@@ -596,6 +659,9 @@ async function buildSessionContextSnapshot(params: SessionContextParams): Promis
             webSearchUnavailable: params.webSearchUnavailable === true,
             mode: params.mode || 'edit',
             tryoutPayloads: scanTryoutPayloads(params.projectPath),
+            agentsMdContent: agentsMd?.content,
+            agentsMdTruncated: agentsMd?.truncated ?? false,
+            agentsMdOriginalSize: agentsMd?.originalSize ?? 0,
         },
         catalogWarnings: catalog.warnings,
         catalogStoreStatus: catalog.storeStatus,
@@ -639,6 +705,19 @@ function deriveBlockHashes(snapshot: SessionContextSnapshot): SessionContextBloc
         // `undefined` when the folder is empty so 'cleared' fires correctly
         // when the user wipes all saved payloads.
         payloads: snapshot.tryoutPayloads.length > 0 ? hashJson(snapshot.tryoutPayloads) : undefined,
+        // Hash over what we actually surface to the model: the (possibly
+        // truncated) bytes plus the truncation banner inputs. Edits inside the
+        // truncated tail are intentionally invisible — if the bytes we ship
+        // and the banner are unchanged, the model has no new information to
+        // see. `undefined` when no AGENTS.md exists so 'cleared' fires when
+        // the user deletes it.
+        agentsMd: snapshot.agentsMdContent !== undefined
+            ? hashJson({
+                content: snapshot.agentsMdContent,
+                truncated: snapshot.agentsMdTruncated,
+                originalSize: snapshot.agentsMdOriginalSize,
+            })
+            : undefined,
     };
 }
 
@@ -686,6 +765,7 @@ const DEFAULT_BLOCK_STATUSES: BlockInjectionStatuses = {
     webAvailability: 'first-injection',
     modePolicy: 'first-injection',
     payloads: 'first-injection',
+    agentsMd: 'first-injection',
 };
 
 function buildEnvBlockText(snapshot: SessionContextSnapshot, status: BlockInjectionStatus): string | undefined {
@@ -804,6 +884,32 @@ The user has saved sample request payloads in .tryout/ (one file per artifact). 
 ${list}`;
 }
 
+/**
+ * Render the AGENTS.md block. The user authors `AGENTS.md` at the project
+ * root to pin custom project-level instructions (analogous to CLAUDE.md for
+ * Claude Code). Treat its contents as user-authored guidance that augments
+ * and (on conflict) overrides the system prompt defaults. When the file is
+ * too large to ship verbatim we cut it at AGENTS_MD_MAX_BYTES and tell the
+ * model the rest is missing so it doesn't claim to follow rules it never saw.
+ */
+function buildAgentsMdBlockText(snapshot: SessionContextSnapshot, status: BlockInjectionStatus): string | undefined {
+    if (status === 'cleared') {
+        return `# Project AGENTS.md [removed]
+The user has deleted AGENTS.md. Discard any prior project-level instructions sourced from it.`;
+    }
+    if (status === 'omit' || snapshot.agentsMdContent === undefined) {
+        return undefined;
+    }
+    const headerSuffix = status === 're-injection' ? ` ${CONTEXT_UPDATED}` : '';
+    const truncationFooter = snapshot.agentsMdTruncated
+        ? `\n\n[file truncated — original size: ${Math.round(snapshot.agentsMdOriginalSize / 1024)} KB, showing first ${Math.round(AGENTS_MD_MAX_BYTES / 1024)} KB. Inform the user that their AGENTS.md exceeds the size limit and any rules beyond this point are NOT in your context.]`
+        : '';
+    return `# Project AGENTS.md${headerSuffix}
+The user has provided custom project-level instructions at AGENTS.md (project root). Follow these in addition to the system prompt; on conflict, these take precedence.
+
+${snapshot.agentsMdContent}${truncationFooter}`;
+}
+
 // ============================================================================
 // User Prompt Generation
 // ============================================================================
@@ -864,6 +970,7 @@ export async function getUserPrompt(params: UserPromptParams): Promise<UserPromp
     const connectorsBlock = buildConnectorsBlockText(snapshot, blockStatuses.connectors);
     const webAvailabilityBlock = buildWebAvailabilityBlockText(snapshot, blockStatuses.webAvailability);
     const payloadsBlock = buildPayloadsBlockText(snapshot.tryoutPayloads, blockStatuses.payloads);
+    const agentsMdBlock = buildAgentsMdBlockText(snapshot, blockStatuses.agentsMd);
     const fullModePolicyBlock = buildFullModePolicyBlockText(
         mode,
         fullModePolicy,
@@ -885,6 +992,7 @@ export async function getUserPrompt(params: UserPromptParams): Promise<UserPromp
         connectors_block: connectorsBlock,
         web_availability_block: webAvailabilityBlock,
         payloads_block: payloadsBlock,
+        agents_md_block: agentsMdBlock,
         full_mode_policy_block: fullModePolicyBlock,
         runtime_version_detection_warning: runtimeVersionDetectionWarning,
         mode_upper: mode.toUpperCase(),

--- a/workspaces/mi/mi-extension/src/ai-features/agent-mode/agents/main/system.ts
+++ b/workspaces/mi/mi-extension/src/ai-features/agent-mode/agents/main/system.ts
@@ -19,6 +19,7 @@
 import { DEFERRED_TOOL_DESCRIPTIONS } from '../../tools/tool_load';
 import {
     FILE_EDIT_TOOL_NAME,
+    FILE_READ_TOOL_NAME,
     CONNECTOR_TOOL_NAME,
     CONTEXT_TOOL_NAME,
     MANAGE_CONNECTOR_TOOL_NAME,
@@ -146,6 +147,11 @@ ${Object.entries(DEFERRED_TOOL_DESCRIPTIONS).map(([name, desc]) => `- ${name}: $
 - User-saved sample requests, one file per artifact. Per-turn user reminder lists which exist — do not pre-load.
 - Read on demand only when reasoning about runtime inputs (body/header/query/path field names, expression mapping). Otherwise ignore.
 - Format: APIs nest requests under \`"/<resource>"\` keys; other artifacts are flat. Pick the request whose \`name\` equals \`defaultRequest\`.
+
+## Project AGENTS.md
+- If a \`<system-reminder>\` titled \`# Project AGENTS.md\` is present in this turn or any prior turn, treat its contents as user-authored project-level instructions that augment this system prompt and override defaults where they conflict.
+- AGENTS.md content is re-sent only when it changes; an absent reminder means either no \`AGENTS.md\` exists at the project root, or its content is unchanged since the last time it was injected — assume the prior content is still in effect.
+- If the reminder ends with a \`[file truncated — ...]\` notice, rules beyond the cut are NOT in your persistent context. When a user request plausibly depends on rules past the cut, read \`AGENTS.md\` on demand with ${FILE_READ_TOOL_NAME} (use \`offset\` to start at the truncated tail so you don't re-fetch what's already in the reminder). Do not pre-fetch — only read when the task actually needs it. Also tell the user once that AGENTS.md exceeds the in-context size limit and ask them to shorten the file or split rules out so the full set stays in context every turn.
 
 ## Connectors and inbound endpoints (${CONNECTOR_TOOL_NAME}, ${MANAGE_CONNECTOR_TOOL_NAME})
 - Workflow: mode='summary' to learn operations / init style → mode='details' for the specific ops/connections you will actually use → write XML → ${MANAGE_CONNECTOR_TOOL_NAME} to add the artifact to the project.

--- a/workspaces/mi/mi-extension/src/ai-features/agent-mode/chat-history-manager.ts
+++ b/workspaces/mi/mi-extension/src/ai-features/agent-mode/chat-history-manager.ts
@@ -78,6 +78,8 @@ export interface SessionContextBlocksState {
     /** Verbatim mode name (`"ask" | "edit" | "plan"`) for "[mode changed from EDIT]" notices. */
     modePolicy?: string;
     payloads?: string;
+    /** sha256-16 of the (possibly truncated) AGENTS.md bytes + truncation banner inputs */
+    agentsMd?: string;
 }
 
 export const TOOL_USE_INTERRUPTION_CONTEXT = `<system-reminder>The user interrupted while a tool was running. The tool use was rejected and any pending mutations were NOT applied. Stop immediately and wait for the user's next message.</system-reminder>`;
@@ -127,6 +129,7 @@ export interface JournalEntry {
     | 'session_start'
     | 'session_end'
     | 'compact_summary'
+    | 'context_warning'
     | 'mode_change'
     | 'undo_checkpoint'
     | 'checkpoint_anchor'
@@ -148,6 +151,8 @@ export interface JournalEntry {
     };
     /** Summary content (compact_summary) */
     summary?: string;
+    /** Warning message body (context_warning) */
+    warningMessage?: string;
     /** Mode value (mode_change) */
     mode?: AgentMode;
     /** Undo checkpoint summary (undo_checkpoint) */
@@ -737,6 +742,28 @@ export class ChatHistoryManager {
     }
 
     /**
+     * Save an AGENTS.md truncation warning entry to history. Rendered on
+     * reload as a synthetic assistant-side message with an `<agents-md-warning>`
+     * tag so the warning persists across panel reconnects.
+     */
+    async saveAgentsMdWarning(warningMessage: string): Promise<void> {
+        const entry: JournalEntry = {
+            type: 'context_warning',
+            timestamp: new Date().toISOString(),
+            sessionId: this.sessionId,
+            warningMessage,
+        };
+
+        try {
+            await this.writeEntry(entry);
+            logInfo(`[ChatHistory] Saved AGENTS.md truncation warning (${warningMessage.length} chars)`);
+        } catch (error) {
+            logError('[ChatHistory] Failed to save AGENTS.md warning', error);
+            throw error;
+        }
+    }
+
+    /**
      * Save a mode change entry to history
      */
     async saveModeChange(mode: AgentMode): Promise<void> {
@@ -936,6 +963,7 @@ export class ChatHistoryManager {
         includeCompactSummaryEntry?: boolean;
         includeUndoCheckpointEntry?: boolean;
         includeCheckpointAnchorEntry?: boolean;
+        includeContextWarningEntry?: boolean;
     }): Promise<any[]> {
         // Sanitize tool-result / text content blocks on load. Older sessions
         // may have persisted raw control bytes (e.g. ANSI codes from a Maven
@@ -981,6 +1009,7 @@ export class ChatHistoryManager {
             const includeCompactSummaryEntry = options?.includeCompactSummaryEntry === true;
             const includeUndoCheckpointEntry = options?.includeUndoCheckpointEntry === true;
             const includeCheckpointAnchorEntry = options?.includeCheckpointAnchorEntry === true;
+            const includeContextWarningEntry = options?.includeContextWarningEntry === true;
             const content = await fs.readFile(this.sessionFile, 'utf8');
             const allEntries = this.parseJournalEntries(content, 'loading messages');
 
@@ -1037,6 +1066,8 @@ export class ChatHistoryManager {
                         messages.push(entry);
                     } else if (includeCheckpointAnchorEntry && entry.type === 'checkpoint_anchor') {
                         messages.push(entry);
+                    } else if (includeContextWarningEntry && entry.type === 'context_warning') {
+                        messages.push(entry);
                     }
                 }
 
@@ -1065,6 +1096,8 @@ export class ChatHistoryManager {
                 } else if (includeUndoCheckpointEntry && entry.type === 'undo_checkpoint') {
                     messages.push(entry);
                 } else if (includeCheckpointAnchorEntry && entry.type === 'checkpoint_anchor') {
+                    messages.push(entry);
+                } else if (includeContextWarningEntry && entry.type === 'context_warning') {
                     messages.push(entry);
                 }
             }
@@ -1483,7 +1516,7 @@ export class ChatHistoryManager {
      * @returns UI events for display
      */
     static convertToEventFormat(messages: any[]): Array<{
-        type: 'user' | 'assistant' | 'tool_call' | 'tool_result' | 'compact_summary' | 'undo_checkpoint' | 'checkpoint_anchor';
+        type: 'user' | 'assistant' | 'tool_call' | 'tool_result' | 'compact_summary' | 'context_warning' | 'undo_checkpoint' | 'checkpoint_anchor';
         chatId?: number;
         content?: string;
         files?: Array<{ name: string; mimetype: string; content: string }>;
@@ -1496,6 +1529,7 @@ export class ChatHistoryManager {
         undoCheckpoint?: UndoCheckpointSummary;
         checkpointAnchor?: CheckpointAnchorSummary;
         targetChatId?: number;
+        warningMessage?: string;
         timestamp: string;
     }> {
         const events: any[] = [];
@@ -1510,6 +1544,19 @@ export class ChatHistoryManager {
                 events.push({
                     type: 'compact_summary',
                     content: msg.summary,
+                    timestamp: msg.timestamp || timestamp,
+                });
+                continue;
+            }
+
+            // Handle context_warning entries (e.g. AGENTS.md truncation). Rendered
+            // on reload as a standalone synthetic assistant message so the warning
+            // persists across panel reconnects (mirrors compact_summary).
+            if (msg.type === 'context_warning') {
+                events.push({
+                    type: 'context_warning',
+                    warningMessage: msg.warningMessage,
+                    content: msg.warningMessage,
                     timestamp: msg.timestamp || timestamp,
                 });
                 continue;

--- a/workspaces/mi/mi-extension/src/rpc-managers/agent-mode/rpc-manager.ts
+++ b/workspaces/mi/mi-extension/src/rpc-managers/agent-mode/rpc-manager.ts
@@ -494,6 +494,7 @@ export class MIAgentPanelRpcManager implements MIAgentPanelAPI {
             includeCompactSummaryEntry: true,
             includeUndoCheckpointEntry: true,
             includeCheckpointAnchorEntry: true,
+            includeContextWarningEntry: true,
         });
         const events = ChatHistoryManager.convertToEventFormat(messages);
         const normalizedEvents = this.applyLatestUndoAvailabilityToEvents(events);

--- a/workspaces/mi/mi-visualizer/src/views/AIPanel/component/AIChatFooter.tsx
+++ b/workspaces/mi/mi-visualizer/src/views/AIPanel/component/AIChatFooter.tsx
@@ -809,6 +809,23 @@ const AIChatFooter: React.FC<AIChatFooterProps> = ({ isUsageExceeded = false }) 
                 }
                 break;
 
+            case "context_warning": {
+                // AGENTS.md (or similar) was truncated. Show as a standalone synthetic
+                // assistant message so the warning renders even before the model starts
+                // streaming text for this turn. Persisted to JSONL by the extension so
+                // it also reappears on reload via the converter.
+                const warningText = (event as any).warningMessage || event.content || '';
+                if (warningText) {
+                    setMessages((prev) => [...prev, {
+                        id: generateId(),
+                        role: Role.MICopilot,
+                        content: `<agents-md-warning>${warningText}</agents-md-warning>`,
+                        type: MessageType.AssistantMessage,
+                    }]);
+                }
+                break;
+            }
+
             case "usage":
                 // Update context usage via shared context state
                 if (event.totalInputTokens !== undefined) {

--- a/workspaces/mi/mi-visualizer/src/views/AIPanel/component/AIChatFooter.tsx
+++ b/workspaces/mi/mi-visualizer/src/views/AIPanel/component/AIChatFooter.tsx
@@ -814,14 +814,30 @@ const AIChatFooter: React.FC<AIChatFooterProps> = ({ isUsageExceeded = false }) 
                 // assistant message so the warning renders even before the model starts
                 // streaming text for this turn. Persisted to JSONL by the extension so
                 // it also reappears on reload via the converter.
-                const warningText = (event as any).warningMessage || event.content || '';
+                const warningText = event.warningMessage || event.content || '';
                 if (warningText) {
-                    setMessages((prev) => [...prev, {
+                    const warningMsg: ChatMessage = {
                         id: generateId(),
                         role: Role.MICopilot,
                         content: `<agents-md-warning>${warningText}</agents-md-warning>`,
                         type: MessageType.AssistantMessage,
-                    }]);
+                    };
+                    // sendAgentMessage optimistically appends an empty assistant
+                    // placeholder before the stream starts, and content_block /
+                    // thinking_* events target that placeholder via
+                    // updateLastMessage. If we append the warning at the end we'd
+                    // displace the placeholder and subsequent stream updates would
+                    // land on the warning bubble instead. Splice the warning
+                    // just before the active placeholder so the placeholder stays
+                    // last and remains the streaming target.
+                    setMessages((prev) => {
+                        if (prev.length > 0
+                            && prev[prev.length - 1].role === Role.MICopilot
+                            && backendRequestTriggeredRef.current) {
+                            return [...prev.slice(0, -1), warningMsg, prev[prev.length - 1]];
+                        }
+                        return [...prev, warningMsg];
+                    });
                 }
                 break;
             }

--- a/workspaces/mi/mi-visualizer/src/views/AIPanel/component/AIChatMessage.tsx
+++ b/workspaces/mi/mi-visualizer/src/views/AIPanel/component/AIChatMessage.tsx
@@ -38,6 +38,7 @@ import ToolCallSegment from "./ToolCallSegment";
 import TodoListSegment from "./TodoListSegment";
 import BashOutputSegment from "./BashOutputSegment";
 import CompactSummarySegment from "./CompactSummarySegment";
+import ContextWarningSegment from "./ContextWarningSegment";
 import ThinkingSegment from "./ThinkingSegment";
 import ErrorSegment from "./ErrorSegment";
 
@@ -340,6 +341,8 @@ const AIChatMessage: React.FC<ChatMessageProps> = ({ message, index }) => {
                 }
             } else if (segment.isCompactSummary) {
                 return <CompactSummarySegment key={i} text={segment.text} />;
+            } else if (segment.isContextWarning) {
+                return <ContextWarningSegment key={i} text={segment.text} />;
             } else if (segment.isFileChanges) {
                 return null;
             } else if (segment.isPlan) {

--- a/workspaces/mi/mi-visualizer/src/views/AIPanel/component/ContextWarningSegment.tsx
+++ b/workspaces/mi/mi-visualizer/src/views/AIPanel/component/ContextWarningSegment.tsx
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from "react";
+import styled from "@emotion/styled";
+
+const WarningContainer = styled.div`
+    margin: 6px 0;
+    padding: 8px 10px;
+    border-left: 3px solid var(--vscode-inputValidation-warningBorder, var(--vscode-editorWarning-foreground, #f1c40f));
+    background: var(--vscode-inputValidation-warningBackground, transparent);
+    color: var(--vscode-inputValidation-warningForeground, var(--vscode-foreground));
+    font-size: 12px;
+    line-height: 1.45;
+    border-radius: 2px;
+`;
+
+const WarningHeader = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-weight: 500;
+    margin-bottom: 4px;
+`;
+
+const WarningBody = styled.div`
+    overflow-wrap: anywhere;
+    white-space: pre-wrap;
+`;
+
+interface ContextWarningSegmentProps {
+    text: string;
+}
+
+const ContextWarningSegment: React.FC<ContextWarningSegmentProps> = ({ text }) => (
+    <WarningContainer role="status" aria-live="polite">
+        <WarningHeader>
+            <span className="codicon codicon-warning" />
+            AGENTS.md truncated
+        </WarningHeader>
+        <WarningBody>{text}</WarningBody>
+    </WarningContainer>
+);
+
+export default ContextWarningSegment;

--- a/workspaces/mi/mi-visualizer/src/views/AIPanel/utils.ts
+++ b/workspaces/mi/mi-visualizer/src/views/AIPanel/utils.ts
@@ -97,6 +97,7 @@ interface ContentSegment {
     isTodoList?: boolean;
     isBashOutput?: boolean;
     isCompactSummary?: boolean;
+    isContextWarning?: boolean;
     isFileChanges?: boolean;
     isPlan?: boolean;
     isThinking?: boolean;
@@ -121,7 +122,7 @@ export function splitContent(content: string): ContentSegment[] {
     // opening fence's \n already sits right before the closer, so we fall back
     // to a `(?<=\n)` lookbehind (which doesn't consume) — otherwise `\`\`\`\n\`\`\``
     // wouldn't match at all.
-    const regex = /```(\w*)\n([\s\S]*?)(?:\r?\n|(?<=\n))```(?=\r?\n|$)|<toolcall([^>]*)>([^<]*?)<\/toolcall>|<todolist>([\s\S]*?)<\/todolist>|<bashoutput(?:\s+[^>]*)?>([\s\S]*?)<\/bashoutput>|<compact>([\s\S]*?)<\/compact>|<filechanges>([\s\S]*?)<\/filechanges>|<plan>([\s\S]*?)<\/plan>|<thinking(\s+[^>]*)?>([\s\S]*?)<\/thinking>/g;
+    const regex = /```(\w*)\n([\s\S]*?)(?:\r?\n|(?<=\n))```(?=\r?\n|$)|<toolcall([^>]*)>([^<]*?)<\/toolcall>|<todolist>([\s\S]*?)<\/todolist>|<bashoutput(?:\s+[^>]*)?>([\s\S]*?)<\/bashoutput>|<compact>([\s\S]*?)<\/compact>|<filechanges>([\s\S]*?)<\/filechanges>|<plan>([\s\S]*?)<\/plan>|<thinking(\s+[^>]*)?>([\s\S]*?)<\/thinking>|<agents-md-warning>([\s\S]*?)<\/agents-md-warning>/g;
     let start = 0;
 
     // Helper function to mark the last toolcall segment as complete
@@ -183,6 +184,10 @@ export function splitContent(content: string): ContentSegment[] {
             const thinkingAttrs = match[10] || '';
             const isLoading = /data-loading="true"/.test(thinkingAttrs);
             segments.push({ isThinking: true, loading: isLoading, text: match[11] });
+        } else if (match[12] !== undefined) {
+            // <agents-md-warning> block matched
+            updateLastToolCallSegmentLoading();
+            segments.push({ isContextWarning: true, loading: false, text: match[12] });
         }
         start = regex.lastIndex;
     }

--- a/workspaces/mi/mi-visualizer/src/views/AIPanel/utils/eventToMessageConverter.ts
+++ b/workspaces/mi/mi-visualizer/src/views/AIPanel/utils/eventToMessageConverter.ts
@@ -355,7 +355,7 @@ export function convertEventsToMessages(
                 messages.push({
                     id: generateId(),
                     role: Role.MICopilot,
-                    content: `<agents-md-warning>${(event as any).warningMessage || event.content || ''}</agents-md-warning>`,
+                    content: `<agents-md-warning>${event.warningMessage || event.content || ''}</agents-md-warning>`,
                     type: MessageType.AssistantMessage,
                 });
                 break;

--- a/workspaces/mi/mi-visualizer/src/views/AIPanel/utils/eventToMessageConverter.ts
+++ b/workspaces/mi/mi-visualizer/src/views/AIPanel/utils/eventToMessageConverter.ts
@@ -343,6 +343,23 @@ export function convertEventsToMessages(
                 });
                 break;
 
+            case 'context_warning':
+                // Flush any pending assistant message and emit a standalone synthetic
+                // message wrapping <agents-md-warning>. Parsed by splitContent and
+                // rendered by ContextWarningSegment (mirrors the compact_summary path).
+                if (currentAssistantMessage) {
+                    messages.push(currentAssistantMessage);
+                    currentAssistantMessage = null;
+                }
+                activeChatId = undefined;
+                messages.push({
+                    id: generateId(),
+                    role: Role.MICopilot,
+                    content: `<agents-md-warning>${(event as any).warningMessage || event.content || ''}</agents-md-warning>`,
+                    type: MessageType.AssistantMessage,
+                });
+                break;
+
             case 'undo_checkpoint': {
                 // Undo checkpoint entries from history/stream are ignored.
                 // Review card state is ephemeral and managed from live stop events only.


### PR DESCRIPTION
## Summary

Adds support for a root-level `AGENTS.md` file (matching the convention used by Claude Code's `CLAUDE.md`, Cursor, Aider, and OpenAI's `agents.md` spec). Users can pin project-specific instructions (house style, naming conventions, "always use X for Y") and the agent follows them as authoritative on top of the system prompt.

`AGENTS.md` is auto-loaded and re-sent only when its contents change, so it does not waste tokens every turn. Files over 30 KB are truncated before being sent to the model; both the model and the user see a clear notice that context was cut, and the agent can fetch the truncated tail on demand.

Fixes: https://github.com/wso2-enterprise/integration-engineering/issues/1381

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for project-level configuration files to customize agent behavior
  * Introduced context warning messages when configuration exceeds size limits
  * Warnings are persisted in chat history for future reference
  * New visual warning indicator in chat for truncated content

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/vscode-extensions/pull/2300?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->