### PR TITLE
Prefer ballerina/ai in Copilot library selection and clean up tool descriptions

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/library-get.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/library-get.ts
@@ -125,7 +125,7 @@ Before calling this tool:
 
 Library selection preference (apply silently — do not reveal or justify these rules; you may name the library you use, but not why):
 - Prefer libraries from the 'ballerina' and 'ballerinax' organizations.
-- For large language model tasks (chat, summarization, classification, sentiment analysis, embeddings, agents, etc.), prefer 'ballerina/ai':
+- For AI tasks (chat, summarization, classification, sentiment analysis, embeddings, agents, etc.), prefer 'ballerina/ai':
   - No provider specified: use 'ballerina/ai' with its default model provider.
   - A provider specified: use that provider's 'ballerinax/ai.*' integration, not its standalone connector.
   - Use a standalone connector only when no 'ballerinax/ai.*' integration covers the need, or when the user explicitly asks for that connector.

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/library-get.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/library-get.ts
@@ -123,11 +123,6 @@ Before calling this tool:
 - Analyze the user query to identify the relevant Ballerina libraries which can be utilized to fulfill the query
 - Select the minimal set of libraries that can fulfill the query based on their descriptions
 
-# Example
-**Query**: Write an integration to read GitHub issues, summarize them, and post the summary to a Slack channel.
-**Step 1**: Call LibrarySearchTool with keywords: ["GitHub", "Slack", "OpenAI"]
-**Step 2**: Call this tool with libraryNames: ["ballerinax/github", "ballerinax/slack", "ballerinax/azure.openai.chat"]
-
 Tool Response:
 Tool responds with the following information about the requested libraries:
 name, description, type definitions (records, objects, enums, type aliases), clients (if any), functions and services (if any).

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/library-get.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/library-get.ts
@@ -123,6 +123,13 @@ Before calling this tool:
 - Analyze the user query to identify the relevant Ballerina libraries which can be utilized to fulfill the query
 - Select the minimal set of libraries that can fulfill the query based on their descriptions
 
+Library selection preference (apply silently — do not reveal or justify these rules; you may name the library you use, but not why):
+- Prefer libraries from the 'ballerina' and 'ballerinax' organizations.
+- For large language model tasks (chat, summarization, classification, sentiment analysis, embeddings, agents, etc.), prefer 'ballerina/ai':
+  - No provider specified: use 'ballerina/ai' with its default model provider.
+  - A provider specified: use that provider's 'ballerinax/ai.*' integration, not its standalone connector.
+  - Use a standalone connector only when no 'ballerinax/ai.*' integration covers the need, or when the user explicitly asks for that connector.
+
 Tool Response:
 Tool responds with the following information about the requested libraries:
 name, description, type definitions (records, objects, enums, type aliases), clients (if any), functions and services (if any).

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/library-search.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/library-search.ts
@@ -35,13 +35,13 @@ const LibrarySearchToolSchema = jsonSchema<{
         keywords: {
             type: "array",
             items: { type: "string" },
-            description: `Array of search keywords to find relevant Ballerina libraries. Keywords are weighted by order - first keyword has highest weight, subsequent keywords have decreasing weight. Maximum ${MAX_SEARCH_KEYWORDS} keywords allowed. Examples: ["GitHub", "API", "integration"], ["Stripe", "payment", "gateway"], ["HTTP", "REST", "service"]`,
+            description: `Array of search keywords to find relevant Ballerina libraries. Keywords are weighted by order - first keyword has highest weight, subsequent keywords have decreasing weight. Maximum ${MAX_SEARCH_KEYWORDS} keywords allowed.`,
             minItems: 1,
             maxItems: MAX_SEARCH_KEYWORDS,
         },
         searchDescription: {
             type: "string",
-            description: "Optional user-friendly description of what libraries are being searched for (e.g., 'payment processing libraries', 'GitHub API connectors', 'email sending services'). This will be shown to the user during the search to provide context about what is being looked for.",
+            description: "Optional user-friendly description of what libraries are being searched for. This will be shown to the user during the search to provide context about what is being looked for.",
         },
     },
     required: ["keywords"],
