### PR TITLE
Fix copilot-created class mediators not packed in CApp

### DIFF
--- a/workspaces/mi/mi-extension/src/ai-features/agent-mode/context/synapse_guide.ts
+++ b/workspaces/mi/mi-extension/src/ai-features/agent-mode/context/synapse_guide.ts
@@ -61,7 +61,7 @@ export const SYNAPSE_GUIDE = `
    - Use the Redis connector instead of the cache mediator for Redis cache.
    - Do not leave placeholders like "To be implemented". Always implement the complete solution.
    - Use WSO2 Connectors whenever possible instead of directly calling APIs.
-   - Do not use new class mediators unless absolutely necessary.
+   - Do not use new class mediators unless absolutely necessary. When you do create one, also flip the root \`pom.xml\` from \`<packaging>pom</packaging>\` to \`<packaging>jar</packaging>\` and ensure a \`synapse-core\` dependency is declared, otherwise the CApp will not pack the jar.
    - Define driver, username, dburl, and passwords inside the dbreport or dblookup mediator <connection> tag instead of generating deployment toml file changes.
    - Do not use fake XML placeholders (e.g., <TODO>, <placeholder>, <...>).
    - The respond mediator should be empty; it does not support child elements.

--- a/workspaces/mi/mi-extension/src/ai-features/agent-mode/context/synapse_guide_old.ts
+++ b/workspaces/mi/mi-extension/src/ai-features/agent-mode/context/synapse_guide_old.ts
@@ -54,7 +54,7 @@ export const SYNAPSE_GUIDE = `
    - When updating an XML artifact, provide the entire file with updated content.
    - Do not leave placeholders like "To be implemented". Always implement the complete solution.
    - Use WSO2 Connectors whenever possible instead of directly calling APIs.
