### PR TITLE
Disable server-side compaction for AWS Bedrock

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
@@ -41,7 +41,6 @@ import * as path from 'path';
 import { approvalViewManager } from '../state/ApprovalViewManager';
 import {
     buildContextManagementOptions,
-    buildBedrockContextManagementOptions,
     detectAppliedCompaction,
     estimateFloorTokens,
     extractCompactionSummary,
@@ -78,18 +77,16 @@ export function clearCompactionDisabledWarning(projectRootPath: string, threadId
 }
 
 function supportsCompaction(loginMethod: LoginMethod): boolean {
+    // AWS Bedrock is intentionally excluded: its Converse/ConverseStream APIs do not
+    // support the `compact-2026-01-12` beta, so server-side compaction is disabled there.
     return loginMethod === LoginMethod.ANTHROPIC_KEY
         || loginMethod === LoginMethod.BI_INTEL
-        || loginMethod === LoginMethod.VERTEX_AI
-        || loginMethod === LoginMethod.AWS_BEDROCK;
+        || loginMethod === LoginMethod.VERTEX_AI;
 }
 
 function buildCompactionProviderOptions(loginMethod: LoginMethod, floorTokens: number) {
     if (!supportsCompaction(loginMethod)) { return undefined; }
-    const config = { estimatedFloorTokens: floorTokens };
-    const options = loginMethod === LoginMethod.AWS_BEDROCK
-        ? buildBedrockContextManagementOptions(config)
-        : buildContextManagementOptions(config);
+    const options = buildContextManagementOptions({ estimatedFloorTokens: floorTokens });
     return options ?? undefined;
 }
 
@@ -99,10 +96,6 @@ function warnCompactionDisabledOnce(projectRootPath: string, eventHandler: (e: a
         compactionDisabledWarnedThreads.add(warnKey);
         eventHandler({ type: 'compaction_disabled' });
     }
-}
-
-function usesContentBasedCompactionDetection(loginMethod: LoginMethod): boolean {
-    return loginMethod === LoginMethod.AWS_BEDROCK;
 }
 
 /** Estimate character length of a message's content for proportional token breakdown. */
@@ -349,10 +342,10 @@ export class AgentExecutor extends AICommandExecutor<GenerateAgentCodeRequest> {
             let accToolResultChars = 0;
 
             // === SERVER-SIDE COMPACTION STATE ===
-            // Primary detection: providerMetadata on text-start (Anthropic/BI_INTEL/Vertex).
-            // Fallback detection: content-based (<analysis> prefix) for Bedrock, which emits
-            // bare text-start events with no providerMetadata.
-            const useContentBasedDetection = usesContentBasedCompactionDetection(loginMethod);
+            // Detection: providerMetadata on text-start (Anthropic/BI_INTEL/Vertex).
+            // No content-based fallback is needed — AWS Bedrock does not run server-side
+            // compaction (its Converse APIs reject the compact beta).
+            const useContentBasedDetection = false;
             let isCompactionBlock = false;
             let compactionContent = '';
             let cleanedCompactionSummary: string | undefined;

--- a/workspaces/common-libs/copilot-utilities/src/context-management/index.ts
+++ b/workspaces/common-libs/copilot-utilities/src/context-management/index.ts
@@ -150,50 +150,6 @@ export function extractCompactionSummary(rawContent: string): string | null {
 }
 
 /**
- * Builds providerOptions for Amazon Bedrock's context management API.
- *
- * Bedrock does not use providerOptions.anthropic — it reads providerOptions.bedrock
- * and passes context_management via additionalModelRequestFields. The beta header
- * is sent via the anthropicBeta array.
- *
- * Returns null under the same conditions as buildContextManagementOptions (floor >= trigger).
- */
-export function buildBedrockContextManagementOptions(
-    config: ContextManagementConfig = {}
-): { bedrock: { anthropicBeta: string[]; additionalModelRequestFields: Record<string, unknown> } } | null {
-    const compactTrigger = config.compactTriggerTokens ?? DEFAULT_COMPACT_TRIGGER;
-    const clearTrigger = config.clearToolUsesTriggerTokens ?? DEFAULT_CLEAR_TOOL_USES_TRIGGER;
-    const keepToolUses = config.keepRecentToolUses ?? DEFAULT_KEEP_RECENT_TOOL_USES;
-    const instructions = config.compactionInstructions ?? SUMMARIZATION_PROMPT;
-
-    if (config.estimatedFloorTokens !== undefined && config.estimatedFloorTokens >= compactTrigger) {
-        return null;
-    }
-
-    return {
-        bedrock: {
-            anthropicBeta: ['compact-2026-01-12'],
-            additionalModelRequestFields: {
-                context_management: {
-                    edits: [
-                        {
-                            type: 'clear_tool_uses_20250919',
-                            trigger: { type: 'input_tokens', value: clearTrigger },
-                            keep: { type: 'tool_uses', value: keepToolUses },
-                        },
-                        {
-                            type: 'compact_20260112',
-                            trigger: { type: 'input_tokens', value: compactTrigger },
-                            instructions,
-                        },
-                    ],
-                },
-            },
-        },
-    };
-}
-
-/**
  * Strips <analysis>...</analysis> blocks from compaction text in model messages.
  * Called in prepareStep to avoid re-sending verbose reasoning tokens on every
  * subsequent turn after compaction.


### PR DESCRIPTION
## Description
 Logging in with **AWS Bedrock** and running an agent task fails with:

  > The compact beta feature is not currently supported on the Converse and ConverseStream APIs because compact is not currently supported

Bedrock's Converse/ConverseStream APIs do not support the `compact-2026-01-12` beta. Because `AWS_BEDROCK` was listed as a compaction-capable provider, every request sent the `compact_20260112` edit and `anthropicBeta: ['compact-2026-01-12']` header, which Bedrock rejects.

## Fix
 Disable server-side compaction for AWS Bedrock. Bedrock requests now omit the `context_management` config and beta header entirely. Other login methods (Anthropic key, BI Intel, Vertex AI) are unchanged and keep full compaction.

It resolves: https://github.com/wso2/product-integrator/issues/1706
## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## UI Component Development
> Specify the reason if following are not followed.
- [ ] Added reusable UI components to the ui-toolkit. Follow the [intructions](./workspaces/common-libs/ui-toolkit/README.md) when adding the componenent.
- [ ] Use ui-toolkit components wherever possible. Run `npm run storybook` from the root directory to view current components.
- [ ] Matches with the native VSCode look and feel.

## Manage Icons
> Specify the reason if following are not followed.
- [ ] Added Icons to the font-wso2-vscode. Follow the [instructions](./workspaces/common-libs/font-wso2-vscode/README.md).

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.