### PR TITLE
Prevent duplicate generations in devant restarts

### DIFF
--- a/workspaces/ballerina/ballerina-core/src/rpc-types/ai-panel/index.ts
+++ b/workspaces/ballerina/ballerina-core/src/rpc-types/ai-panel/index.ts
@@ -67,6 +67,7 @@ export interface AIPanelAPI {
     getDefaultPrompt: () => Promise<AIPanelPrompt>; //starting args
     getAIMachineSnapshot: () => Promise<AIMachineSnapshot>; //login state machine
     clearInitialPrompt: () => void; //starting args
+    isScaffoldEnvActive: () => Promise<boolean>; // INITIAL_SCAFFOLD_PROMPT env present (Devant)
     // Data-mapper related functions
     openChatWindowWithCommand: () => void;
     generateContextTypes: (params: ProcessContextTypeCreationRequest) => void;

--- a/workspaces/ballerina/ballerina-core/src/rpc-types/ai-panel/rpc-type.ts
+++ b/workspaces/ballerina/ballerina-core/src/rpc-types/ai-panel/rpc-type.ts
@@ -67,6 +67,7 @@ export const isPlatformExtensionAvailable: RequestType<void, boolean> = { method
 export const getDefaultPrompt: RequestType<void, AIPanelPrompt> = { method: `${_preFix}/getDefaultPrompt` };
 export const getAIMachineSnapshot: RequestType<void, AIMachineSnapshot> = { method: `${_preFix}/getAIMachineSnapshot` };
 export const clearInitialPrompt: NotificationType<void> = { method: `${_preFix}/clearInitialPrompt` };
+export const isScaffoldEnvActive: RequestType<void, boolean> = { method: `${_preFix}/isScaffoldEnvActive` };
 export const openChatWindowWithCommand: NotificationType<void> = { method: `${_preFix}/openChatWindowWithCommand` };
 export const generateContextTypes: NotificationType<ProcessContextTypeCreationRequest> = { method: `${_preFix}/generateContextTypes` };
 export const generateMappingCode: NotificationType<ProcessMappingParametersRequest> = { method: `${_preFix}/generateMappingCode` };

--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/ai-panel/rpc-handler.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/ai-panel/rpc-handler.ts
@@ -53,6 +53,7 @@ import {
     getChatMessages,
     getCheckpoints,
     getDefaultPrompt,
+    isScaffoldEnvActive,
     getDriftDiagnosticContents,
     getFromDocumentation,
     getGeneratedDocumentation,
@@ -119,6 +120,7 @@ export function registerAiPanelRpcHandlers(messenger: Messenger) {
     messenger.onRequest(getLoginMethod, () => rpcManger.getLoginMethod());
     messenger.onRequest(isPlatformExtensionAvailable, () => rpcManger.isPlatformExtensionAvailable());
     messenger.onRequest(getDefaultPrompt, () => rpcManger.getDefaultPrompt());
+    messenger.onRequest(isScaffoldEnvActive, () => rpcManger.isScaffoldEnvActive());
     messenger.onRequest(getAIMachineSnapshot, () => rpcManger.getAIMachineSnapshot());
     messenger.onNotification(clearInitialPrompt, () => rpcManger.clearInitialPrompt());
     messenger.onNotification(openChatWindowWithCommand, () => rpcManger.openChatWindowWithCommand());

--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
@@ -143,6 +143,10 @@ export class AiPanelRpcManager implements AIPanelAPI {
         extension.aiChatDefaultPrompt = undefined;
     }
 
+    async isScaffoldEnvActive(): Promise<boolean> {
+        return !!(process.env.INITIAL_SCAFFOLD_PROMPT && process.env.INITIAL_SCAFFOLD_STEPS);
+    }
+
     async getServiceNames(): Promise<TestGenerationMentions> {
         return new Promise(async (resolve, reject) => {
             try {

--- a/workspaces/ballerina/ballerina-rpc-client/src/rpc-clients/ai-panel/rpc-client.ts
+++ b/workspaces/ballerina/ballerina-rpc-client/src/rpc-clients/ai-panel/rpc-client.ts
@@ -82,6 +82,7 @@ import {
     getChatMessages,
     getCheckpoints,
     getDefaultPrompt,
+    isScaffoldEnvActive,
     getDriftDiagnosticContents,
     getFromDocumentation,
     getGeneratedDocumentation,
@@ -146,6 +147,10 @@ export class AiPanelRpcClient implements AIPanelAPI {
 
     clearInitialPrompt(): void {
         return this._messenger.sendNotification(clearInitialPrompt, HOST_EXTENSION);
+    }
+
+    isScaffoldEnvActive(): Promise<boolean> {
+        return this._messenger.sendRequest(isScaffoldEnvActive, HOST_EXTENSION);
     }
 
     openChatWindowWithCommand(): void {

--- a/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -152,6 +152,18 @@ function appendToLastEntry(entries: StreamEntry[], item: StreamItem): StreamEntr
     return [...entries.slice(0, -1), { ...last, items: [...last.items, item] }];
 }
 
+const SCAFFOLD_DONE_PREFIX = "ballerina.scaffold.done:";
+
+// Stable, non-crypto hash for keying scaffold runs by (prompt + steps).
+function scaffoldKeyHash(text: string, hiddenContext: string | undefined): string {
+    const input = text + "\0" + (hiddenContext ?? "");
+    let h = 5381;
+    for (let i = 0; i < input.length; i++) {
+        h = ((h << 5) + h + input.charCodeAt(i)) | 0;
+    }
+    return (h >>> 0).toString(36);
+}
+
 const AIChat: React.FC = () => {
     const { rpcClient } = useRpcContext();
     const [messages, setMessages] = useState<Array<{ role: string; content: string; type: string; checkpointId?: string; messageId?: string }>>([]);
@@ -252,6 +264,7 @@ const AIChat: React.FC = () => {
     const messagesRef = useRef<any>([]);
 
     const isErrorChunkReceivedRef = useRef(false);
+    const activeScaffoldKeyRef = useRef<string | null>(null);
 
     const messagesEndRef = React.useRef<HTMLDivElement>(null);
 
@@ -279,7 +292,7 @@ const AIChat: React.FC = () => {
             rpcClient
                 .getAiPanelRpcClient()
                 .getDefaultPrompt()
-                .then((defaultPrompt: AIPanelPrompt) => {
+                .then(async (defaultPrompt: AIPanelPrompt) => {
                     if (defaultPrompt) {
                         // Extract CodeContext from both command-template metadata and text-type direct param
                         const codeCtx = defaultPrompt.type === 'command-template'
@@ -299,6 +312,23 @@ const AIChat: React.FC = () => {
                             setFooterInputPlaceholder(textPrompt.inputPlaceholder ?? "Describe your integration...");
 
                             if (defaultPrompt.autoSubmit && defaultPrompt.text.trim().length > 0) {
+                                // Devant scaffold gate: when the extension was launched with INITIAL_SCAFFOLD_PROMPT,
+                                // never auto-execute the same scaffold twice on this env URL (localStorage scoped per origin).
+                                // Fail open — if the RPC errors for any reason, behave as if env is unset.
+                                const isScaffoldEnv = await rpcClient
+                                    .getAiPanelRpcClient()
+                                    .isScaffoldEnvActive()
+                                    .catch(() => false);
+                                if (isScaffoldEnv) {
+                                    const key = SCAFFOLD_DONE_PREFIX + scaffoldKeyHash(defaultPrompt.text, defaultPrompt.hiddenContext);
+                                    if (localStorage.getItem(key) === "1") {
+                                        // Already executed in a previous session for this env+spec.
+                                        // Drop the cached prompt so it isn't re-served on next panel mount.
+                                        rpcClient.getAiPanelRpcClient().clearInitialPrompt();
+                                        return;
+                                    }
+                                    activeScaffoldKeyRef.current = key;
+                                }
                                 void handleSend({
                                     input: [{ content: defaultPrompt.text }],
                                     attachments: [],
@@ -878,9 +908,14 @@ const AIChat: React.FC = () => {
             setIsMigrationEnhancementRunning(false);
             fetchUsage();
             setAgentMode(AgentMode.Edit);
+            if (activeScaffoldKeyRef.current && !isErrorChunkReceivedRef.current) {
+                localStorage.setItem(activeScaffoldKeyRef.current, "1");
+            }
+            activeScaffoldKeyRef.current = null;
 
         } else if (type === "abort") {
             console.log("Received abort signal");
+            activeScaffoldKeyRef.current = null;
             setIsWebToolsEnabled(userWebSearchPreferenceRef.current);
             setWebToolApprovalRequest(null);
             const abortItem: StreamItem = { kind: "text", text: "*[Request interrupted by user]*" };


### PR DESCRIPTION
Cherry-pick of c1b1ba543e208a1beafbfa9a110ce0c693ff76a5 onto `hotfix/cloudeditor-05291`.

Prevents duplicate generations on Devant restarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added scaffold environment detection capability in the AI panel for enhanced initial prompt management.

* **Improvements**
  * Initial scaffold prompts now prevent duplicate auto-execution within the same environment, eliminating unnecessary repetition and providing a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->