-   - Do not use new class mediators unless it is absolutely necessary.
+   - Do not use new class mediators unless it is absolutely necessary. When you do create one, also flip the root \`pom.xml\` from \`<packaging>pom</packaging>\` to \`<packaging>jar</packaging>\` and ensure a \`synapse-core\` dependency is declared, otherwise the CApp will not pack the jar.
    - Define driver, username, dburl, and passwords inside the dbreport or dblookup mediator <connection> tag instead of generating deployment toml file changes.
    - Do not use fake XML placeholders (for example, <TODO>, <placeholder>, or <...>) in generated artifacts.
    - To include an API key in uri-template, define:

--- a/workspaces/mi/mi-extension/src/ai-features/agent-mode/tools/file_tools.ts
+++ b/workspaces/mi/mi-extension/src/ai-features/agent-mode/tools/file_tools.ts
@@ -652,6 +652,22 @@ function trackModifiedFile(modifiedFiles: string[] | undefined, filePath: string
     }
 }
 
+/**
+ * Returns true for class mediator java sources under src/main/java/.
+ * Used to nudge the agent to keep root pom.xml packaging and deps consistent;
+ * the CApp will not pack the jar when packaging is still "pom".
+ */
+function isClassMediatorPath(filePath: string): boolean {
+    const normalized = filePath.replace(/\\/g, '/').toLowerCase();
+    return /(^|\/)src\/main\/java\//.test(normalized) && normalized.endsWith('.java');
+}
+
+const CLASS_MEDIATOR_POM_REMINDER =
+    '\n\n<system-reminder>You just wrote/edited a class mediator java source. ' +
+    'Verify the project root pom.xml has <packaging>jar</packaging> (default is "pom") ' +
+    'and that a synapse-core dependency is declared. Without both, the CApp will not ' +
+    'pack the jar and the class mediator will silently fail to deploy.</system-reminder>';
+
 
 // ============================================================================
 // Execute Functions (Business Logic)
@@ -780,9 +796,10 @@ export function createWriteExecute(
         console.log(`[FileWriteTool] Successfully ${action} and synced file: ${file_path} with ${lineCount} lines`);
 
         // Build result with structured validation data
+        const classMediatorReminder = isClassMediatorPath(file_path) ? CLASS_MEDIATOR_POM_REMINDER : '';
         const result: ToolResult = {
             success: true,
-            message: `Successfully ${action} file '${file_path}' with ${lineCount} line(s).${validation ? formatValidationMessage(validation, 15) : ''}`
+            message: `Successfully ${action} file '${file_path}' with ${lineCount} line(s).${validation ? formatValidationMessage(validation, 15) : ''}${classMediatorReminder}`
         };
 
         if (validation) {
@@ -1077,9 +1094,10 @@ export function createEditExecute(
         const replacedCount = replace_all ? occurrences : 1;
         logDebug(`[FileEditTool] Successfully replaced ${replacedCount} occurrence(s) in: ${file_path}`);
 
+        const classMediatorReminder = isClassMediatorPath(file_path) ? CLASS_MEDIATOR_POM_REMINDER : '';
         const result: ToolResult = {
             success: true,
-            message: `Replaced ${replacedCount} occurrence(s) in '${file_path}'.${validation ? formatValidationMessage(validation, 15) : ''}`
+            message: `Replaced ${replacedCount} occurrence(s) in '${file_path}'.${validation ? formatValidationMessage(validation, 15) : ''}${classMediatorReminder}`
         };
 
         if (validation) {

--- a/workspaces/mi/mi-extension/src/ai-features/agent-mode/tools/file_tools.ts
+++ b/workspaces/mi/mi-extension/src/ai-features/agent-mode/tools/file_tools.ts
@@ -654,19 +654,45 @@ function trackModifiedFile(modifiedFiles: string[] | undefined, filePath: string
 
 /**
  * Returns true for class mediator java sources under src/main/java/.
- * Used to nudge the agent to keep root pom.xml packaging and deps consistent;
- * the CApp will not pack the jar when packaging is still "pom".
  */
 function isClassMediatorPath(filePath: string): boolean {
     const normalized = filePath.replace(/\\/g, '/').toLowerCase();
     return /(^|\/)src\/main\/java\//.test(normalized) && normalized.endsWith('.java');
 }
 
-const CLASS_MEDIATOR_POM_REMINDER =
-    '\n\n<system-reminder>You just wrote/edited a class mediator java source. ' +
-    'Verify the project root pom.xml has <packaging>jar</packaging> (default is "pom") ' +
-    'and that a synapse-core dependency is declared. Without both, the CApp will not ' +
-    'pack the jar and the class mediator will silently fail to deploy.</system-reminder>';
+/**
+ * Builds a `<system-reminder>` for class mediator writes/edits when the
+ * project root pom.xml is not yet configured to pack a jar. Returns ''
+ * when packaging is already "jar" so the model is not nagged unnecessarily.
+ * Falls back to a generic reminder if pom.xml cannot be read or parsed,
+ * since the safe default is to surface the requirement.
+ */
+function buildClassMediatorPomReminder(projectPath: string): string {
+    const pomPath = path.join(projectPath, 'pom.xml');
+    let currentPackaging: string | undefined;
+    try {
+        const pomContent = fs.readFileSync(pomPath, 'utf-8');
+        const match = pomContent.match(/<packaging>\s*([^<\s]+)\s*<\/packaging>/);
+        currentPackaging = match?.[1]?.toLowerCase();
+    } catch {
+        // pom.xml missing or unreadable; fall through to the generic reminder.
+    }
+
+    if (currentPackaging === 'jar') {
+        return '';
+    }
+
+    const currentDesc = currentPackaging
+        ? `currently <packaging>${currentPackaging}</packaging>`
+        : 'current packaging could not be determined';
+    return (
+        '\n\n<system-reminder>You just wrote/edited a class mediator java source, ' +
+        `but the project root pom.xml ${currentDesc}. ` +
+        'Change it to <packaging>jar</packaging> and ensure a synapse-core dependency ' +
+        'is declared, otherwise the CApp will not pack the jar and the class mediator ' +
+        'will silently fail to deploy.</system-reminder>'
+    );
+}
 
 
 // ============================================================================
@@ -796,7 +822,7 @@ export function createWriteExecute(
         console.log(`[FileWriteTool] Successfully ${action} and synced file: ${file_path} with ${lineCount} lines`);
 
         // Build result with structured validation data
-        const classMediatorReminder = isClassMediatorPath(file_path) ? CLASS_MEDIATOR_POM_REMINDER : '';
+        const classMediatorReminder = isClassMediatorPath(file_path) ? buildClassMediatorPomReminder(projectPath) : '';
         const result: ToolResult = {
             success: true,
             message: `Successfully ${action} file '${file_path}' with ${lineCount} line(s).${validation ? formatValidationMessage(validation, 15) : ''}${classMediatorReminder}`
@@ -1094,7 +1120,7 @@ export function createEditExecute(
         const replacedCount = replace_all ? occurrences : 1;
         logDebug(`[FileEditTool] Successfully replaced ${replacedCount} occurrence(s) in: ${file_path}`);
 
-        const classMediatorReminder = isClassMediatorPath(file_path) ? CLASS_MEDIATOR_POM_REMINDER : '';
+        const classMediatorReminder = isClassMediatorPath(file_path) ? buildClassMediatorPomReminder(projectPath) : '';
         const result: ToolResult = {
             success: true,
             message: `Replaced ${replacedCount} occurrence(s) in '${file_path}'.${validation ? formatValidationMessage(validation, 15) : ''}${classMediatorReminder}`


### PR DESCRIPTION
## Summary

- Instruct agent-mode (both v2 and legacy synapse guides) to flip the project root `pom.xml` from `<packaging>pom</packaging>` to `<packaging>jar</packaging>` and ensure a `synapse-core` dependency is declared whenever the agent creates a class mediator.
- Without this, copilot-created class mediators silently fail to deploy because the CApp does not pack the compiled jar (root cause documented in the linked issue).

## Issue

Fixes wso2/product-integrator#1631