### PR TITLE
Align Skills manager UI with the MCP panel

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/SettingsPanel/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/SettingsPanel/index.tsx
@@ -182,7 +182,7 @@ export const SettingsPanel = (props: SettingsPanelProps) => {
     const agentsMdSubtitle = (() => {
         if (!agentsMdInfo) return "…";
         if (!agentsMdInfo.hasWorkspace) return "No workspace open";
-        if (!agentsMdInfo.fileExists) return "No AGENTS.md (click icon to create)";
+        if (!agentsMdInfo.fileExists) return "No AGENTS.md";
         if (agentsMdInfo.isEmpty) return "Empty file";
         const n = agentsMdInfo.lineCount ?? 0;
         return `${n} line${n === 1 ? "" : "s"}`;

--- a/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/AIChatInput/SuggestionsList.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/AIChatInput/SuggestionsList.tsx
@@ -195,7 +195,7 @@ const SuggestionsList: React.FC<SuggestionsListProps> = ({
                                 aria-selected={isActive}
                             >
                                 <CommandIconBox active={isActive}>
-                                    <span className="codicon codicon-wand" />
+                                    <span className="codicon codicon-lightbulb-sparkle" />
                                 </CommandIconBox>
                                 <CommandTextGroup>
                                     <CommandName>{suggestion.text}</CommandName>

--- a/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/SkillsManager/SkillRow.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/SkillsManager/SkillRow.tsx
@@ -21,61 +21,126 @@ import styled from "@emotion/styled";
 import { SkillEntry, SkillTier } from "@wso2/ballerina-core";
 import { SecondaryActionButton, DangerActionButton } from "../../styles";
 
-// ─── Styled components (matching MCP's ServerCard pattern) ───────────────────
+// ─── Styled components (mirrors McpManagerPanel's compact row) ───────────────
 
-const Card = styled.div`
-    border: 1px solid var(--vscode-widget-border, var(--vscode-panel-border));
-    border-radius: 6px;
-    padding: 10px 12px;
+const Row = styled.div`
     display: flex;
     flex-direction: column;
-    gap: 0;
-    margin-bottom: 6px;
+    border-bottom: 1px solid var(--vscode-panel-border);
+
+    &:last-child { border-bottom: none; }
 `;
 
-const CardHeader = styled.div`
+const RowHeader = styled.div`
     display: flex;
     align-items: center;
     gap: 8px;
+    padding: 6px 10px;
+    transition: background 0.12s ease;
+
+    &:hover { background: var(--vscode-list-hoverBackground); }
+
+    &:hover .skill-row-actions,
+    &:focus-within .skill-row-actions {
+        visibility: visible;
+    }
 `;
 
-const CardName = styled.span`
+const RowMain = styled.div`
     flex: 1;
     min-width: 0;
-    font-size: 12px;
-    font-weight: 600;
-    color: var(--vscode-editor-foreground);
-    white-space: nowrap;
+    display: inline-flex;
+    align-items: baseline;
+    gap: 8px;
+`;
+
+const RowName = styled.span<{ $dim?: boolean }>`
+    flex-shrink: 0;
+    max-width: 50%;
+    font-size: 13px;
+    font-weight: 500;
+    color: ${(p: { $dim?: boolean }) => (p.$dim
+        ? "var(--vscode-descriptionForeground)"
+        : "var(--vscode-foreground)")};
     overflow: hidden;
     text-overflow: ellipsis;
-`;
-
-const CardDescription = styled.span`
-    font-size: 11px;
-    color: var(--vscode-descriptionForeground);
-    margin-top: 2px;
-    display: block;
     white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
 `;
 
-const BuiltinRow = styled.div`
-    display: flex;
-    flex-direction: column;
-    padding: 4px 0;
-    margin-bottom: 4px;
-`;
-
-const ActionRow = styled.div`
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    margin-top: 4px;
-`;
-
-const Spacer = styled.div`
+const RowMeta = styled.span`
     flex: 1;
+    min-width: 0;
+    font-size: 11.5px;
+    color: var(--vscode-descriptionForeground);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+`;
+
+const RowActions = styled.div`
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+    flex-shrink: 0;
+    visibility: hidden;
+`;
+
+const RowIconButton = styled.button<{ $danger?: boolean }>`
+    width: 22px;
+    height: 22px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    border: none;
+    border-radius: 3px;
+    cursor: pointer;
+    color: var(--vscode-descriptionForeground);
+    font-family: var(--vscode-font-family);
+
+    &:hover {
+        background: ${(p: { $danger?: boolean }) => (p.$danger
+            ? "var(--vscode-inputValidation-errorBackground, var(--vscode-toolbar-hoverBackground))"
+            : "var(--vscode-toolbar-hoverBackground)")};
+        color: ${(p: { $danger?: boolean }) => (p.$danger
+            ? "var(--vscode-errorForeground)"
+            : "var(--vscode-foreground)")};
+    }
+
+    .codicon { font-size: 14px; }
+`;
+
+const ToggleSwitch = styled.button<{ $on: boolean }>`
+    width: 30px;
+    height: 16px;
+    border-radius: 8px;
+    cursor: pointer;
+    position: relative;
+    flex-shrink: 0;
+    background: ${(p: { $on: boolean }) => (p.$on
+        ? "var(--vscode-button-background)"
+        : "var(--vscode-input-background)")};
+    border: 1px solid ${(p: { $on: boolean }) => (p.$on
+        ? "var(--vscode-contrastBorder, var(--vscode-button-background))"
+        : "var(--vscode-contrastBorder, var(--vscode-checkbox-border, var(--vscode-descriptionForeground)))")};
+    transition: background 0.15s, border-color 0.15s;
+
+    &::after {
+        content: "";
+        position: absolute;
+        box-sizing: border-box;
+        top: 1px;
+        left: ${(p: { $on: boolean }) => (p.$on ? "15px" : "1px")};
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        background: ${(p: { $on: boolean }) => (p.$on
+            ? "var(--vscode-button-foreground)"
+            : "var(--vscode-descriptionForeground)")};
+        border: 1px solid var(--vscode-contrastBorder, transparent);
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+        transition: left 0.15s, background 0.15s;
+    }
 `;
 
 const ConfirmRow = styled.div`
@@ -83,38 +148,27 @@ const ConfirmRow = styled.div`
     display: flex;
     align-items: center;
     gap: 8px;
-    font-size: 11px;
+    min-width: 0;
+    font-size: 12px;
     color: var(--vscode-foreground);
+`;
+
+const ConfirmText = styled.span`
+    flex: 0 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    strong { font-weight: 600; }
+`;
+
+const Spacer = styled.div`
+    flex: 1;
 `;
 
 const ActionButton = SecondaryActionButton;
 const DeleteButton = DangerActionButton;
-
-const ToggleTrack = styled.button<{ enabled: boolean }>`
-    width: 36px;
-    height: 20px;
-    border-radius: 10px;
-    border: none;
-    cursor: pointer;
-    padding: 0;
-    flex-shrink: 0;
-    position: relative;
-    background: ${({ enabled }: { enabled: boolean }) =>
-        enabled ? 'var(--vscode-button-background)' : 'var(--vscode-button-secondaryBackground, #555)'};
-    transition: background 0.2s;
-    &:hover { opacity: 0.85; }
-`;
-
-const ToggleKnob = styled.span<{ enabled: boolean }>`
-    position: absolute;
-    top: 2px;
-    left: ${({ enabled }: { enabled: boolean }) => enabled ? '18px' : '2px'};
-    width: 16px;
-    height: 16px;
-    border-radius: 50%;
-    background: var(--vscode-button-foreground, #fff);
-    transition: left 0.2s;
-`;
 
 const getShortName = (name: string) =>
     name.includes('/') ? name.split('/').pop()! : name;
@@ -134,75 +188,48 @@ const SkillRow: React.FC<SkillRowProps> = ({ skill, onToggle, onEdit, onDelete }
     const shortName = getShortName(skill.name);
     const enabled = skill.enabled !== false;
 
-    if (skill.tier === SkillTier.BUILTIN) {
-        return (
-            <BuiltinRow>
-                <CardHeader>
-                    <CardName title={skill.name}>{shortName}</CardName>
-                    {onToggle && (
-                        <ToggleTrack
-                            type="button"
-                            enabled={enabled}
-                            title={enabled ? 'Disable skill' : 'Enable skill'}
-                            onClick={() => onToggle(skill, !enabled)}
-                        >
-                            <ToggleKnob enabled={enabled} />
-                        </ToggleTrack>
-                    )}
-                </CardHeader>
-                {skill.trigger && <CardDescription title={skill.trigger}>{skill.trigger}</CardDescription>}
-            </BuiltinRow>
-        );
-    }
-
     return (
-        <Card>
-            <CardHeader>
-                <CardName title={skill.name}>{shortName}</CardName>
-                {onToggle && (
-                    <ToggleTrack
-                        type="button"
-                        enabled={enabled}
-                        title={enabled ? 'Disable skill' : 'Enable skill'}
-                        onClick={() => onToggle(skill, !enabled)}
-                    >
-                        <ToggleKnob enabled={enabled} />
-                    </ToggleTrack>
+        <Row>
+            <RowHeader>
+                {confirming ? (
+                    <ConfirmRow>
+                        <ConfirmText>Delete <strong>{shortName}</strong>?</ConfirmText>
+                        <Spacer />
+                        <DeleteButton type="button" onClick={() => { setConfirming(false); onDelete?.(skill); }}>Yes, delete</DeleteButton>
+                        <ActionButton type="button" onClick={() => setConfirming(false)}>Cancel</ActionButton>
+                    </ConfirmRow>
+                ) : (
+                    <>
+                        <RowMain>
+                            <RowName $dim={!enabled} title={skill.name}>{shortName}</RowName>
+                            {skill.trigger && <RowMeta title={skill.trigger}>{skill.trigger}</RowMeta>}
+                        </RowMain>
+                        {isEditable && (onEdit || onDelete) && (
+                            <RowActions className="skill-row-actions">
+                                {onEdit && (
+                                    <RowIconButton type="button" title="Edit skill" aria-label="Edit skill" onClick={() => onEdit(skill)}>
+                                        <span className="codicon codicon-edit" />
+                                    </RowIconButton>
+                                )}
+                                {onDelete && (
+                                    <RowIconButton type="button" $danger title="Delete skill" aria-label="Delete skill" onClick={() => setConfirming(true)}>
+                                        <span className="codicon codicon-trash" />
+                                    </RowIconButton>
+                                )}
+                            </RowActions>
+                        )}
+                        {onToggle && (
+                            <ToggleSwitch
+                                type="button"
+                                $on={enabled}
+                                title={enabled ? "Disable skill" : "Enable skill"}
+                                onClick={() => onToggle(skill, !enabled)}
+                            />
+                        )}
+                    </>
                 )}
-            </CardHeader>
-            {skill.trigger && <CardDescription title={skill.trigger}>{skill.trigger}</CardDescription>}
-
-            {isEditable && (onEdit || onDelete) && (
-                <ActionRow>
-                    {confirming ? (
-                        <ConfirmRow>
-                            <span>Delete <strong>{shortName}</strong>?</span>
-                            <Spacer />
-                            <DeleteButton type="button" onClick={() => { setConfirming(false); onDelete?.(skill); }}>
-                                Yes, delete
-                            </DeleteButton>
-                            <ActionButton type="button" onClick={() => setConfirming(false)}>
-                                Cancel
-                            </ActionButton>
-                        </ConfirmRow>
-                    ) : (
-                        <>
-                            <Spacer />
-                            {onEdit && (
-                                <ActionButton type="button" onClick={() => onEdit(skill)}>
-                                    Edit
-                                </ActionButton>
-                            )}
-                            {onDelete && (
-                                <DeleteButton type="button" onClick={() => setConfirming(true)}>
-                                    Delete
-                                </DeleteButton>
-                            )}
-                        </>
-                    )}
-                </ActionRow>
-            )}
-        </Card>
+            </RowHeader>
+        </Row>
     );
 };
 

--- a/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/SkillsManager/SkillRow.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/SkillsManager/SkillRow.tsx
@@ -83,6 +83,9 @@ const RowActions = styled.div`
     gap: 2px;
     flex-shrink: 0;
     visibility: hidden;
+    /* Rendered after the toggle in the DOM (so forward tab reaches it once
+       :focus-within reveals it), but kept left of the toggle visually. */
+    order: 1;
 `;
 
 const RowIconButton = styled.button<{ $danger?: boolean }>`
@@ -117,6 +120,7 @@ const ToggleSwitch = styled.button<{ $on: boolean }>`
     cursor: pointer;
     position: relative;
     flex-shrink: 0;
+    order: 2;
     background: ${(p: { $on: boolean }) => (p.$on
         ? "var(--vscode-button-background)"
         : "var(--vscode-input-background)")};
@@ -204,6 +208,14 @@ const SkillRow: React.FC<SkillRowProps> = ({ skill, onToggle, onEdit, onDelete }
                             <RowName $dim={!enabled} title={skill.name}>{shortName}</RowName>
                             {skill.trigger && <RowMeta title={skill.trigger}>{skill.trigger}</RowMeta>}
                         </RowMain>
+                        {onToggle && (
+                            <ToggleSwitch
+                                type="button"
+                                $on={enabled}
+                                title={enabled ? "Disable skill" : "Enable skill"}
+                                onClick={() => onToggle(skill, !enabled)}
+                            />
+                        )}
                         {isEditable && (onEdit || onDelete) && (
                             <RowActions className="skill-row-actions">
                                 {onEdit && (
@@ -217,14 +229,6 @@ const SkillRow: React.FC<SkillRowProps> = ({ skill, onToggle, onEdit, onDelete }
                                     </RowIconButton>
                                 )}
                             </RowActions>
-                        )}
-                        {onToggle && (
-                            <ToggleSwitch
-                                type="button"
-                                $on={enabled}
-                                title={enabled ? "Disable skill" : "Enable skill"}
-                                onClick={() => onToggle(skill, !enabled)}
-                            />
                         )}
                     </>
                 )}

--- a/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/SkillsManager/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/SkillsManager/index.tsx
@@ -28,6 +28,7 @@ import {
     ToggleSkillRequest,
 } from "@wso2/ballerina-core";
 import { AIChatView, PrimaryActionButton } from "../../styles";
+import { Loader } from "../Loader";
 import SkillRow from "./SkillRow";
 import AddSkillModal from "./AddSkillModal";
 
@@ -126,18 +127,25 @@ const SectionDivider = styled.div`
     align-self: center;
 `;
 
+const SectionHelper = styled.div`
+    font-size: 11px;
+    color: var(--vscode-descriptionForeground);
+    margin: -2px 0 4px 16px;
+`;
+
+const RowsContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    border: 1px solid var(--vscode-widget-border, var(--vscode-panel-border));
+    border-radius: 6px;
+    overflow: hidden;
+    background: var(--vscode-editor-background);
+`;
+
 const EmptyMessage = styled.div`
     font-size: 12px;
     color: var(--vscode-descriptionForeground);
     padding: 6px 0;
-`;
-
-
-const LoadingMessage = styled.div`
-    font-size: 12px;
-    color: var(--vscode-descriptionForeground);
-    padding: 20px 0;
-    text-align: center;
 `;
 
 // ─── Component ───────────────────────────────────────────────────────────────
@@ -235,6 +243,34 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ onClose, onSkillsChange }
         />
     );
 
+    const renderSection = (tier: SkillTier, label: string, helper: string, items: SkillEntry[], emptyText: string) => {
+        const isCollapsed = collapsedSections.has(tier);
+        return (
+            <Section key={tier}>
+                <SectionHeader>
+                    <SectionTitleButton
+                        type="button"
+                        onClick={() => toggleSectionCollapsed(tier)}
+                        title={isCollapsed ? "Expand section" : "Collapse section"}
+                    >
+                        <span className={`codicon codicon-${isCollapsed ? "chevron-right" : "chevron-down"}`} />
+                        {label} ({items.length})
+                    </SectionTitleButton>
+                    <SectionDivider />
+                </SectionHeader>
+                {!isCollapsed && (
+                    <>
+                        <SectionHelper>{helper}</SectionHelper>
+                        {items.length === 0
+                            ? <EmptyMessage>{emptyText}</EmptyMessage>
+                            : <RowsContainer>{items.map(renderSkillCard)}</RowsContainer>
+                        }
+                    </>
+                )}
+            </Section>
+        );
+    };
+
     return (
         <AIChatView>
             <PanelHeader>
@@ -259,77 +295,12 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ onClose, onSkillsChange }
 
             <PanelContent>
                 {isLoading ? (
-                    <LoadingMessage>Loading skills…</LoadingMessage>
+                    <Loader label="Loading skills…" />
                 ) : (
                     <>
-                        {/* Built-in */}
-                        <Section>
-                            <SectionHeader>
-                                <SectionTitleButton
-                                    type="button"
-                                    onClick={() => toggleSectionCollapsed(SkillTier.BUILTIN)}
-                                    title={collapsedSections.has(SkillTier.BUILTIN) ? "Expand section" : "Collapse section"}
-                                >
-                                    <span className={`codicon codicon-${collapsedSections.has(SkillTier.BUILTIN) ? "chevron-right" : "chevron-down"}`} />
-                                    Built-in ({builtinSkills.length})
-                                </SectionTitleButton>
-                                <SectionDivider />
-                            </SectionHeader>
-                            {!collapsedSections.has(SkillTier.BUILTIN) && (
-                                <>
-                                    {builtinSkills.length === 0
-                                        ? <EmptyMessage>No built-in skills.</EmptyMessage>
-                                        : builtinSkills.map(renderSkillCard)
-                                    }
-                                </>
-                            )}
-                        </Section>
-
-                        {/* Project */}
-                        <Section>
-                            <SectionHeader>
-                                <SectionTitleButton
-                                    type="button"
-                                    onClick={() => toggleSectionCollapsed(SkillTier.PROJECT)}
-                                    title={collapsedSections.has(SkillTier.PROJECT) ? "Expand section" : "Collapse section"}
-                                >
-                                    <span className={`codicon codicon-${collapsedSections.has(SkillTier.PROJECT) ? "chevron-right" : "chevron-down"}`} />
-                                    Project ({projectSkills.length})
-                                </SectionTitleButton>
-                                <SectionDivider />
-                            </SectionHeader>
-                            {!collapsedSections.has(SkillTier.PROJECT) && (
-                                <>
-                                    {projectSkills.length === 0
-                                        ? <EmptyMessage>No project skills yet.</EmptyMessage>
-                                        : projectSkills.map(renderSkillCard)
-                                    }
-                                </>
-                            )}
-                        </Section>
-
-                        {/* User */}
-                        <Section>
-                            <SectionHeader>
-                                <SectionTitleButton
-                                    type="button"
-                                    onClick={() => toggleSectionCollapsed(SkillTier.USER)}
-                                    title={collapsedSections.has(SkillTier.USER) ? "Expand section" : "Collapse section"}
-                                >
-                                    <span className={`codicon codicon-${collapsedSections.has(SkillTier.USER) ? "chevron-right" : "chevron-down"}`} />
-                                    User ({userSkills.length})
-                                </SectionTitleButton>
-                                <SectionDivider />
-                            </SectionHeader>
-                            {!collapsedSections.has(SkillTier.USER) && (
-                                <>
-                                    {userSkills.length === 0
-                                        ? <EmptyMessage>No user skills yet.</EmptyMessage>
-                                        : userSkills.map(renderSkillCard)
-                                    }
-                                </>
-                            )}
-                        </Section>
+                        {renderSection(SkillTier.BUILTIN, "Built-in", "Skills shipped with the Copilot.", builtinSkills, "No built-in skills.")}
+                        {renderSection(SkillTier.PROJECT, "Project", "Saved to this project and shared with your team.", projectSkills, "No project skills yet.")}
+                        {renderSection(SkillTier.USER, "User", "Available across all your projects.", userSkills, "No user skills yet.")}
                     </>
                 )}
             </PanelContent>


### PR DESCRIPTION
- Render skills as compact rows in a single bordered container, matching the MCP server rows
- Use the MCP toggle switch style and hover-revealed Edit/Delete icon buttons with inline delete confirm
- Add per-section helper text and use the shared Loader
- Use the skills icon (codicon-lightbulb-sparkle) for slash-command skill suggestions, matching the Skills entry in Settings
- Drop the redundant "click icon to create" hint from the empty AGENTS.md subtitle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Redesigned skill management interface with enhanced layout and action controls
  * Added collapsible skill sections for better organization
  * Updated visual indicators and messaging in AI panel features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->