### PR TITLE
Fix file attachment failures in MI Copilot

### DIFF
--- a/workspaces/mi/mi-extension/src/ai-features/agent-mode/attachment-utils.ts
+++ b/workspaces/mi/mi-extension/src/ai-features/agent-mode/attachment-utils.ts
@@ -79,6 +79,34 @@ function isValidImageDataUri(dataUri: string): boolean {
     return isValidBase64(match[2]);
 }
 
+/**
+ * Strips an optional `data:<mediaType>;base64,` prefix, returning the raw base64 payload.
+ *
+ * A full `data:` URI must never reach the AI SDK as inline `data`/`image`: the SDK
+ * parses it into a URL and, since Anthropic only declares `http(s)` URLs as supported,
+ * tries to `fetch()` the data URI, which Node rejects with "URL scheme must be http or
+ * https, got data:". Normalizing to raw base64 keeps the payload on the inline-data path.
+ * No-op when the input is already raw base64.
+ */
+function stripDataUriPrefix(content: string): string {
+    const match = content.match(/^data:[^;]+;base64,([\s\S]+)$/);
+    return match ? match[1] : content;
+}
+
+/**
+ * Converts an image data URI (or raw base64) into an AI SDK `image` content part,
+ * passing raw base64 + explicit `mediaType` to avoid the data-URI fetch path
+ * (see {@link stripDataUriPrefix}).
+ */
+function toImageContentPart(imageDataUri: string): { type: "image"; image: string; mediaType?: string } {
+    const match = imageDataUri.match(/^data:([^;]+);base64,([\s\S]+)$/);
+    if (match) {
+        return { type: "image", image: match[2], mediaType: match[1] };
+    }
+    // Fallback: pass through unchanged (already-raw base64 or unexpected format).
+    return { type: "image", image: imageDataUri };
+}
+
 export function filterFiles(files: FileObject[]): { textFiles: FileObject[]; pdfFiles: FileObject[] } {
     const textFiles: FileObject[] = [];
     const pdfFiles: FileObject[] = [];
@@ -124,7 +152,7 @@ export function buildMessageContent(promptBlocks: Array<{ type: 'text'; text: st
         for (const pdfFile of pdfFiles) {
             content.push({
                 type: "file",
-                data: pdfFile.content,
+                data: stripDataUriPrefix(pdfFile.content),
                 mediaType: "application/pdf",
             });
         }
@@ -145,10 +173,7 @@ export function buildMessageContent(promptBlocks: Array<{ type: 'text'; text: st
         });
 
         for (const image of images) {
-            content.push({
-                type: "image",
-                image: image.imageBase64,
-            });
+            content.push(toImageContentPart(image.imageBase64));
         }
     }
 
@@ -165,7 +190,7 @@ export function validateAttachments(files?: FileObject[], images?: ImageObject[]
         for (const file of files) {
             if (file.mimetype !== "application/pdf" && !TEXT_MIMETYPES.has(file.mimetype)) {
                 warnings.push(`Unsupported file type (${file.mimetype}): ${file.name}`);
-            } else if (file.mimetype === "application/pdf" && !isValidBase64(file.content)) {
+            } else if (file.mimetype === "application/pdf" && !isValidBase64(stripDataUriPrefix(file.content))) {
                 warnings.push(`Invalid base64 encoding: ${file.name}`);
             }
         }

--- a/workspaces/mi/mi-extension/src/ai-features/copilot/message-utils.ts
+++ b/workspaces/mi/mi-extension/src/ai-features/copilot/message-utils.ts
@@ -118,6 +118,20 @@ function isValidBase64(str: string): boolean {
 }
 
 /**
+ * Strips an optional `data:<mediaType>;base64,` prefix, returning the raw base64 payload.
+ *
+ * A full `data:` URI must never reach the AI SDK as inline `data`: the SDK parses it
+ * into a URL and, since Anthropic only declares `http(s)` URLs as supported, tries to
+ * `fetch()` the data URI, which Node rejects with "URL scheme must be http or https,
+ * got data:". Normalizing to raw base64 keeps the payload on the inline-data path.
+ * No-op when the input is already raw base64.
+ */
+function stripDataUriPrefix(content: string): string {
+    const match = content.match(/^data:[^;]+;base64,([\s\S]+)$/);
+    return match ? match[1] : content;
+}
+
+/**
  * Validates if a string is a properly formatted image data URI
  * @param dataUri - The data URI string to validate
  * @returns true if the string is a valid image data URI, false otherwise
@@ -192,7 +206,7 @@ export function buildMessageContent(
         for (const pdfFile of pdfFiles) {
             content.push({
                 type: "file",
-                data: pdfFile.content,  // Base64 encoded content (pre-validated)
+                data: stripDataUriPrefix(pdfFile.content),  // Raw base64 (data: prefix stripped if present)
                 mediaType: "application/pdf"
             });
         }
@@ -217,12 +231,16 @@ export function buildMessageContent(
         });
 
         for (const image of images) {
-            // Use AI SDK format: { type: 'image', image: dataUri }
-            // The AI SDK will convert this to the provider's format internally
-            content.push({
-                type: "image",
-                image: image.imageBase64  // Use the full data URI (pre-validated)
-            });
+            // Split the data URI into raw base64 + mediaType. Passing the full
+            // "data:...;base64,..." string as `image` makes AI SDK v6 try to fetch
+            // it as a URL, which Node rejects ("URL scheme must be http or https,
+            // got data:"). Raw base64 keeps it on the inline-data path.
+            const match = image.imageBase64.match(/^data:([^;]+);base64,(.+)$/);
+            content.push(
+                match
+                    ? { type: "image", image: match[2], mediaType: match[1] }
+                    : { type: "image", image: image.imageBase64 }
+            );
         }
     }
 
@@ -261,7 +279,7 @@ export function validateAttachments(files?: FileObject[], images?: ImageObject[]
                 warnings.push(`Unsupported file type (${file.mimetype}): ${file.name}`);
             }
             // Check PDF base64 encoding
-            else if (file.mimetype === "application/pdf" && !isValidBase64(file.content)) {
+            else if (file.mimetype === "application/pdf" && !isValidBase64(stripDataUriPrefix(file.content))) {
                 warnings.push(`Invalid base64 encoding: ${file.name}`);
             }
         }

--- a/workspaces/mi/mi-visualizer/src/views/AIPanel/component/AIChatFooter.tsx
+++ b/workspaces/mi/mi-visualizer/src/views/AIPanel/component/AIChatFooter.tsx
@@ -2804,6 +2804,8 @@ const AIChatFooter: React.FC<AIChatFooterProps> = ({ isUsageExceeded = false }) 
 
                 {fileUploadStatus.type === "error" && (
                     <FlexRow
+                        role="alert"
+                        aria-live="assertive"
                         style={{
                             gap: "6px",
                             alignItems: "center",

--- a/workspaces/mi/mi-visualizer/src/views/AIPanel/component/AIChatFooter.tsx
+++ b/workspaces/mi/mi-visualizer/src/views/AIPanel/component/AIChatFooter.tsx
@@ -368,7 +368,7 @@ const AIChatFooter: React.FC<AIChatFooterProps> = ({ isUsageExceeded = false }) 
         currentSessionId,
     } = useMICopilotContext();
 
-    const [, setFileUploadStatus] = useState({ type: "", text: "" });
+    const [fileUploadStatus, setFileUploadStatus] = useState<{ type: string; text: string }>({ type: "", text: "" });
     const isResponseReceived = useRef(false);
     const textAreaRef = useRef<HTMLTextAreaElement>(null);
     const abortedRef = useRef(false);
@@ -1390,6 +1390,14 @@ const AIChatFooter: React.FC<AIChatFooterProps> = ({ isUsageExceeded = false }) 
             rpcClient.getMiDiagramRpcClient().executeCommand({ commands: ["MI.clearAIPrompt"] });
         }
     }, [isInitialPromptLoaded]);
+
+    // Auto-dismiss file upload errors so they don't linger once the user retries.
+    useEffect(() => {
+        if (fileUploadStatus.type === "error") {
+            const timer = setTimeout(() => setFileUploadStatus({ type: "", text: "" }), 5000);
+            return () => clearTimeout(timer);
+        }
+    }, [fileUploadStatus]);
 
     // Auto-resize the textarea based on content
     useEffect(() => {
@@ -2793,6 +2801,21 @@ const AIChatFooter: React.FC<AIChatFooterProps> = ({ isUsageExceeded = false }) 
                         rows={1}
                     />
                 </div>
+
+                {fileUploadStatus.type === "error" && (
+                    <FlexRow
+                        style={{
+                            gap: "6px",
+                            alignItems: "center",
+                            padding: "0 8px 4px 8px",
+                            color: "var(--vscode-errorForeground)",
+                            fontSize: "11px",
+                        }}
+                    >
+                        <Codicon name="error" iconSx={{ fontSize: "12px" }} />
+                        <span>{fileUploadStatus.text}</span>
+                    </FlexRow>
+                )}
 
                 {(files.length > 0 || images.length > 0) && !isInitialPromptLoaded && (
                     <FlexRow style={{ flexWrap: "wrap", gap: "4px", padding: "0 8px 4px 8px" }}>

--- a/workspaces/mi/mi-visualizer/src/views/AIPanel/constants.ts
+++ b/workspaces/mi/mi-visualizer/src/views/AIPanel/constants.ts
@@ -27,7 +27,7 @@ export const COPILOT_ERROR_MESSAGES = {
 };
 
 // MI Copilot maximum allowed file size
-export const MAX_FILE_SIZE = 5 * 1024 * 1024; // Default to 5MB
+export const MAX_FILE_SIZE = 10 * 1024 * 1024; // Default to 10MB
 
 export const USER_INPUT_PLACEHOLDER_MESSAGE = "Ask WSO2 Integrator Copilot";
 

--- a/workspaces/mi/mi-visualizer/src/views/AIPanel/utils.ts
+++ b/workspaces/mi/mi-visualizer/src/views/AIPanel/utils.ts
@@ -530,11 +530,21 @@ const FILE_EXTENSION_TO_MIME: Record<string, string> = {
 };
 
 function resolveMimeType(file: File): string {
-    if (file.type) {
+    const extension = file.name.split(".").pop()?.toLowerCase();
+    const extensionMime = extension ? FILE_EXTENSION_TO_MIME[extension] : undefined;
+
+    // Trust the browser-reported type only when it is one we actually support.
+    // Some platforms/webviews report supported files (notably PDFs) with a generic
+    // or empty type (e.g. "application/octet-stream" or ""), which would otherwise
+    // fail the supported-type check and be silently dropped. Fall back to the
+    // extension mapping in those cases.
+    const isSupported = (mime: string) =>
+        VALID_FILE_TYPES.files.includes(mime) || VALID_FILE_TYPES.images.includes(mime);
+
+    if (file.type && isSupported(file.type)) {
         return file.type;
     }
-    const extension = file.name.split(".").pop()?.toLowerCase();
-    return extension ? FILE_EXTENSION_TO_MIME[extension] || "" : "";
+    return extensionMime || file.type || "";
 }
 
 export const handleFileAttach = (e: any, existingFiles: FileObject[], setFiles: Function, existingImages: ImageObject[], setImages: Function, setFileUploadStatus: Function) => {
@@ -546,7 +556,7 @@ export const handleFileAttach = (e: any, existingFiles: FileObject[], setFiles: 
         const mimeType = resolveMimeType(file);
 
         if (file.size > MAX_FILE_SIZE) {
-            setFileUploadStatus({ type: "error", text: `File '${file.name}' exceeds the size limit of 5 MB.` });
+            setFileUploadStatus({ type: "error", text: `File '${file.name}' exceeds the size limit of ${Math.round(MAX_FILE_SIZE / (1024 * 1024))} MB.` });
             continue;
         }
         

--- a/workspaces/mi/mi-visualizer/src/views/AIPanel/utils.ts
+++ b/workspaces/mi/mi-visualizer/src/views/AIPanel/utils.ts
@@ -557,7 +557,13 @@ export const handleFileAttach = (e: any, existingFiles: FileObject[], setFiles: 
     // status. The error notice is set once, after the whole selection is processed.
     const errors: string[] = [];
     const reportReadError = (name: string) =>
-        setFileUploadStatus({ type: "error", text: `Failed to read file '${name}'.` });
+        setFileUploadStatus((prev: { type: string; text: string }) => {
+            const message = `Failed to read file '${name}'.`;
+            // Append so an async read failure doesn't overwrite synchronous
+            // validation errors (or an earlier read failure).
+            const text = prev.type === "error" && prev.text ? `${prev.text} ${message}` : message;
+            return { type: "error", text };
+        });
 
     for (const file of files) {
         const mimeType = resolveMimeType(file);

--- a/workspaces/mi/mi-visualizer/src/views/AIPanel/utils.ts
+++ b/workspaces/mi/mi-visualizer/src/views/AIPanel/utils.ts
@@ -544,7 +544,7 @@ function resolveMimeType(file: File): string {
     if (file.type && isSupported(file.type)) {
         return file.type;
     }
-    return extensionMime || file.type || "";
+    return extensionMime || "";
 }
 
 export const handleFileAttach = (e: any, existingFiles: FileObject[], setFiles: Function, existingImages: ImageObject[], setImages: Function, setFileUploadStatus: Function) => {
@@ -552,19 +552,26 @@ export const handleFileAttach = (e: any, existingFiles: FileObject[], setFiles: 
     const validFileTypes = VALID_FILE_TYPES.files;
     const validImageTypes = VALID_FILE_TYPES.images;
 
+    // Collect rejection reasons synchronously so that async reader callbacks (which
+    // resolve later, in arbitrary order) cannot overwrite a rejection with a success
+    // status. The error notice is set once, after the whole selection is processed.
+    const errors: string[] = [];
+    const reportReadError = (name: string) =>
+        setFileUploadStatus({ type: "error", text: `Failed to read file '${name}'.` });
+
     for (const file of files) {
         const mimeType = resolveMimeType(file);
 
         if (file.size > MAX_FILE_SIZE) {
-            setFileUploadStatus({ type: "error", text: `File '${file.name}' exceeds the size limit of ${Math.round(MAX_FILE_SIZE / (1024 * 1024))} MB.` });
+            errors.push(`File '${file.name}' exceeds the size limit of ${Math.round(MAX_FILE_SIZE / (1024 * 1024))} MB.`);
             continue;
         }
-        
+
         if (existingFiles.some(existingFile => existingFile.name === file.name)) {
-            setFileUploadStatus({ type: "error", text: `File '${file.name}' already added.` });
+            errors.push(`File '${file.name}' already added.`);
             continue;
         } else if (existingImages.some(existingImage => existingImage.imageName === file.name)) {
-            setFileUploadStatus({ type: "error", text: `Image '${file.name}' already added.` });
+            errors.push(`Image '${file.name}' already added.`);
             continue;
         }
 
@@ -582,8 +589,8 @@ export const handleFileAttach = (e: any, existingFiles: FileObject[], setFiles: 
                     ...prevFiles,
                     { name: file.name, mimetype: mimeType, content: fileContents },
                 ]);
-                setFileUploadStatus({ type: "success", text: `File uploaded successfully.` });
             };
+            reader.onerror = () => reportReadError(file.name);
             if (mimeType === "application/pdf") {
                 reader.readAsDataURL(file); // Convert PDF to base64
             } else {
@@ -602,13 +609,15 @@ export const handleFileAttach = (e: any, existingFiles: FileObject[], setFiles: 
                     }
                 }
                 setImages((prevImages: any) => [...prevImages, { imageName: file.name, imageBase64: imageBase64 }]);
-                setFileUploadStatus({ type: "success", text: `File uploaded successfully.` });
             };
+            reader.onerror = () => reportReadError(file.name);
             reader.readAsDataURL(file);
         } else {
-            setFileUploadStatus({ type: "error", text: `File format not supported for '${file.name}'` });
+            errors.push(`File format not supported for '${file.name}'`);
         }
     }
+
+    setFileUploadStatus(errors.length > 0 ? { type: "error", text: errors.join(" ") } : { type: "", text: "" });
     e.target.value = "";
 };
 


### PR DESCRIPTION
Fixes https://github.com/wso2/product-integrator/issues/1636

Attaching files to MI Copilot failed in two ways: sending an image or PDF errored with "URL scheme must be http or https, got data:", and oversized files silently failed to attach with no feedback.

This PR fixes both, surfaces upload errors in the UI, and raises the attachment size limit to 10 MB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-clearing inline upload error banner after 5s.
  * Image attachments now carry MIME info for more consistent display.

* **Improvements**
  * Increased max upload size to 10 MB.
  * Normalize data-URI‑prefixed attachments so embedded base64 is handled consistently.
  * PDF/image validation now uses stripped base64 from data URIs.
  * Improved MIME detection and consolidated upload error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->