### PR TITLE
Switch agent file tools to a binary deny-list

### DIFF
--- a/workspaces/mi/mi-extension/src/ai-features/agent-mode/tools/file_tools.ts
+++ b/workspaces/mi/mi-extension/src/ai-features/agent-mode/tools/file_tools.ts
@@ -26,8 +26,7 @@ import * as vscode from 'vscode';
 import {
     ValidationResult,
     ToolResult,
-    VALID_FILE_EXTENSIONS,
-    VALID_SPECIAL_FILE_NAMES,
+    hasBlockedBinaryExtension,
     MAX_LINE_LENGTH,
     ErrorMessages,
     FILE_READ_TOOL_NAME,
@@ -119,40 +118,22 @@ function getPdfDocumentStatic(): PdfDocumentStaticLike {
     }
 }
 
+/**
+ * Returns true if a path is safe to read or write as text — anything not in
+ * the binary deny-list. This includes files with no extension (Dockerfile,
+ * Makefile, .gitignore, etc.).
+ */
 function isTextAllowedFilePath(filePath: string): boolean {
     const normalizedPath = filePath.trim();
     if (!normalizedPath) {
         return false;
     }
-
-    const fileName = path.basename(normalizedPath);
-    const lowerFileName = fileName.toLowerCase();
-    const hasValidExtension = VALID_FILE_EXTENSIONS.some(ext =>
-        lowerFileName.endsWith(ext)
-    );
-    if (hasValidExtension) {
-        return true;
-    }
-
-    return VALID_SPECIAL_FILE_NAMES.some(
-        (specialName) => specialName.toLowerCase() === lowerFileName
-    );
-}
-
-function getAllowedFileTypesDescription(): string {
-    return [...VALID_FILE_EXTENSIONS, ...VALID_SPECIAL_FILE_NAMES].join(', ');
-}
-
-function getReadAllowedFileTypesDescription(): string {
-    return [...VALID_FILE_EXTENSIONS, ...VALID_SPECIAL_FILE_NAMES, READ_PDF_EXTENSION, ...READ_IMAGE_EXTENSIONS].join(', ');
+    return !hasBlockedBinaryExtension(path.basename(normalizedPath));
 }
 
 function getReadFileKind(filePath: string): ReadFileKind {
-    if (isTextAllowedFilePath(filePath)) {
-        return 'text';
-    }
-
     const lowerExt = path.extname(filePath).toLowerCase();
+
     if (lowerExt === READ_PDF_EXTENSION) {
         return 'pdf';
     }
@@ -161,7 +142,12 @@ function getReadFileKind(filePath: string): ReadFileKind {
         return 'image';
     }
 
-    return 'unsupported';
+    // For everything else, the deny-list is authoritative — anything not
+    // blocked is treated as text (including extensionless files).
+    if (hasBlockedBinaryExtension(path.basename(filePath))) {
+        return 'unsupported';
+    }
+    return 'text';
 }
 
 function getImageMediaType(filePath: string): string | undefined {
@@ -333,11 +319,11 @@ function validateTextFilePath(projectPath: string, filePath: string): Validation
         return securityValidation;
     }
 
-    // Reject non-text files (images, PDFs, binaries) to prevent corrupt overwrites
+    // Reject binary files (images, PDFs, archives, native binaries, etc.) to prevent corrupt overwrites.
     if (!isTextAllowedFilePath(filePath)) {
         return {
             valid: false,
-            error: `Cannot write/edit binary or non-text file '${filePath}'. Allowed text file types: ${getAllowedFileTypesDescription()}`
+            error: `Cannot write/edit binary file '${filePath}'. The extension is on the blocked-binary list (archives, executables, images, PDFs, office docs, fonts, media, etc.).`
         };
     }
 
