### PR TITLE
Skip integration type picker for safe service/listener combinations

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/features/devant/activator.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/devant/activator.ts
@@ -21,6 +21,8 @@ import {
     WICommandIds,
     ICommitAndPushCmdParams,
     ICreateNewIntegrationCmdParams,
+    resolveIntegrationType,
+    AUTOMATION_WITH_LISTENER_WARNING,
 } from "@wso2/wso2-platform-core";
 import { BallerinaExtension } from "../../core";
 import { openView, StateMachine } from "../../stateMachine";
@@ -93,7 +95,7 @@ const handleComponentPushToDevant = async () => {
             scopeSet.add(SCOPE.AUTOMATION);
         }
 
-        let integrationType: SCOPE;
+        let integrationType: SCOPE | undefined;
 
         if (scopeSet.size === 0) {
             window
@@ -107,12 +109,29 @@ const handleComponentPushToDevant = async () => {
                     }
                 });
             return;
-        } else if (scopeSet.size === 1) {
-            integrationType = [...scopeSet][0];
+        }
+
+        const resolution = resolveIntegrationType([...scopeSet]);
+
+        if (resolution.kind === "autoPick") {
+            integrationType = resolution.scope as SCOPE;
+        } else if (resolution.kind === "autoPickWithWarning") {
+            const choice = await window.showWarningMessage(
+                AUTOMATION_WITH_LISTENER_WARNING,
+                { modal: true },
+                "Continue",
+            );
+            if (choice !== "Continue") {
+                return;
+            }
+            integrationType = resolution.scope as SCOPE;
         } else {
-            const selectedScope = await window.showQuickPick([...scopeSet], {
+            const selectedScope = await window.showQuickPick(resolution.choices, {
                 placeHolder: "Multiple types of artifacts detected. Please select the artifact type to be deployed",
             });
+            if (!selectedScope) {
+                return;
+            }
             integrationType = selectedScope as SCOPE;
         }
 

--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/bi-diagram/rpc-manager.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/bi-diagram/rpc-manager.ts
@@ -169,6 +169,8 @@ import {
     IWso2PlatformExtensionAPI,
     ICreateNewIntegrationCmdParams,
     ICreateNewIntegrationCmdIntegrations,
+    resolveIntegrationType,
+    AUTOMATION_WITH_LISTENER_WARNING,
 } from "@wso2/wso2-platform-core";
 import {
     ShellExecution,
@@ -1294,11 +1296,25 @@ export class BiDiagramRpcManager implements BIDiagramAPI {
             return undefined;
         }
 
-        if (integrationTypes.length === 1) {
-            return integrationTypes[0];
+        const resolution = resolveIntegrationType(integrationTypes);
+
+        if (resolution.kind === "autoPick") {
+            return resolution.scope as SCOPE;
         }
 
-        const selectedScope = await window.showQuickPick(integrationTypes, {
+        if (resolution.kind === "autoPickWithWarning") {
+            const choice = await window.showWarningMessage(
+                AUTOMATION_WITH_LISTENER_WARNING,
+                { modal: true },
+                "Continue",
+            );
+            if (choice !== "Continue") {
+                return undefined;
+            }
+            return resolution.scope as SCOPE;
+        }
+
+        const selectedScope = await window.showQuickPick(resolution.choices, {
             placeHolder: 'You have different types of artifacts within this integration. Select the artifact type to be deployed'
         });
 

--- a/workspaces/wso2-platform/wso2-platform-core/src/utils.ts
+++ b/workspaces/wso2-platform/wso2-platform-core/src/utils.ts
@@ -356,3 +356,74 @@ export const getComponentKindRepoSource = (source: ComponentKindSource) => {
 		path: source?.github?.path || source?.bitbucket?.path || source?.gitlab?.path || "",
 	};
 };
+
+/** Scopes whose deployment target is a long-running service. */
+const SERVICE_SCOPES: ReadonlySet<string> = new Set([
+	DevantScopes.INTEGRATION_AS_API,
+	DevantScopes.AI_AGENT,
+	DevantScopes.MCP,
+]);
+
+/** Scopes that represent passive listeners which run alongside whatever else is deployed. */
+const LISTENER_SCOPES: ReadonlySet<string> = new Set([
+	DevantScopes.EVENT_INTEGRATION,
+	DevantScopes.FILE_INTEGRATION,
+]);
+
+export type ResolveIntegrationTypeResult =
+	| { kind: "autoPick"; scope: string }
+	| { kind: "autoPickWithWarning"; scope: string }
+	| { kind: "ask"; choices: string[] };
+
+/**
+ * Decide whether the user must be prompted for an integration type, or whether
+ * one can be chosen automatically (with or without a warning) based on which
+ * scopes are present together.
+ *
+ * Rules:
+ *   1. Exactly one SERVICE scope + zero or more LISTENER scopes → silently pick the SERVICE.
+ *   2. AUTOMATION + ≥1 LISTENER scope + zero SERVICE scopes → pick AUTOMATION with warning.
+ *   3. Otherwise → ask the user (return the de-duplicated input as choices).
+ */
+export const resolveIntegrationType = (
+	supportedIntegrationTypes: readonly string[],
+): ResolveIntegrationTypeResult => {
+	const unique = Array.from(new Set(supportedIntegrationTypes));
+
+	if (unique.length === 0) {
+		return { kind: "ask", choices: [] };
+	}
+
+	if (unique.length === 1) {
+		return { kind: "autoPick", scope: unique[0] };
+	}
+
+	const services = unique.filter((s) => SERVICE_SCOPES.has(s));
+	const listeners = unique.filter((s) => LISTENER_SCOPES.has(s));
+	const hasAutomation = unique.includes(DevantScopes.AUTOMATION);
+	const classifiedCount = services.length + listeners.length + (hasAutomation ? 1 : 0);
+
+	// Any unclassified scope (LIBRARY, ANY, or future additions) blocks auto-pick.
+	if (classifiedCount !== unique.length) {
+		return { kind: "ask", choices: unique };
+	}
+
+	// Rule 1: exactly one SERVICE + only LISTENER scopes alongside → silent pick.
+	if (services.length === 1 && !hasAutomation) {
+		return { kind: "autoPick", scope: services[0] };
+	}
+
+	// Rule 2: AUTOMATION + ≥1 LISTENER + no SERVICE → pick automation, warn.
+	if (hasAutomation && services.length === 0 && listeners.length >= 1) {
+		return { kind: "autoPickWithWarning", scope: DevantScopes.AUTOMATION };
+	}
+
+	return { kind: "ask", choices: unique };
+};
+
+/**
+ * The standard warning message shown when {@link resolveIntegrationType} returns
+ * `autoPickWithWarning`. Callers may wrap this in their own UI (modal, banner, etc.).
+ */
+export const AUTOMATION_WITH_LISTENER_WARNING =
+	"This integration contains a listener that will run continuously while the automation is running. The automation will be deployed, and the listener will be active for the duration of every automation run.";


### PR DESCRIPTION
This update automatically selects the integration type for certain combinations of services and listeners, eliminating unnecessary prompts. Specifically, it auto-picks the service when a single service is combined with any listeners and warns the user when automation is combined with listeners, indicating that the listener will run during automation. This change enhances the user experience by reducing confusion and streamlining the deployment process.
Fixes wso2/product-integrator#1616



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced integration type resolution for Devant deployments with improved selection logic.
  * Added warning notifications when automation type conflicts with listener scopes during deployment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->