### PR TITLE
Improve Fill With AI experience with MCP Server

### DIFF
--- a/workspaces/mi/mi-extension/src/rpc-managers/ai-features/rpc-manager.ts
+++ b/workspaces/mi/mi-extension/src/rpc-managers/ai-features/rpc-manager.ts
@@ -956,7 +956,7 @@ Respond ONLY with a JSON object in this exact format, no other text:
             };
         } catch (error: any) {
             const message: string = error?.message ?? 'Unknown error';
-            // 'Unsupported login method: undefined' is thrown when the user is not logged in at all
+            // Error is thrown when the user is not logged in at all
             if (message.includes('Authentication failed') || message.includes('Unsupported login method')) {
                 // Let the webview catch this and prompt the user to sign in
                 throw new Error('Authentication failed: Please sign in to use AI features');

--- a/workspaces/mi/mi-extension/src/rpc-managers/ai-features/rpc-manager.ts
+++ b/workspaces/mi/mi-extension/src/rpc-managers/ai-features/rpc-manager.ts
@@ -955,7 +955,13 @@ Respond ONLY with a JSON object in this exact format, no other text:
                 inputSchema: JSON.stringify(parsed.inputSchema || {}),
             };
         } catch (error: any) {
-            vscode.window.showErrorMessage(`Fill With AI failed: ${error?.message ?? 'Unknown error'}`);
+            const message: string = error?.message ?? 'Unknown error';
+            // 'Unsupported login method: undefined' is thrown when the user is not logged in at all
+            if (message.includes('Authentication failed') || message.includes('Unsupported login method')) {
+                // Let the webview catch this and prompt the user to sign in
+                throw new Error('Authentication failed: Please sign in to use AI features');
+            }
+            vscode.window.showErrorMessage(`Fill With AI failed: ${message}`);
             return { name: '', description: '', inputSchema: '{}' };
         }
     }

