### PR TITLE
Enable navigating to the Data Mapper from `Map Data` node

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -853,8 +853,8 @@ importers:
         specifier: 29.7.0
         version: 29.7.0(@types/node@22.15.24)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.24)(typescript@5.8.3))
       joi:
-        specifier: 17.13.3
-        version: 17.13.3
+        specifier: 18.2.1
+        version: 18.2.1
       lodash.camelcase:
         specifier: 4.3.0
         version: 4.3.0
@@ -6738,11 +6738,25 @@ packages:
       graphql-ws:
         optional: true
 
-  '@hapi/hoek@9.3.0':
-    resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
+  '@hapi/address@5.1.1':
+    resolution: {integrity: sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==}
+    engines: {node: '>=14.0.0'}
 
-  '@hapi/topo@5.1.0':
-    resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
+  '@hapi/formula@3.0.2':
+    resolution: {integrity: sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==}
+
+  '@hapi/hoek@11.0.7':
+    resolution: {integrity: sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==}
+
+  '@hapi/pinpoint@2.0.1':
+    resolution: {integrity: sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==}
+
+  '@hapi/tlds@1.1.7':
+    resolution: {integrity: sha512-MgNjRwy9Ti92yVAixLmDc8dd1bJIKwO9qlWCfFQRwRmUEDPQHYn4G6hwPFvFGUTzAa0FsS+inMjLin7GnyBRhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@hapi/topo@6.0.2':
+    resolution: {integrity: sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==}
 
   '@headlessui/react@1.7.18':
     resolution: {integrity: sha512-4i5DOrzwN4qSgNsL4Si61VMkUcWbcSKueUV7sFhpHzQcSShdlHENE5+QBntMSRvHt8NyoFO2AGG8si9lq+w4zQ==}
@@ -8783,15 +8797,6 @@ packages:
   '@sentry/webpack-plugin@1.20.1':
     resolution: {integrity: sha512-klOLkfM/oSYzcR2M9oDmJA5/Mdaw0Mtck/h820Z+gqpd6WJepjhqVDel1z2VddaP/XMY0Dj6elCGp2/nDWNr0w==}
     engines: {node: '>= 8'}
-
-  '@sideway/address@4.1.5':
-    resolution: {integrity: sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==}
-
-  '@sideway/formula@3.0.1':
-    resolution: {integrity: sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==}
-
-  '@sideway/pinpoint@2.0.0':
-    resolution: {integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==}
 
   '@sinclair/typebox@0.27.10':
     resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
@@ -17787,8 +17792,9 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
-  joi@17.13.3:
-    resolution: {integrity: sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==}
+  joi@18.2.1:
+    resolution: {integrity: sha512-2/OKlogiESf2Nh3TFCrRjrr9z1DRHeW0I+KReF67+4J0Ns+8hBtHRmoWAZ2OFU6I5+TWLEe6sVlSdXPjHm5UbQ==}
+    engines: {node: '>= 20'}
 
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
@@ -28356,11 +28362,21 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@hapi/hoek@9.3.0': {}
-
-  '@hapi/topo@5.1.0':
+  '@hapi/address@5.1.1':
     dependencies:
-      '@hapi/hoek': 9.3.0
+      '@hapi/hoek': 11.0.7
+
+  '@hapi/formula@3.0.2': {}
+
+  '@hapi/hoek@11.0.7': {}
+
+  '@hapi/pinpoint@2.0.1': {}
+
+  '@hapi/tlds@1.1.7': {}
+
+  '@hapi/topo@6.0.2':
+    dependencies:
+      '@hapi/hoek': 11.0.7
 
   '@headlessui/react@1.7.18(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
@@ -31782,14 +31798,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
-
-  '@sideway/address@4.1.5':
-    dependencies:
-      '@hapi/hoek': 9.3.0
-
-  '@sideway/formula@3.0.1': {}
-
-  '@sideway/pinpoint@2.0.0': {}
 
   '@sinclair/typebox@0.27.10': {}
 
@@ -47965,13 +47973,15 @@ snapshots:
 
   jiti@2.7.0: {}
 
-  joi@17.13.3:
+  joi@18.2.1:
     dependencies:
-      '@hapi/hoek': 9.3.0
-      '@hapi/topo': 5.1.0
-      '@sideway/address': 4.1.5
-      '@sideway/formula': 3.0.1
-      '@sideway/pinpoint': 2.0.0
+      '@hapi/address': 5.1.1
+      '@hapi/formula': 3.0.2
+      '@hapi/hoek': 11.0.7
+      '@hapi/pinpoint': 2.0.1
+      '@hapi/tlds': 1.1.7
+      '@hapi/topo': 6.0.2
+      '@standard-schema/spec': 1.1.0
 
   jose@6.2.3: {}
 
@@ -53603,7 +53613,7 @@ snapshots:
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
-      webpack: 5.104.1(postcss@8.5.10)(webpack-cli@4.10.0)
+      webpack: 5.104.1(postcss@8.5.10)(webpack-cli@5.1.4)
 
   source-map-resolve@0.6.0:
     dependencies:

--- a/workspaces/ballerina/ballerina-low-code-diagram/package.json
+++ b/workspaces/ballerina/ballerina-low-code-diagram/package.json
@@ -34,7 +34,7 @@
         "graphql": "16.11.0",
         "handlebars": "4.7.9",
         "jest": "29.7.0",
-        "joi": "17.13.3",
+        "joi": "18.2.1",
         "lodash.camelcase": "4.3.0",
         "lodash.clonedeep": "4.5.0",
         "lodash.debounce": "4.0.8",

--- a/workspaces/ballerina/bi-diagram/src/components/nodes/BaseNode/BaseNodeWidget.tsx
+++ b/workspaces/ballerina/bi-diagram/src/components/nodes/BaseNode/BaseNodeWidget.tsx
@@ -199,6 +199,8 @@ export function BaseNodeWidget(props: BaseNodeWidgetProps) {
         model.node.codedata.node === "FUNCTION_CALL" &&
         model.node.codedata.org === project?.org &&
         Boolean(model.node.properties?.view?.value);
+    const canOpenDataMapper =
+        model.node.codedata.node === "DATA_MAPPER_CALL" && Boolean(model.node.properties?.view?.value);
 
     const handleOnClick = async (event: React.MouseEvent<HTMLDivElement>) => {
         if (readOnly) {
@@ -266,6 +268,13 @@ export function BaseNodeWidget(props: BaseNodeWidgetProps) {
             return;
         }
         viewFunction();
+    };
+
+    const handleOnOpenDataMapperClick = () => {
+        if (readOnly) {
+            return;
+        }
+        openDataMapper();
     };
 
     const openDataMapper = async () => {
@@ -401,6 +410,21 @@ export function BaseNodeWidget(props: BaseNodeWidgetProps) {
                                     buttonSx={readOnly ? { cursor: "not-allowed" } : {}}
                                     appearance="icon"
                                     onClick={handleOnViewFunctionClick}
+                                >
+                                    <Icon
+                                        name="bi-function-flow"
+                                        sx={{ width: 16, height: 16 }}
+                                        iconSx={{ fontSize: 16 }}
+                                    />
+                                </NodeStyles.MenuButton>
+                            </Tooltip>
+                        )}
+                        {canOpenDataMapper && (
+                            <Tooltip content="View data mapper">
+                                <NodeStyles.MenuButton
+                                    buttonSx={readOnly ? { cursor: "not-allowed" } : {}}
+                                    appearance="icon"
+                                    onClick={handleOnOpenDataMapperClick}
                                 >
                                     <Icon
                                         name="bi-function-flow"

--- a/workspaces/ballerina/bi-diagram/src/test/__snapshots__/Diagram.test.tsx.snap
+++ b/workspaces/ballerina/bi-diagram/src/test/__snapshots__/Diagram.test.tsx.snap
@@ -6960,6 +6960,29 @@ exports[`BI Diagram - Snapshot Tests renders all nodes flow correctly: all-nodes
                   class="css-31"
                 >
                   <div
+                    class="css-32"
+                  >
+                    <div
+                      class="css-23 css-24"
+                    >
+                      <vscode-button>
+                        <div
+                          class="css-33"
+                        >
+                          <i
+                            class="fw-bi-function-flow"
+                            style="font-size: 16px;"
+                          />
+                        </div>
+                        <input
+                          slot="form-associated-proxy"
+                          style="display: none;"
+                          type="undefined"
+                        />
+                      </vscode-button>
+                    </div>
+                  </div>
+                  <div
                     class="css-23 css-24"
                   >
                     <vscode-button>

--- a/workspaces/ballerina/data-mapper/src/components/Diagram/Node/LinkConnector/LinkConnectorNode.ts
+++ b/workspaces/ballerina/data-mapper/src/components/Diagram/Node/LinkConnector/LinkConnectorNode.ts
@@ -49,6 +49,7 @@ export class LinkConnectorNode extends DataMapperNodeModel {
     public hidden: boolean;
     public shouldInitLinks: boolean;
     public label: string;
+    public hasUnresolvedInputs: boolean;
 
     constructor(
         public context: IDataMapperContext,
@@ -68,6 +69,7 @@ export class LinkConnectorNode extends DataMapperNodeModel {
         const prevSourcePorts = this.sourcePorts;
         this.sourcePorts = [];
         this.targetMappedPort = undefined;
+        this.hasUnresolvedInputs = false;
         this.inPort = new IntermediatePortModel(`${this.mapping.inputs.join('_')}_${this.mapping.output}_IN`, "IN");
         this.outPort = new IntermediatePortModel(`${this.mapping.inputs.join('_')}_${this.mapping.output}_OUT`, "OUT");
         this.addPort(this.inPort);
@@ -87,11 +89,14 @@ export class LinkConnectorNode extends DataMapperNodeModel {
             if (!matchedSearch) return;
 
             const inputNode = findInputNode(field, this, views, lastViewIndex);
-            if (inputNode) {
-                const inputPort = getInputPort(inputNode, field?.replace(/\.\d+/g, ''));
-                if (!this.sourcePorts.some(port => port?.getID() === inputPort?.getID())) {
-                    this.sourcePorts.push(inputPort);
-                }
+            const inputPort = inputNode ? getInputPort(inputNode, field?.replace(/\.\d+/g, '')) : undefined;
+            if (!inputPort) {
+                // The input field is absent from the diagram, hence the mapping cannot be visualized as a link
+                this.hasUnresolvedInputs = true;
+                return;
+            }
+            if (!this.sourcePorts.some(port => port.getID() === inputPort.getID())) {
+                this.sourcePorts.push(inputPort);
             }
         })
 
@@ -185,7 +190,7 @@ export class LinkConnectorNode extends DataMapperNodeModel {
                 }
             })
 
-            if (this.targetMappedPort) {
+            if (this.targetMappedPort && !this.hasOnlyUnresolvedInputs()) {
                 const outPort = this.outPort;
                 const targetPort = this.targetMappedPort;
 
@@ -228,6 +233,12 @@ export class LinkConnectorNode extends DataMapperNodeModel {
 
     public hasError(): boolean {
         return this.diagnostics.length > 0;
+    }
+
+    // True when none of the mapping inputs could be resolved to a port,
+    // i.e. the mapping has inputs but their fields are absent from the diagram
+    public hasOnlyUnresolvedInputs(): boolean {
+        return this.hasUnresolvedInputs && this.sourcePorts.length === 0;
     }
 
     public async deleteLink(): Promise<void> {

--- a/workspaces/ballerina/data-mapper/src/components/Diagram/Node/LinkConnector/LinkConnectorNodeWidget.tsx
+++ b/workspaces/ballerina/data-mapper/src/components/Diagram/Node/LinkConnector/LinkConnectorNodeWidget.tsx
@@ -65,7 +65,7 @@ export function LinkConnectorNodeWidget(props: LinkConnectorNodeWidgetProps) {
         </div>
     );
 
-    return (!node.hidden && (
+    return (!node.hidden && !node.hasOnlyUnresolvedInputs() && (
         <div className={classes.root} data-testid={`link-connector-node-${node?.targetPort?.getName()}`}>
             <div className={classes.header}>
                 {renderPortWidget(engine, node.inPort, `${node?.value}-input`)}

--- a/workspaces/ballerina/data-mapper/src/components/Diagram/Node/QueryExprConnector/QueryExprConnectorNode.ts
+++ b/workspaces/ballerina/data-mapper/src/components/Diagram/Node/QueryExprConnector/QueryExprConnectorNode.ts
@@ -49,6 +49,7 @@ export class QueryExprConnectorNode extends DataMapperNodeModel {
     public hidden: boolean;
     public shouldInitLinks: boolean;
     public label: string;
+    public hasUnresolvedInputs: boolean;
 
     constructor(
         public context: IDataMapperContext,
@@ -67,6 +68,7 @@ export class QueryExprConnectorNode extends DataMapperNodeModel {
         const prevSourcePorts = this.sourcePorts;
         this.sourcePorts = [];
         this.targetMappedPort = undefined;
+        this.hasUnresolvedInputs = false;
         this.inPort = new IntermediatePortModel(`${this.mapping.inputs.join('_')}_${this.mapping.output}_IN`, "IN");
         this.outPort = new IntermediatePortModel(`${this.mapping.inputs.join('_')}_${this.mapping.output}_OUT`, "OUT");
         this.addPort(this.inPort);
@@ -85,11 +87,14 @@ export class QueryExprConnectorNode extends DataMapperNodeModel {
             if (!matchedSearch) return;
 
             const inputNode = findInputNode(field, this, views, lastViewIndex);
-            if (inputNode) {
-                const inputPort = getInputPort(inputNode, field?.replace(/\.\d+/g, ''));
-                if (!this.sourcePorts.some(port => port.getID() === inputPort.getID())) {
-                    this.sourcePorts.push(inputPort);
-                }
+            const inputPort = inputNode ? getInputPort(inputNode, field?.replace(/\.\d+/g, '')) : undefined;
+            if (!inputPort) {
+                // The input field is absent from the diagram, hence the mapping cannot be visualized as a link
+                this.hasUnresolvedInputs = true;
+                return;
+            }
+            if (!this.sourcePorts.some(port => port.getID() === inputPort.getID())) {
+                this.sourcePorts.push(inputPort);
             }
         })
 
@@ -183,7 +188,7 @@ export class QueryExprConnectorNode extends DataMapperNodeModel {
                 }
             })
 
-            if (this.targetMappedPort) {
+            if (this.targetMappedPort && !this.hasOnlyUnresolvedInputs()) {
                 const outPort = this.outPort;
                 const targetPort = this.targetMappedPort;
 
@@ -231,5 +236,11 @@ export class QueryExprConnectorNode extends DataMapperNodeModel {
 
     public hasError(): boolean {
         return this.diagnostics?.length > 0;
+    }
+
+    // True when none of the mapping inputs could be resolved to a port,
+    // i.e. the mapping has inputs but their fields are absent from the diagram
+    public hasOnlyUnresolvedInputs(): boolean {
+        return this.hasUnresolvedInputs && this.sourcePorts.length === 0;
     }
 }

--- a/workspaces/ballerina/data-mapper/src/components/Diagram/Node/QueryExprConnector/QueryExprConnectorNodeWidget.tsx
+++ b/workspaces/ballerina/data-mapper/src/components/Diagram/Node/QueryExprConnector/QueryExprConnectorNodeWidget.tsx
@@ -82,7 +82,7 @@ export function QueryExprConnectorNodeWidget(props: QueryExprConnectorNodeWidget
         </div>
     );
 
-    return (!node.hidden && (
+    return (!node.hidden && !node.hasOnlyUnresolvedInputs() && (
             <div className={classes.root} data-testid={`link-connector-node-${node?.targetPort?.getName()}`}>
                 <div className={classes.header}>
                     {renderPortWidget(engine, node.inPort, `${node?.value}-input`)}


### PR DESCRIPTION
## Purpose
$title
Addresses: https://github.com/wso2/product-integrator/issues/1703


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated "View data mapper" button in the diagram interface, enabling direct access to data mapping functionality. The button respects read-only mode restrictions.

* **Bug Fixes**
  * Improved diagram robustness by preventing incomplete connector nodes from rendering when their inputs cannot be resolved to diagram ports, thus avoiding invalid link configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->