### PR TITLE
Return config packagePath validation errors to the agent instead of the UI

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/config-collector.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/config-collector.ts
@@ -34,7 +34,7 @@ import {
     isPlaceholderValue,
     computeCollectStatus,
 } from "../../../../utils/toml-utils";
-import { resolveContained, resolvePackageBasePath } from "./path-utils";
+import { PathValidationError, resolveContained, resolvePackageBasePath } from "./path-utils";
 import { getOrgPackageName } from "../../../../utils/config";
 import { langClient } from "../../activator";
 
@@ -326,6 +326,9 @@ export async function ConfigCollectorTool(
                 return createErrorResult("INVALID_MODE", `Unknown mode: ${(input as any).mode}`);
         }
     } catch (error: any) {
+        if (error instanceof PathValidationError) {
+            return createErrorResult(error.code, error.message);
+        }
         return handleError(error, requestId, eventHandler);
     }
 }

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/config-collector.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/config-collector.ts
@@ -34,7 +34,7 @@ import {
     isPlaceholderValue,
     computeCollectStatus,
 } from "../../../../utils/toml-utils";
-import { PathValidationError, resolveContained, resolvePackageBasePath } from "./path-utils";
+import { RecoverableAgentError, resolveContained, resolvePackageBasePath } from "./path-utils";
 import { getOrgPackageName } from "../../../../utils/config";
 import { langClient } from "../../activator";
 
@@ -326,7 +326,7 @@ export async function ConfigCollectorTool(
                 return createErrorResult("INVALID_MODE", `Unknown mode: ${(input as any).mode}`);
         }
     } catch (error: any) {
-        if (error instanceof PathValidationError) {
+        if (error instanceof RecoverableAgentError) {
             return createErrorResult(error.code, error.message);
         }
         return handleError(error, requestId, eventHandler);

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/path-utils.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/path-utils.ts
@@ -17,6 +17,15 @@
 import * as fs from "fs";
 import * as path from "path";
 
+// Recoverable agent-input error — callers return it to the agent, not the user.
+export class PathValidationError extends Error {
+    readonly code = "INVALID_PATH";
+    constructor(message: string) {
+        super(message);
+        this.name = "PathValidationError";
+    }
+}
+
 /**
  * Safely resolve a relative path against a base directory, ensuring the
  * result remains contained within the base. Throws on absolute paths, null
@@ -25,7 +34,7 @@ import * as path from "path";
  */
 export function resolveContained(basePath: string, relativePath: string): string {
     if (path.isAbsolute(relativePath) || relativePath.includes("\0")) {
-        throw new Error(
+        throw new PathValidationError(
             `Invalid path "${relativePath}": must be a relative path within the project`
         );
     }
@@ -33,7 +42,7 @@ export function resolveContained(basePath: string, relativePath: string): string
     const resolved = path.resolve(baseResolved, relativePath);
     const rel = path.relative(baseResolved, resolved);
     if (rel === ".." || rel.startsWith(".." + path.sep) || path.isAbsolute(rel)) {
-        throw new Error(
+        throw new PathValidationError(
             `Invalid path "${relativePath}": escapes the project root`
         );
     }
@@ -73,7 +82,7 @@ export function resolvePackageBasePath(tempPath: string, packagePath?: string): 
     if (packagePath) {
         const resolved = resolveContained(tempPath, packagePath);
         if (!fs.existsSync(resolved) || !fs.statSync(resolved).isDirectory()) {
-            throw new Error(
+            throw new PathValidationError(
                 `Invalid packagePath: directory "${packagePath}" does not exist in the project`
             );
         }
@@ -81,7 +90,7 @@ export function resolvePackageBasePath(tempPath: string, packagePath?: string): 
     }
 
     if (isWorkspaceTempProject(tempPath)) {
-        throw new Error(
+        throw new PathValidationError(
             "packagePath is required for workspace projects. " +
             "Pass the relative package path (e.g., \"pkg1\") so the operation targets the correct package."
         );

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/path-utils.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/path-utils.ts
@@ -17,12 +17,17 @@
 import * as fs from "fs";
 import * as path from "path";
 
-// Recoverable agent-input error — callers return it to the agent, not the user.
-export class PathValidationError extends Error {
-    readonly code = "INVALID_PATH";
-    constructor(message: string) {
+// Bad agent input the agent can fix and retry — returned to it, not shown to the user.
+export class RecoverableAgentError extends Error {
+    constructor(message: string, readonly code: string) {
         super(message);
-        this.name = "PathValidationError";
+        this.name = new.target.name;
+    }
+}
+
+export class PathValidationError extends RecoverableAgentError {
+    constructor(message: string) {
+        super(message, "INVALID_PATH");
     }
 }
 


### PR DESCRIPTION
Related to https://github.com/wso2/product-integrator/issues/1637

- Add a `PathValidationError` type for recoverable packagePath/path validation failures
- In `ConfigCollector`, return these to the agent (so it can retry scoped to a package) instead of surfacing a "Configuration failed" card to the user


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error reporting in AI agent tools for invalid path inputs, delivering clearer and more consistent error messages when path validation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->