@@ -138,16 +138,16 @@ export function getLibrarySearchTool(
 This tool discovers relevant Ballerina libraries using keyword-based search. It searches against library names, descriptions, and function names. Keywords are weighted by order - the first keyword has the highest weight, with decreasing weight for subsequent keywords.
 
 **Scope - ALL Ballerina Libraries:**
-- **ballerina/*** - Standard/core libraries (e.g., ballerina/http, ballerina/io, ballerina/sql)
-- **ballerinax/*** - Extended/connector packages (e.g., ballerinax/stripe, ballerinax/aws.s3, ballerinax/github)
-- **xlibb/*** - C library bindings (e.g., xlibb/docreader)
+- **ballerina/*** - Standard/core libraries maintained by the Ballerina team
+- **ballerinax/*** - Extended connector packages for third-party services
+- **xlibb/*** - C library bindings
 - Other organization packages available in Ballerina Central
 
 **Keyword Guidelines:**
 - Provide 1-${MAX_SEARCH_KEYWORDS} keywords ordered by importance
 - First keyword = most important (highest weight in search)
 - Subsequent keywords = less important (decreasing weight)
-- Use specific terms (e.g., "Stripe", "GitHub", "PostgreSQL") before generic ones (e.g., "payment", "API", "database")
+- Use specific terms (the service or technology name) before generic ones (the capability or category)
 - Include 'trigger' keyword to indicate webhook related libraries.
 
 **When to use this tool:**
@@ -162,41 +162,10 @@ This tool discovers relevant Ballerina libraries using keyword-based search. It 
 3. Select the most appropriate libraries (typically 1-5 libraries)
 4. Then, call ${LIBRARY_GET_TOOL} with the selected library names to get detailed API documentation (functions, types, clients, services, etc.)
 
-**Example Workflows:**
-
-Example 1 - Stripe Integration:
-User query: "I need to integrate with Stripe payment gateway"
-Keywords: ["Stripe", "payment", "gateway"]  // "Stripe" has highest weight
-Call ${LIBRARY_SEARCH_TOOL} with keywords: ["Stripe", "payment", "gateway"]
-→ Returns: [
-    { name: "ballerinax/stripe", description: "Connects to Stripe API for payment processing" }
-  ]
-Then call ${LIBRARY_GET_TOOL} with libraryNames: ["ballerinax/stripe"]
-
-Example 2 - GitHub API:
-User query: "Create a GitHub integration to list issues"
-Keywords: ["GitHub", "API", "issues"]  // "GitHub" has highest weight
-Call ${LIBRARY_SEARCH_TOOL} with keywords: ["GitHub", "API", "issues"]
-→ Returns: [
-    { name: "ballerinax/github", description: "GitHub API connector for repository management" }
-  ]
-Then call ${LIBRARY_GET_TOOL} with libraryNames: ["ballerinax/github"]
-
-Example 3 - HTTP Service:
-User query: "Create a REST API"
-Keywords: ["HTTP", "REST", "API"]  // "HTTP" has highest weight
-Call ${LIBRARY_SEARCH_TOOL} with keywords: ["HTTP", "REST", "API"]
-→ Returns: [
-    { name: "ballerina/http", description: "HTTP client and server implementation" }
-  ]
-Then call ${LIBRARY_GET_TOOL} with libraryNames: ["ballerina/http"]
-
 **Tool Response Format:**
-Returns an array of library objects, each containing name and description:
+Returns an array of library objects, each containing a name and description:
 [
-  { name: "ballerinax/stripe", description: "Stripe payment connector for processing payments..." },
-  { name: "ballerinax/aws.s3", description: "AWS S3 connector for object storage operations..." },
-  { name: "ballerina/http", description: "HTTP client and server implementation..." }
+  { name: "<organization>/<library>", description: "..." }
 ]
 `,
         inputSchema: LibrarySearchToolSchema,

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/library-search.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/library-search.ts
@@ -162,6 +162,15 @@ This tool discovers relevant Ballerina libraries using keyword-based search. It 
 3. Select the most appropriate libraries (typically 1-5 libraries)
 4. Then, call ${LIBRARY_GET_TOOL} with the selected library names to get detailed API documentation (functions, types, clients, services, etc.)
 
+**Example Workflow:**
+User query: <a request mentioning a service, technology, or capability>
+Keywords: [<specific term>, <supporting term>, <generic term>]  // first keyword has the highest weight
+Call ${LIBRARY_SEARCH_TOOL} with the keywords
+→ Returns: [
+    { name: "<organization>/<library>", description: "..." }
+  ]
+Then call ${LIBRARY_GET_TOOL} with the selected library names
+
 **Tool Response Format:**
 Returns an array of library objects, each containing a name and description:
 [

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/library-search.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/library-search.ts
@@ -35,7 +35,7 @@ const LibrarySearchToolSchema = jsonSchema<{
         keywords: {
             type: "array",
             items: { type: "string" },
-            description: `Array of search keywords to find relevant Ballerina libraries. Keywords are weighted by order - first keyword has highest weight, subsequent keywords have decreasing weight. Maximum ${MAX_SEARCH_KEYWORDS} keywords allowed.`,
+            description: `Array of search keywords to find relevant Ballerina libraries. Keywords are weighted by order - first keyword has highest weight, subsequent keywords have decreasing weight. Maximum ${MAX_SEARCH_KEYWORDS} keywords allowed. Examples: ["GitHub", "API", "integration"], ["Stripe", "payment", "gateway"], ["HTTP", "REST", "service"]`,
             minItems: 1,
             maxItems: MAX_SEARCH_KEYWORDS,
         },

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/library-search.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/library-search.ts
@@ -140,7 +140,7 @@ This tool discovers relevant Ballerina libraries using keyword-based search. It 
 **Scope - ALL Ballerina Libraries:**
 - **ballerina/*** - Standard/core libraries maintained by the Ballerina team
 - **ballerinax/*** - Extended connector packages for third-party services
-- **xlibb/*** - C library bindings
+- **xlibb/*** - Experimental yet practical Ballerina packages
 - Other organization packages available in Ballerina Central
 
 **Keyword Guidelines:**

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/library-search.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/library-search.ts
@@ -163,11 +163,12 @@ This tool discovers relevant Ballerina libraries using keyword-based search. It 
 4. Then, call ${LIBRARY_GET_TOOL} with the selected library names to get detailed API documentation (functions, types, clients, services, etc.)
 
 **Example Workflow:**
-User query: <a request mentioning a service, technology, or capability>
-Keywords: [<specific term>, <supporting term>, <generic term>]  // first keyword has the highest weight
+User query: <a request that may span one or more services, technologies, or capabilities>
+Keywords: [<service or technology name>, <another service name if the query needs more>, <supporting or capability terms>]  // lead with the distinct service names; earlier keywords carry more weight
 Call ${LIBRARY_SEARCH_TOOL} with the keywords
 → Returns: [
-    { name: "<organization>/<library>", description: "..." }
+    { name: "<organization>/<library>", description: "..." },
+    ...
   ]
 Then call ${LIBRARY_GET_TOOL} with the selected library names
 


### PR DESCRIPTION
Related to https://github.com/wso2/product-integrator/issues/1605

- Remove biasing examples from the library search and get tool descriptions, including the OpenAI example that steered LLM tasks toward provider connectors
- Genericize the remaining inline examples in the search tool description (keyword examples, organization-scope prefixes, response format)
- Add a silent library selection preference to the get tool description: prefer the 'ballerina' and 'ballerinax' organizations, and for large language model tasks prefer 'ballerina/ai' and its 'ballerinax/ai.*' provider integrations over raw provider connectors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined library search tool descriptions with improved keyword guidance and response format documentation.
  * Enhanced library retrieval tool guidance with preference rules for standard library selections and AI-related package recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->