### PR TITLE
Fix unable to open AI agent service when extra functions exist

### DIFF
--- a/workspaces/ballerina/component-diagram/src/components/nodes/EntryNode/components/AIServiceWidget.tsx
+++ b/workspaces/ballerina/component-diagram/src/components/nodes/EntryNode/components/AIServiceWidget.tsx
@@ -105,17 +105,14 @@ export function AIServiceWidget({ model, engine }: BaseNodeWidgetProps) {
     const { onFunctionSelect, onDeleteComponent, readonly } = useDiagramContext();
     const isMenuOpen = Boolean(menuAnchorEl);
 
-    const serviceFunctions = [];
-    if ((model.node as CDService).remoteFunctions?.length > 0) {
-        serviceFunctions.push(...(model.node as CDService).remoteFunctions);
-    }
-    if ((model.node as CDService).resourceFunctions?.length > 0) {
-        serviceFunctions.push(...(model.node as CDService).resourceFunctions);
-    }
+    // ai:Listener entry point is fixed to `post chat`.
+    const chatResource = (model.node as CDService).resourceFunctions?.find(
+        (r) => r.accessor === "post" && r.path === "chat"
+    );
 
     const handleOnClick = () => {
-        if (serviceFunctions.length > 0) {
-            onFunctionSelect(serviceFunctions[0]);
+        if (chatResource) {
+            onFunctionSelect(chatResource);
         }
     };
 
@@ -198,9 +195,9 @@ export function AIServiceWidget({ model, engine }: BaseNodeWidgetProps) {
             </Popover>
 
             <BottomPortWidget port={model.getPort("out")!} engine={engine} />
-            {serviceFunctions.length > 0 && (
+            {chatResource && (
                 <BottomPortWidget
-                    port={model.getPort(getEntryNodeFunctionPortName(serviceFunctions[0]))!}
+                    port={model.getPort(getEntryNodeFunctionPortName(chatResource))!}
                     engine={engine}
                 />
             )}


### PR DESCRIPTION
## Summary

Fixes https://github.com/wso2/product-integrator/issues/1525

The AI Agent Service entry node in the component diagram picked the first function (remotes first, then resources). A stray `remote function chat` — e.g. one mistakenly generated by Copilot alongside the real `resource function post chat` — would be selected, sending navigation to a location no AI service artifact covers, so the editor failed to open.

Now the click target is found by an exact match on `accessor === "post" && path === "chat"`, which is the only valid `ai:Listener` entry point.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected AI service widget functionality in component diagrams to accurately identify and select chat service entry points based on specific connection parameters. Previously, the system aggregated multiple function types and selected the first available option. Updated visual port connections to properly reflect the selected resource.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/vscode-extensions/pull/2303?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->