@@ -359,7 +345,7 @@ function validateReadableFilePath(projectPath: string, filePath: string): Valida
     if (getReadFileKind(filePath) === 'unsupported') {
         return {
             valid: false,
-            error: `File must use an allowed read type: ${getReadAllowedFileTypesDescription()}`
+            error: `Cannot read binary file '${filePath}'. The extension is on the blocked-binary list (archives, executables, native libraries, office docs, fonts, audio/video, etc.). Use shell tools for binary inspection if needed.`
         };
     }
 

--- a/workspaces/mi/mi-extension/src/ai-features/agent-mode/tools/file_tools.ts
+++ b/workspaces/mi/mi-extension/src/ai-features/agent-mode/tools/file_tools.ts
@@ -132,7 +132,8 @@ function isTextAllowedFilePath(filePath: string): boolean {
 }
 
 function getReadFileKind(filePath: string): ReadFileKind {
-    const lowerExt = path.extname(filePath).toLowerCase();
+    const trimmed = filePath.trim();
+    const lowerExt = path.extname(trimmed).toLowerCase();
 
     if (lowerExt === READ_PDF_EXTENSION) {
         return 'pdf';
@@ -144,7 +145,7 @@ function getReadFileKind(filePath: string): ReadFileKind {
 
     // For everything else, the deny-list is authoritative — anything not
     // blocked is treated as text (including extensionless files).
-    if (hasBlockedBinaryExtension(path.basename(filePath))) {
+    if (hasBlockedBinaryExtension(path.basename(trimmed))) {
         return 'unsupported';
     }
     return 'text';

--- a/workspaces/mi/mi-extension/src/ai-features/agent-mode/tools/shell_sandbox.ts
+++ b/workspaces/mi/mi-extension/src/ai-features/agent-mode/tools/shell_sandbox.ts
@@ -20,6 +20,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { analyzePowerShellCommand } from './shell_sandbox_powershell';
+import { hasBlockedBinaryExtension } from './types';
 
 /**
  * Shell sandbox policy summary:
@@ -1259,6 +1260,12 @@ function analyzeSegment(
     const disallowedMutationPaths = isMutation
         ? findDisallowedMutationPaths(projectPath, allowedMutationRoots, writePathTokens)
         : [];
+    // Block mutations whose destination is a binary file (matches the file_tool deny-list).
+    // Skip tokens that still contain unresolved shell expansion — those are handled by
+    // dynamicMutationPathTokens above, and naive endsWith checks would miss them anyway.
+    const blockedBinaryMutationPaths = writePathTokens.filter(
+        (token) => !hasDynamicShellExpansion(token) && hasBlockedBinaryExtension(path.basename(token))
+    );
     const resolvedMutationPaths = isMutation ? resolveMutationPaths(projectPath, writePathTokens) : [];
     const writesOnlyToExternalAllowedRoots = resolvedMutationPaths.length > 0
         && resolvedMutationPaths.every((resolvedPath) =>
@@ -1284,6 +1291,13 @@ function analyzeSegment(
         reasons.push(
             `Mutating paths outside allowed roots is blocked. Disallowed path(s): ${disallowedMutationPaths.join(', ')}. ` +
             `Allowed roots: project root${outsideRoots ? `, ${outsideRoots}` : ''}.`
+        );
+    } else if (blockedBinaryMutationPaths.length > 0) {
+        blocked = true;
+        reasons.push(
+            `Writing to binary file paths is blocked (matches the file-tool deny-list). ` +
+            `Blocked path(s): ${blockedBinaryMutationPaths.join(', ')}. ` +
+            `Use directory-level operations (e.g. \`rm -rf dist\`) instead of targeting binary files by name.`
         );
     } else if (isMutation && !writesOnlyToExternalAllowedRoots) {
         reasons.push('Commands that may modify files or system state require approval.');

--- a/workspaces/mi/mi-extension/src/ai-features/agent-mode/tools/shell_sandbox.ts
+++ b/workspaces/mi/mi-extension/src/ai-features/agent-mode/tools/shell_sandbox.ts
@@ -1295,7 +1295,7 @@ function analyzeSegment(
     } else if (blockedBinaryMutationPaths.length > 0) {
         blocked = true;
         reasons.push(
-            `Writing to binary file paths is blocked (matches the file-tool deny-list). ` +
+            `Mutating binary file paths is blocked (write/edit/delete/rename; matches the file-tool deny-list). ` +
             `Blocked path(s): ${blockedBinaryMutationPaths.join(', ')}. ` +
             `Use directory-level operations (e.g. \`rm -rf dist\`) instead of targeting binary files by name.`
         );

--- a/workspaces/mi/mi-extension/src/ai-features/agent-mode/tools/shell_sandbox_powershell.ts
+++ b/workspaces/mi/mi-extension/src/ai-features/agent-mode/tools/shell_sandbox_powershell.ts
@@ -20,6 +20,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { parsePowerShellAst, PowerShellAstCommand, PowerShellAstResult } from './shell_sandbox_powershell_ast';
+import { hasBlockedBinaryExtension } from './types';
 
 interface ShellSegmentAnalysisLike {
     raw: string;
@@ -895,6 +896,24 @@ export function analyzePowerShellCommand(
         reasons.push(
             `Mutating paths outside allowed roots is blocked. Disallowed path(s): ${dedupe(disallowedMutationPaths).join(', ')}. ` +
             `Allowed roots: project root, ${normalizedExternalAllowedRoots.join(', ')}.`
+        );
+    }
+
+    // Mirror the POSIX analyzer: block mutations targeting binary file paths
+    // (matches the file-tool deny-list). Basename is compared case-insensitively
+    // via `hasBlockedBinaryExtension`. We use `path.win32.basename` to handle
+    // both `/` and `\` separators in PowerShell tokens.
+    const blockedBinaryMutationPaths = dedupe(
+        extractedPathTokens.mutationPathTokens.filter(
+            (token) => hasBlockedBinaryExtension(path.win32.basename(stripWrappingQuotes(token)))
+        )
+    );
+    if (blockedBinaryMutationPaths.length > 0) {
+        blocked = true;
+        reasons.push(
+            `Mutating binary file paths is blocked (write/edit/delete/rename; matches the file-tool deny-list). ` +
+            `Blocked path(s): ${blockedBinaryMutationPaths.join(', ')}. ` +
+            `Use directory-level operations (e.g. \`Remove-Item -Recurse dist\`) instead of targeting binary files by name.`
         );
     }
 

--- a/workspaces/mi/mi-extension/src/ai-features/agent-mode/tools/types.ts
+++ b/workspaces/mi/mi-extension/src/ai-features/agent-mode/tools/types.ts
@@ -62,46 +62,57 @@ export interface FileEditHunk {
 // Constants
 // ============================================================================
 
-// TODO: This should be checked. Some files might be in the project that are not in this list.
 /**
- * Valid file extensions for MI/Synapse projects
- * - .xml: Synapse configurations (APIs, sequences, endpoints, etc.)
- * - .yaml/.yml: Configuration files
- * - .properties: Property files
- * - .md: Documentation
- * - .json: JSON configurations
- * - .dmc: Data mapper configurations
- * - .ts: TypeScript files (for data mapper)
+ * Binary / non-text file extensions that the agent must not open or mutate
+ * as text. Anything else is treated as text-writable by file_write/file_edit
+ * and as text-readable by file_read (images and PDFs are routed to multimodal
+ * read paths separately and so are also listed here to block text writes).
+ *
+ * Keep entries lowercase, leading-dot. Order is informational only.
  */
-export const VALID_FILE_EXTENSIONS = [
-    '.xml',
-    '.yaml',
-    '.yml',
-    '.properties',
-    '.md',
-    '.json',
-    '.dmc',
-    '.ts',
-    '.toml',
-    '.txt',
-    '.log',
-    '.java',
-    '.xslt',
-    '.sql',
-    '.xsd',
-    '.wsdl',
-    '.csv',
-    '.html',
-    '.sh',
-    '.bat'
-];
+export const BLOCKED_BINARY_EXTENSIONS = [
+    // Archives / compressed
+    '.zip', '.tar', '.gz', '.tgz', '.bz2', '.tbz2', '.7z', '.rar', '.xz', '.lz', '.lzma', '.zst',
+    // JVM compiled artifacts
+    '.jar', '.war', '.ear', '.class',
+    // Native binaries / object files
+    '.exe', '.dll', '.so', '.dylib', '.bin', '.o', '.a', '.lib', '.obj', '.pdb',
+    // Compiled Python
+    '.pyc', '.pyo', '.pyd',
+    // Office documents (binary; the agent can't meaningfully edit these as text)
+    '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx', '.odt', '.ods', '.odp',
+    // Image formats not handled by the multimodal read path
+    '.bmp', '.tiff', '.tif', '.ico', '.heic', '.heif', '.avif',
+    // Images handled by the multimodal read path — blocked for writes only.
+    // file_read special-cases these (see READ_IMAGE_EXTENSIONS in file_tools.ts).
+    '.png', '.jpg', '.jpeg', '.gif', '.webp',
+    // PDF — blocked for writes only; file_read routes to the PDF multimodal path.
+    '.pdf',
+    // Audio
+    '.mp3', '.wav', '.flac', '.ogg', '.aac', '.m4a', '.wma',
+    // Video
+    '.mp4', '.mov', '.avi', '.mkv', '.webm', '.flv', '.wmv', '.mpeg', '.mpg', '.m4v',
+    // Fonts
+    '.ttf', '.otf', '.woff', '.woff2', '.eot',
+    // Databases
+    '.db', '.sqlite', '.sqlite3', '.mdb', '.accdb',
+    // Installers / disk images
+    '.iso', '.dmg', '.deb', '.rpm', '.msi', '.pkg', '.apk', '.ipa',
+    // Design assets
+    '.psd', '.ai', '.sketch', '.fig'
+] as const;
 
 /**
- * Valid file names without extensions
+ * Returns true if `filePath` ends with an extension in {@link BLOCKED_BINARY_EXTENSIONS}.
+ * Case-insensitive; safe to call with a basename or a full path.
  */
-export const VALID_SPECIAL_FILE_NAMES = [
-    'Dockerfile',
-];
+export function hasBlockedBinaryExtension(filePath: string): boolean {
+    if (!filePath) {
+        return false;
+    }
+    const lower = filePath.toLowerCase();
+    return BLOCKED_BINARY_EXTENSIONS.some((ext) => lower.endsWith(ext));
+}
 
 export const MAX_LINE_LENGTH = 2000;
 export const DEFAULT_READ_LIMIT = 2000;

--- a/workspaces/mi/mi-extension/src/ai-features/agent-mode/tools/validation-utils.ts
+++ b/workspaces/mi/mi-extension/src/ai-features/agent-mode/tools/validation-utils.ts
@@ -115,8 +115,9 @@ export async function validateXmlFile(
     projectPath: string,
     includeCodeActions: boolean = false
 ): Promise<ValidationDiagnostics | null> {
-    // Only validate XML files
-    if (!absolutePath.toLowerCase().endsWith('.xml')) {
+    // Only validate XML files (incl. .dbs data services, which are XML in the SynapseXml language).
+    const lowerPath = absolutePath.toLowerCase();
+    if (!lowerPath.endsWith('.xml') && !lowerPath.endsWith('.dbs')) {
         return null;
     }
 

--- a/workspaces/mi/mi-extension/src/rpc-managers/agent-mode/rpc-manager.ts
+++ b/workspaces/mi/mi-extension/src/rpc-managers/agent-mode/rpc-manager.ts
@@ -68,7 +68,6 @@ import {
 } from '../../ai-features/agent-mode/tools/plan_mode_tools';
 import { cleanupPersistedToolResultsForProject } from '../../ai-features/agent-mode/tools/tool-result-persistence';
 import { validateAttachments } from '../../ai-features/agent-mode/attachment-utils';
-import { VALID_FILE_EXTENSIONS, VALID_SPECIAL_FILE_NAMES } from '../../ai-features/agent-mode/tools/types';
 import { cleanupRunningBackgroundShells } from '../../ai-features/agent-mode/tools/bash_tools';
 import { cleanupRunningBackgroundSubagents } from '../../ai-features/agent-mode/tools/subagent_tool';
 import { beginServerManagementRunTracking, cleanupServerManagementOnAgentEnd } from '../../ai-features/agent-mode/tools/runtime_tools';
@@ -92,6 +91,15 @@ const MENTION_MAX_CACHE_ITEMS = 5000;
 const SHELL_APPROVAL_RULES_FILE_NAME = 'shell-approval-rules.json';
 const MENTION_ROOT_DIRS = ['deployment', 'src'];
 const MENTION_POM_FILE = 'pom.xml';
+// Extensions surfaced in the @-mention picker. This is a UX allow-list (keep
+// it short to avoid noisy results), not a security boundary — file-tool
+// security uses the deny-list in tools/types.ts. Keep entries lowercase.
+const MENTIONABLE_FILE_EXTENSIONS = new Set([
+    '.xml', '.dbs', '.yaml', '.yml', '.properties', '.md', '.json',
+    '.dmc', '.ts', '.toml', '.txt', '.log', '.java', '.xslt', '.sql',
+    '.xsd', '.wsdl', '.csv', '.html', '.sh', '.bat'
+]);
+const MENTIONABLE_SPECIAL_FILE_NAMES = ['Dockerfile'];
 const MENTION_SKIP_DIRS = new Set([
     '.git',
     'node_modules',
@@ -1403,10 +1411,10 @@ export class MIAgentPanelRpcManager implements MIAgentPanelAPI {
     private isMentionableFile(fileName: string): boolean {
         const lowerFileName = fileName.toLowerCase();
         const ext = path.extname(fileName).toLowerCase();
-        if (VALID_FILE_EXTENSIONS.includes(ext)) {
+        if (MENTIONABLE_FILE_EXTENSIONS.has(ext)) {
             return true;
         }
-        return VALID_SPECIAL_FILE_NAMES.some(
+        return MENTIONABLE_SPECIAL_FILE_NAMES.some(
             (specialName) => specialName.toLowerCase() === lowerFileName
         );
     }
@@ -1534,7 +1542,7 @@ export class MIAgentPanelRpcManager implements MIAgentPanelAPI {
             }
         };
 
-        const rootTopLevelFiles = [MENTION_POM_FILE, ...VALID_SPECIAL_FILE_NAMES];
+        const rootTopLevelFiles = [MENTION_POM_FILE, ...MENTIONABLE_SPECIAL_FILE_NAMES];
         for (const topLevelFile of rootTopLevelFiles) {
             if (mentionables.size >= MENTION_MAX_CACHE_ITEMS) {
                 break;


### PR DESCRIPTION
## Summary

The agent's file tools previously used an allow-list of ~20 text extensions plus `Dockerfile`, which blocked common extensionless files (`Makefile`, `.gitignore`, `LICENSE`, etc.) and any unanticipated text format.

This PR inverts the gate to a deny-list of binary extensions (archives, executables, office docs, images, PDFs, media, fonts, etc.). Everything else, including extensionless files, is treated as text.

## Changes

- New shared `BLOCKED_BINARY_EXTENSIONS` + `hasBlockedBinaryExtension()` helper.
- `file_read` / `file_write` / `file_edit` now defer to the deny-list (multimodal routing for images and PDFs unchanged).
- Shell sandbox enforces the same deny-list on mutation paths.
- XML validation extended to `.dbs` data-service files.
- `@`-mention picker decoupled from the security gate; it keeps its own short UX allow-list.

Fixes: https://github.com/wso2/product-integrator/issues/1474