--- a/workspaces/mi/mi-visualizer/src/components/AuthenticationDialog/AuthenticationDialog.tsx
+++ b/workspaces/mi/mi-visualizer/src/components/AuthenticationDialog/AuthenticationDialog.tsx
@@ -23,7 +23,7 @@ import { useVisualizerContext } from "@wso2/mi-rpc-client";
 
 export interface AuthenticationDialogProps {
     isOpen: boolean;
-    operationType: 'createUnitTests' | 'generateTestCase' | 'dataMapperMigration';
+    operationType: 'createUnitTests' | 'generateTestCase' | 'dataMapperMigration' | 'mcpToolSuggestion';
     sessionStorageKey: string;
     formValues?: any;
     signInMessage?: string;

--- a/workspaces/mi/mi-visualizer/src/components/AuthenticationDialog/useAuthentication.ts
+++ b/workspaces/mi/mi-visualizer/src/components/AuthenticationDialog/useAuthentication.ts
@@ -20,7 +20,7 @@ import { useState } from 'react';
 import { useVisualizerContext } from "@wso2/mi-rpc-client";
 
 export interface UseAuthenticationOptions {
-    operationType: 'createUnitTests' | 'generateTestCase' | 'dataMapperMigration';
+    operationType: 'createUnitTests' | 'generateTestCase' | 'dataMapperMigration' | 'mcpToolSuggestion';
     sessionStorageKey: string;
 }
 

--- a/workspaces/mi/mi-visualizer/src/views/Forms/InboundEPform/index.tsx
+++ b/workspaces/mi/mi-visualizer/src/views/Forms/InboundEPform/index.tsx
@@ -63,6 +63,10 @@ export interface Region {
     value: string;
 }
 
+// MCP servers are created through the dedicated MCP Server artifact flow,
+// so the raw MCP inbound connector is hidden from the event integration list.
+const HIDDEN_INBOUND_CONNECTORS = /^mcp\b/i;
+
 export interface InboundEPWizardProps {
     path: string;
     model?: InboundEndpoint;
@@ -114,8 +118,8 @@ export function InboundEPWizard(props: InboundEPWizardProps) {
 
             const localConnectors = await rpcClient.getMiDiagramRpcClient().getLocalInboundConnectors();
 
-            setLocalConnectors(localConnectors["inbound-connector-data"]);
-            setStoreConnectors(data);
+            setLocalConnectors(localConnectors["inbound-connector-data"]?.filter((connector: any) => !HIDDEN_INBOUND_CONNECTORS.test(connector.name)));
+            setStoreConnectors(data?.filter((connector: any) => !HIDDEN_INBOUND_CONNECTORS.test(connector.connectorName)));
         } catch (e) {
             rpcClient.getMiVisualizerRpcClient().showNotification({message: "Error occurred while fetching inbound-connectors", type: "error"});
             console.error("Error fetching connectors", e);

--- a/workspaces/mi/mi-visualizer/src/views/Forms/MCPServerForm/AddAPIToolDialog.tsx
+++ b/workspaces/mi/mi-visualizer/src/views/Forms/MCPServerForm/AddAPIToolDialog.tsx
@@ -23,6 +23,7 @@ import { useForm } from 'react-hook-form';
 import { useVisualizerContext } from '@wso2/mi-rpc-client';
 import { DialogField, DialogButtonGroup, DialogTitle } from '../Commons';
 import { SelectAllRow, CustomInputsContainer, ItemsList, ListItem, ListItemHeader } from './styles';
+import { AuthenticationDialog, useAuthentication } from '../../../components/AuthenticationDialog';
 import { EMPTY_MCP_SCHEMA, INVALID_MCP_SCHEMA_MESSAGE } from '../../../constants';
 
 interface APIOperation {
@@ -121,6 +122,12 @@ export function AddAPIToolDialog({
     const [aiLoadingIds, setAiLoadingIds] = useState<Set<string>>(new Set());
     const [apiSchemas, setApiSchemas] = useState<Record<string, string>>({});
     const [apiDescriptions, setApiDescriptions] = useState<Record<string, string>>({});
+    const [pendingAiOperationId, setPendingAiOperationId] = useState<string | null>(null);
+
+    const { showSignInConfirm, checkAuthentication, openSignInView, closeSignInView } = useAuthentication({
+        operationType: 'mcpToolSuggestion',
+        sessionStorageKey: 'pendingMcpApiToolFill',
+    });
 
     const { register, handleSubmit, watch, getValues, setValue, setError, clearErrors, reset, formState: { errors } } = useForm<FormValues>({
         defaultValues: { items: {} },
@@ -228,7 +235,16 @@ export function AddAPIToolDialog({
         return true;
     };
 
+    const promptSignIn = (operationId: string) => {
+        setPendingAiOperationId(operationId);
+        openSignInView({ operationId });
+    };
+
     const handleFillWithAI = async (op: APIOperation) => {
+        if (!(await checkAuthentication())) {
+            promptSignIn(op.id);
+            return;
+        }
         setAiLoadingIds(prev => new Set(prev).add(op.id));
         try {
             const customName = getValues(`items.${op.id}.customName` as const);
@@ -251,8 +267,23 @@ export function AddAPIToolDialog({
                 setValue(`items.${op.id}.inputSchema` as const, result.inputSchema);
                 validateSchema(op.id, result.inputSchema);
             }
+        } catch (error: any) {
+            if (String(error?.message ?? error).includes('Authentication failed')) {
+                promptSignIn(op.id);
+            } else {
+                console.error('Fill with AI failed', error);
+            }
         } finally {
             setAiLoadingIds(prev => { const n = new Set(prev); n.delete(op.id); return n; });
+        }
+    };
+
+    const handleAuthenticationSuccess = async (formValues: any) => {
+        const operationId = formValues?.operationId ?? pendingAiOperationId;
+        setPendingAiOperationId(null);
+        const op = selectedAPI?.operations.find((o: APIOperation) => o.id === operationId);
+        if (op) {
+            handleFillWithAI(op);
         }
     };
 
@@ -466,6 +497,17 @@ export function AddAPIToolDialog({
                     Add Selected Tools ({selectedOperationIds.size})
                 </Button>
             </DialogButtonGroup>
+
+            <AuthenticationDialog
+                isOpen={showSignInConfirm}
+                operationType="mcpToolSuggestion"
+                sessionStorageKey="pendingMcpApiToolFill"
+                formValues={pendingAiOperationId ? { operationId: pendingAiOperationId } : undefined}
+                signInMessage="You need to sign in to WSO2 Integrator Copilot to use the Fill with AI feature. Would you like to sign in?"
+                waitingMessage="Please complete the sign-in process. The tool details will be filled automatically after successful authentication."
+                onCancel={() => { setPendingAiOperationId(null); closeSignInView(); }}
+                onAuthenticationSuccess={handleAuthenticationSuccess}
+            />
         </Dialog>
     );
 }

--- a/workspaces/mi/mi-visualizer/src/views/Forms/MCPServerForm/AddSequenceToolDialog.tsx
+++ b/workspaces/mi/mi-visualizer/src/views/Forms/MCPServerForm/AddSequenceToolDialog.tsx
@@ -24,6 +24,7 @@ import { Sequence } from '@wso2/mi-core';
 import { useVisualizerContext } from '@wso2/mi-rpc-client';
 import { DialogField, DialogButtonGroup, DialogTitle } from '../Commons';
 import { SelectAllRow, CustomInputsContainer, ItemsList, ListItem, ListItemHeader } from './styles';
+import { AuthenticationDialog, useAuthentication } from '../../../components/AuthenticationDialog';
 import { EMPTY_MCP_SCHEMA, INVALID_MCP_SCHEMA_MESSAGE } from '../../../constants';
 
 // Styled Components
@@ -57,6 +58,12 @@ export function AddSequenceToolDialog({ isOpen, sequences, onConfirm, onCancel }
     const { rpcClient } = useVisualizerContext();
     const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
     const [aiLoadingIds, setAiLoadingIds] = useState<Set<string>>(new Set());
+    const [pendingAiSequenceId, setPendingAiSequenceId] = useState<string | null>(null);
+
+    const { showSignInConfirm, checkAuthentication, openSignInView, closeSignInView } = useAuthentication({
+        operationType: 'mcpToolSuggestion',
+        sessionStorageKey: 'pendingMcpSequenceToolFill',
+    });
 
     const { register, handleSubmit, watch, getValues, setValue, setError, clearErrors, reset, formState: { errors } } = useForm<FormValues>({
         defaultValues: { items: {} },
@@ -114,7 +121,16 @@ export function AddSequenceToolDialog({ isOpen, sequences, onConfirm, onCancel }
         return true;
     };
 
+    const promptSignIn = (sequenceId: string) => {
+        setPendingAiSequenceId(sequenceId);
+        openSignInView({ sequenceId });
+    };
+
     const handleFillWithAI = async (seq: Sequence) => {
+        if (!(await checkAuthentication())) {
+            promptSignIn(seq.id);
+            return;
+        }
         setAiLoadingIds(prev => new Set(prev).add(seq.id));
         try {
             const customName = getValues(`items.${seq.id}.customName` as const);
@@ -133,8 +149,23 @@ export function AddSequenceToolDialog({ isOpen, sequences, onConfirm, onCancel }
                 setValue(`items.${seq.id}.inputSchema` as const, result.inputSchema);
                 validateSchema(seq.id, result.inputSchema);
             }
+        } catch (error: any) {
+            if (String(error?.message ?? error).includes('Authentication failed')) {
+                promptSignIn(seq.id);
+            } else {
+                console.error('Fill with AI failed', error);
+            }
         } finally {
             setAiLoadingIds(prev => { const n = new Set(prev); n.delete(seq.id); return n; });
+        }
+    };
+
+    const handleAuthenticationSuccess = async (formValues: any) => {
+        const sequenceId = formValues?.sequenceId ?? pendingAiSequenceId;
+        setPendingAiSequenceId(null);
+        const seq = sequences.find(s => s.id === sequenceId);
+        if (seq) {
+            handleFillWithAI(seq);
         }
     };
 
@@ -303,6 +334,17 @@ export function AddSequenceToolDialog({ isOpen, sequences, onConfirm, onCancel }
                     Add Selected ({selectedIds.size})
                 </Button>
             </DialogButtonGroup>
+
+            <AuthenticationDialog
+                isOpen={showSignInConfirm}
+                operationType="mcpToolSuggestion"
+                sessionStorageKey="pendingMcpSequenceToolFill"
+                formValues={pendingAiSequenceId ? { sequenceId: pendingAiSequenceId } : undefined}
+                signInMessage="You need to sign in to WSO2 Integrator Copilot to use the Fill with AI feature. Would you like to sign in?"
+                waitingMessage="Please complete the sign-in process. The tool details will be filled automatically after successful authentication."
+                onCancel={() => { setPendingAiSequenceId(null); closeSignInView(); }}
+                onAuthenticationSuccess={handleAuthenticationSuccess}
+            />
         </Dialog>
     );
 }

--- a/workspaces/mi/mi-visualizer/src/views/Forms/MCPServerForm/CreateScratchToolDialog.tsx
+++ b/workspaces/mi/mi-visualizer/src/views/Forms/MCPServerForm/CreateScratchToolDialog.tsx
@@ -24,6 +24,7 @@ import * as yup from 'yup';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useVisualizerContext } from '@wso2/mi-rpc-client';
 import { DialogField, DialogButtonGroup, DialogTitle } from '../Commons';
+import { AuthenticationDialog, useAuthentication } from '../../../components/AuthenticationDialog';
 import { EMPTY_MCP_SCHEMA, INVALID_MCP_SCHEMA_MESSAGE } from '../../../constants';
 
 // Styled Components
@@ -72,6 +73,11 @@ export function CreateScratchToolDialog({
     const { rpcClient } = useVisualizerContext();
     const [aiLoading, setAiLoading] = useState(false);
 
+    const { showSignInConfirm, checkAuthentication, openSignInView, closeSignInView } = useAuthentication({
+        operationType: 'mcpToolSuggestion',
+        sessionStorageKey: 'pendingMcpScratchToolFill',
+    });
+
     const schema = useMemo(() => yup.object({
         name: yup.string()
             .required('Tool name is required')
@@ -119,6 +125,10 @@ export function CreateScratchToolDialog({
 
     const handleFillWithAI = async () => {
         if (!name?.trim()) return;
+        if (!(await checkAuthentication())) {
+            openSignInView();
+            return;
+        }
         setAiLoading(true);
         try {
             const result = await rpcClient.getMiVisualizerRpcClient().getMcpToolSuggestion({ toolName: name.trim() });
@@ -129,8 +139,12 @@ export function CreateScratchToolDialog({
                 setValue('inputSchema', result.inputSchema);
                 await validateSchema(result.inputSchema);
             }
-        } catch {
-            setError('inputSchema', { message: INVALID_MCP_SCHEMA_MESSAGE });
+        } catch (error: any) {
+            if (String(error?.message ?? error).includes('Authentication failed')) {
+                openSignInView();
+            } else {
+                console.error('Fill with AI failed', error);
+            }
         } finally {
             setAiLoading(false);
         }
@@ -232,6 +246,16 @@ export function CreateScratchToolDialog({
                     Create Tool
                 </Button>
             </DialogButtonGroup>
+
+            <AuthenticationDialog
+                isOpen={showSignInConfirm}
+                operationType="mcpToolSuggestion"
+                sessionStorageKey="pendingMcpScratchToolFill"
+                signInMessage="You need to sign in to WSO2 Integrator Copilot to use the Fill with AI feature. Would you like to sign in?"
+                waitingMessage="Please complete the sign-in process. The tool details will be filled automatically after successful authentication."
+                onCancel={closeSignInView}
+                onAuthenticationSuccess={async () => { handleFillWithAI(); }}
+            />
         </Dialog>
     );
 }


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject

- Handles the scenario where the user is not logged in
- Hides MCP inbound from the event integration list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sign-in gating added for "Fill with AI" so AI operations can prompt for authentication and resume after successful sign-in.

* **Bug Fixes**
  * Improved AI error handling to detect auth failures and open the sign-in prompt rather than showing generic failure messages.

* **Changes**
  * MCP-related inbound connectors are hidden from the event integration selection list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->