### PR TITLE
Backport Linux CI e2e test fixes for group1 and group4

### DIFF
--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/automation/flow-nodes.spec.ts
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/automation/flow-nodes.spec.ts
@@ -54,10 +54,17 @@ async function saveForm(webview: Frame) {
         const panelText = await webview.getByTestId('side-panel').innerText({ timeout: 1000 }).catch(() => '');
         throw new Error(`Flow node form did not finish saving.\n${panelText}\n${error}`);
     });
-    await webview.getByTestId('side-panel').waitFor({ state: 'hidden', timeout: 60000 }).catch(async (error) => {
-        const panelText = await webview.getByTestId('side-panel').innerText({ timeout: 1000 }).catch(() => '');
-        throw new Error(`Flow node form did not close after saving.\n${panelText}\n${error}`);
-    });
+    // Retry the Save click once — on slow CI runners the first click can land
+    // before the form's onChange state settles, leaving the panel open.
+    const closed = await webview.getByTestId('side-panel').waitFor({ state: 'hidden', timeout: 20000 }).then(() => true, () => false);
+    if (!closed) {
+        await dismissHelperPanel();
+        await webview.getByRole('button', { name: 'Save' }).last().click({ force: true }).catch(() => { });
+        await webview.getByTestId('side-panel').waitFor({ state: 'hidden', timeout: 60000 }).catch(async (error) => {
+            const panelText = await webview.getByTestId('side-panel').innerText({ timeout: 1000 }).catch(() => '');
+            throw new Error(`Flow node form did not close after saving.\n${panelText}\n${error}`);
+        });
+    }
     await webview.locator('[data-testid="bi-diagram-canvas"]').waitFor({ state: 'visible', timeout: 60000 });
     await page.page.waitForTimeout(1000);
 }
@@ -68,6 +75,25 @@ async function selectNode(sidePanel: SidePanel, nodeTitle: string, sectionTitle?
         await sidePanel.expandSection(sectionTitle);
     }
     await sidePanel.clickNode(nodeTitle);
+}
+
+// Fills a named ex-editor field directly via the CodeMirror view. Unlike
+// Form.fill's cmEditor handler (which silently no-ops if the ex-editor
+// container has not rendered yet — observed on slow Linux CI runners),
+// this explicitly waits for the editor to be mounted before dispatching.
+async function fillExEditor(webview: Frame, key: string, value: string) {
+    const container = webview.locator(`[data-testid="ex-editor-${key}"]`);
+    await container.waitFor({ state: 'visible', timeout: 30000 });
+    await container.locator('.cm-content').first().waitFor({ state: 'attached', timeout: 30000 });
+    await container.evaluate((element, text) => {
+        const cmContent = element.querySelector('.cm-content') as HTMLElement & { cmView?: { view?: any } };
+        const view = cmContent?.cmView?.view;
+        if (!view) {
+            throw new Error('CodeMirror view not found in ex-editor container');
+        }
+        view.focus();
+        view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: text } });
+    }, value);
 }
 
 async function fillFirstCodeMirror(webview: Frame, value: string) {
@@ -101,46 +127,73 @@ async function clickLinkButtonText(webview: Frame, text: string) {
     });
 }
 
-// Add buttons only appear on hover and are not stable Playwright targets; synthetic
-// mouse events via evaluateAll are used because standard hover()+click() does not
-// reliably trigger the diagram's React event handlers for these SVG overlay nodes.
+// Mirrors the original clickNextDiagramPlus algorithm from the main branch but
+// uses real Playwright hover instead of synthetic dispatchEvent (which does not
+// trigger React event handlers on Linux GitHub runners).
+// Priority: empty-node-add-button (always visible) > second-to-last link-add-button.
+// Second-to-last avoids the function-level link after the Error Handler (always last).
 async function clickNextDiagramPlus(webview: Frame) {
     await webview.locator('[data-testid="bi-diagram-canvas"]').waitFor({ state: 'visible', timeout: 30000 });
-    const clickedId = await webview.locator('[data-testid]').evaluateAll((elements) => {
-        const links = elements.filter((element) => {
-            const id = element.getAttribute('data-testid') || '';
-            return id.startsWith('diagram-link-');
-        });
-        for (const link of links) {
-            for (const type of ['pointerover', 'mouseover', 'mouseenter', 'pointerenter']) {
-                link.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true, view: window }));
-            }
-        }
+    await page.page.waitForTimeout(500);
 
-        const candidates = elements.filter((element) => {
-            const id = element.getAttribute('data-testid') || '';
-            return id.startsWith('link-add-button') || id.startsWith('empty-node-add-button');
-        });
-        const target = candidates.find((element) => (element.getAttribute('data-testid') || '').startsWith('empty-node-add-button'))
-            || candidates[candidates.length - 2]
-            || candidates[candidates.length - 1];
-        if (!target) {
-            return '';
-        }
-        for (const type of ['pointerover', 'mouseover', 'mouseenter', 'pointerenter']) {
-            target.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true, view: window }));
-        }
-        for (const type of ['pointerdown', 'mousedown', 'mouseup', 'click']) {
-            target.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true, view: window }));
-        }
-        return target.getAttribute('data-testid') || '';
-    });
-
-    await webview.getByTestId('side-panel').waitFor({ state: 'visible', timeout: 30000 });
-    if (!clickedId) {
-        throw new Error('No diagram add button was available');
+    // Prefer always-visible empty-node-add-buttons (branch/clause placeholders)
+    const emptyBtns = webview.locator('[data-testid^="empty-node-add-button"]');
+    if (await emptyBtns.count() > 0) {
+        await emptyBtns.first().click({ force: true });
+        await webview.getByTestId('side-panel').waitFor({ state: 'visible', timeout: 30000 });
+        return;
     }
+
+    // As the diagram grows it extends past the viewport, making lower links
+    // unhoverable ("Element is outside of the viewport" on 1080p CI runners).
+    // The diagram registers VerticalScrollCanvasAction, so a real mouse wheel
+    // over the canvas pans the diagram vertically — scroll each link into the
+    // canvas area before hovering it.
+    const canvasBox = await webview.locator('[data-testid="bi-diagram-canvas"]').boundingBox();
+    const scrollLinkIntoView = async (link: ReturnType<Frame['locator']>) => {
+        if (!canvasBox) return;
+        await page.page.mouse.move(canvasBox.x + canvasBox.width / 2, canvasBox.y + canvasBox.height / 2);
+        for (let attempt = 0; attempt < 20; attempt++) {
+            const box = await link.boundingBox();
+            if (box && box.y >= canvasBox.y + 10 && box.y + box.height <= canvasBox.y + canvasBox.height - 10) {
+                return;
+            }
+            const delta = box && box.y < canvasBox.y + 10 ? -200 : 200;
+            await page.page.mouse.wheel(0, delta);
+            await page.page.waitForTimeout(150);
+        }
+    };
+
+    // Hover every diagram link with real Playwright so React renders the
+    // link-add-button overlays, then identify the second-to-last button.
+    const links = webview.locator('[data-testid^="diagram-link-"]');
+    const linkCount = await links.count();
+    for (let i = 0; i < linkCount; i++) {
+        await scrollLinkIntoView(links.nth(i));
+        await links.nth(i).hover({ force: true }).catch(() => { });
+        await page.page.waitForTimeout(100);
+    }
+
+    const addBtns = webview.locator('[data-testid^="link-add-button-"]');
+    const btnCount = await addBtns.count();
+    if (btnCount === 0) throw new Error('No diagram add button was available');
+
+    // Re-hover the specific link for the second-to-last button so the button is
+    // visible at click time (hover state resets as we iterate over all links).
+    // Second-to-last avoids the function-level continuation link (which is last).
+    const targetBtnIdx = Math.max(0, btnCount - 2);
+    const targetBtnTestId = await addBtns.nth(targetBtnIdx).getAttribute('data-testid');
+    const correspondingLinkId = targetBtnTestId?.replace('link-add-button', 'diagram-link');
+    if (correspondingLinkId) {
+        const targetLink = webview.locator(`[data-testid="${correspondingLinkId}"]`);
+        await scrollLinkIntoView(targetLink);
+        await targetLink.hover({ force: true });
+        await page.page.waitForTimeout(200);
+    }
+    await addBtns.nth(targetBtnIdx).click({ force: true });
+    await webview.getByTestId('side-panel').waitFor({ state: 'visible', timeout: 30000 });
 }
+
 
 export default function createTests() {
     test.describe.serial('Automation Flow Nodes Tests', {}, async () => {
@@ -168,15 +221,7 @@ export default function createTests() {
             await diagram.clickAddButtonByIndex(1);
             await selectNode(sidePanel, 'Log Info', 'Logging');
             await form.switchToFormView(false, artifactWebView);
-            await form.fill({
-                values: {
-                    'msg': {
-                        type: 'cmEditor',
-                        value: 'flow started',
-                        additionalProps: { switchMode: 'primary-mode', clickLabel: true, window: global.window }
-                    }
-                }
-            });
+            await fillExEditor(artifactWebView, 'msg', '"flow started"');
             await saveForm(artifactWebView);
 
             logStep('Add int count Declare Variable node');
@@ -209,15 +254,7 @@ export default function createTests() {
             await diagram.clickHoverAddButtonByIndex(3);
             await selectNode(sidePanel, 'Log Debug', 'Logging');
             await form.switchToFormView(false, artifactWebView);
-            await form.fill({
-                values: {
-                    'msg': {
-                        type: 'cmEditor',
-                        value: 'string `initial ${count} ${msg}`',
-                        additionalProps: { switchMode: 'primary-mode', clickLabel: true, window: global.window }
-                    }
-                }
-            });
+            await fillExEditor(artifactWebView, 'msg', 'string `initial ${count} ${msg}`');
             await saveForm(artifactWebView);
 
             logStep('Add If node with Else block');
@@ -241,30 +278,14 @@ export default function createTests() {
             await clickNextDiagramPlus(artifactWebView);
             await selectNode(sidePanel, 'Log Error', 'Logging');
             await form.switchToFormView(false, artifactWebView);
-            await form.fill({
-                values: {
-                    'msg': {
-                        type: 'cmEditor',
-                        value: 'sample error log',
-                        additionalProps: { switchMode: 'primary-mode', clickLabel: true, window: global.window }
-                    }
-                }
-            });
+            await fillExEditor(artifactWebView, 'msg', '"sample error log"');
             await saveForm(artifactWebView);
 
             logStep('Add Log Warn node');
             await clickNextDiagramPlus(artifactWebView);
             await selectNode(sidePanel, 'Log Warn', 'Logging');
             await form.switchToFormView(false, artifactWebView);
-            await form.fill({
-                values: {
-                    'msg': {
-                        type: 'cmEditor',
-                        value: 'sample warn log',
-                        additionalProps: { switchMode: 'primary-mode', clickLabel: true, window: global.window }
-                    }
-                }
-            });
+            await fillExEditor(artifactWebView, 'msg', '"sample warn log"');
             await saveForm(artifactWebView);
 
             logStep('Add While node');

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/diagram/diagram.spec.ts
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/diagram/diagram.spec.ts
@@ -124,10 +124,12 @@ export default function createTests() {
                 }
             });
 
-            // Click the add Else Block 
-            // Click the "Add Else Block" button in the If configuration UI before saving
+            // Dismiss the expression helper popup triggered by CodeMirror fill before clicking
+            await page.page.keyboard.press('Escape');
+            await page.page.waitForTimeout(300);
+
+            // Click the add Else Block
             // The "Add Else Block" is not a button, but a div with text.
-            // So select it by its text using .getByText or .locator, and click it.
             const addElseBlockDiv = artifactWebView.getByText('Add Else Block', { exact: true });
             await addElseBlockDiv.click();
             await artifactWebView.getByRole('button', { name: 'Save' }).click();
@@ -154,8 +156,8 @@ export default function createTests() {
                 values: {
                     'msg': {
                         type: 'cmEditor',
-                        value: 'Equal',
-                        additionalProps: { switchMode: 'primary-mode', clickLabel: true, window: global.window }
+                        value: '"Equal"',
+                        additionalProps: { clickLabel: true }
                     }
                 }
             });
@@ -177,8 +179,8 @@ export default function createTests() {
                 values: {
                     'msg': {
                         type: 'cmEditor',
-                        value: 'Not Equal',
-                        additionalProps: { switchMode: 'primary-mode', clickLabel: true, window: global.window }
+                        value: '"Not Equal"',
+                        additionalProps: { clickLabel: true }
                     }
                 }
             });

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/diagram/diagram.spec.ts
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/diagram/diagram.spec.ts
@@ -124,14 +124,18 @@ export default function createTests() {
                 }
             });
 
-            // Dismiss the expression helper popup triggered by CodeMirror fill before clicking
+            // Dismiss the expression helper popup triggered by the CodeMirror fill: the first
+            // Escape closes the completion tooltip, the second the helper pane itself.
+            await page.page.keyboard.press('Escape');
+            await page.page.waitForTimeout(300);
             await page.page.keyboard.press('Escape');
             await page.page.waitForTimeout(300);
 
             // Click the add Else Block
-            // The "Add Else Block" is not a button, but a div with text.
+            // The "Add Else Block" is not a button, but a div with text. The helper pane can
+            // linger over it on CI, so bypass the pointer-interception check.
             const addElseBlockDiv = artifactWebView.getByText('Add Else Block', { exact: true });
-            await addElseBlockDiv.click();
+            await addElseBlockDiv.click({ force: true });
             await artifactWebView.getByRole('button', { name: 'Save' }).click();
             await page.page.waitForTimeout(1000);
 

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/event-integration/azure.spec.ts
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/event-integration/azure.spec.ts
@@ -44,17 +44,34 @@ export default function createTests() {
                 values: {
                     'connectionString': {
                         type: 'cmEditor',
-                        value: 'Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=test',
-                        additionalProps: { clickLabel: true, switchMode: 'primary-mode', window: global.window }
-                    },
-                    'entityConfig': {
-                        type: 'cmEditor',
-                        value: `{ queueName: "testQueue" }`,
-                        additionalProps: { clickLabel: true, switchMode: 'expression-mode', window: global.window }
+                        value: '"Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=test"',
+                        additionalProps: { clickLabel: true }
                     }
                 }
             });
-            await form.submit('Create');
+            // Dismiss expression helper popup triggered by CodeMirror focus before filling next field
+            await page.page.keyboard.press('Escape');
+            await page.page.waitForTimeout(300);
+            // entityConfig defaults to Record mode (controlled React component) where view.dispatch
+            // is immediately reset to {}. Switch to Expression mode first so the fill sticks.
+            const entityConfigContainer = artifactWebView.locator('[data-testid="ex-editor-entityConfig"]');
+            if (await entityConfigContainer.count() > 0) {
+                const exprModeBtn = entityConfigContainer.locator('[data-testid="expression-mode"]');
+                if (await exprModeBtn.count() > 0) {
+                    await exprModeBtn.click({ force: true });
+                    await page.page.waitForTimeout(300);
+                }
+            }
+            await form.fill({
+                values: {
+                    'entityConfig': {
+                        type: 'cmEditor',
+                        value: `{ queueName: "testQueue" }`,
+                        additionalProps: { clickLabel: true }
+                    }
+                }
+            });
+            await form.submit('Create', true);
 
             const projectExplorer = new ProjectExplorer(page.page);
             await projectExplorer.findItem([DEFAULT_PROJECT_NAME, `Azure Service Bus Event Integration`]);
@@ -83,17 +100,34 @@ export default function createTests() {
                 values: {
                     'connectionString': {
                         type: 'cmEditor',
-                        value: 'Endpoint=sb://test.updated.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=test',
-                        additionalProps: { clickLabel: true, switchMode: 'primary-mode', window: global.window }
-                    },
-                    'entityConfig': {
-                        type: 'cmEditor',
-                        value: `{ queueName: "updated-queue-name" }`,
-                        additionalProps: { clickLabel: true, switchMode: 'expression-mode', window: global.window }
+                        value: '"Endpoint=sb://test.updated.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=test"',
+                        additionalProps: { clickLabel: true }
                     }
                 }
             });
-            await form.submit('Save Changes');
+            // Dismiss expression helper popup triggered by CodeMirror focus before filling next field
+            await page.page.keyboard.press('Escape');
+            await page.page.waitForTimeout(300);
+            // entityConfig defaults to Record mode (controlled React component) where view.dispatch
+            // is immediately reset to {}. Switch to Expression mode first so the fill sticks.
+            const entityConfigContainerEdit = artifactWebView.locator('[data-testid="ex-editor-entityConfig"]');
+            if (await entityConfigContainerEdit.count() > 0) {
+                const exprModeBtnEdit = entityConfigContainerEdit.locator('[data-testid="expression-mode"]');
+                if (await exprModeBtnEdit.count() > 0) {
+                    await exprModeBtnEdit.click({ force: true });
+                    await page.page.waitForTimeout(300);
+                }
+            }
+            await form.fill({
+                values: {
+                    'entityConfig': {
+                        type: 'cmEditor',
+                        value: `{ queueName: "updated-queue-name" }`,
+                        additionalProps: { clickLabel: true }
+                    }
+                }
+            });
+            await form.submit('Save Changes', true);
 
             const saveChangesBtn = artifactWebView.locator('#save-changes-btn vscode-button[appearance="primary"]');
             await saveChangesBtn.waitFor({ state: 'visible' });

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/test-function/test-function.spec.ts
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/test-function/test-function.spec.ts
@@ -17,7 +17,7 @@
  */
 
 import { test } from '@playwright/test';
-import { BI_INTEGRATOR_LABEL, BI_WEBVIEW_NOT_FOUND_ERROR, initTest, page } from '../utils/helpers';
+import { BI_INTEGRATOR_LABEL, BI_WEBVIEW_NOT_FOUND_ERROR, getWebview, initTest, page } from '../utils/helpers';
 import { Form, switchToIFrame } from '@wso2/playwright-vscode-tester';
 
 export default function createTests() {
@@ -29,25 +29,29 @@ export default function createTests() {
             const testAttempt = testInfo.retry + 1;
             console.log('Creating test function in test attempt: ', testAttempt);
 
-            // 1. Execute command to add test function
+            // 1. Wait for the BI webview to be ready so StateMachine has the project path set
+            console.log('Waiting for BI webview to initialize...');
+            await getWebview(BI_INTEGRATOR_LABEL, page);
+
+            // 2. Execute command to add test function
             console.log('Executing command to add test function...');
             await page.executePaletteCommand('BI.test.add.function');
 
-            // 2. Get the webview after command execution
+            // 3. Get the webview after command execution
             const artifactWebView = await switchToIFrame(BI_INTEGRATOR_LABEL, page.page, 30000);
             if (!artifactWebView) {
                 throw new Error(BI_WEBVIEW_NOT_FOUND_ERROR);
             }
 
-            // 3. Verify the "Create New Test Case" form is displayed
+            // 4. Verify the "Create New Test Case" form is displayed
             const createForm = artifactWebView.getByRole('heading', { name: /Create New Test Case/i });
-            await createForm.waitFor({ timeout: 10000 });
+            await createForm.waitFor({ timeout: 20000 });
 
-            // 4. Verify the form subtitle shows "Create a new test for your integration"
+            // 5. Verify the form subtitle shows "Create a new test for your integration"
             const subtitle = artifactWebView.getByText(/Create a new test for your integration/i);
             await subtitle.waitFor();
 
-            // 5. Fill the Test Function name field
+            // 6. Fill the Test Function name field
             const functionName = `testFunction${testAttempt}`;
             console.log(`Filling test function name: ${functionName}`);
 


### PR DESCRIPTION
## Summary
- Backports the e2e spec fixes from `wso2/ballerina-vscode` main that resolve the group1 and group4 failures seen in https://github.com/wso2/vscode-extensions/actions/runs/27420923017
- `flow-nodes.spec.ts` (group1): explicit CodeMirror fill via the view API (Form.fill cmEditor silently no-ops when the ex-editor container has not rendered on slow runners), Save retry, and real mouse-wheel scrolling to bring off-viewport diagram links into view
- `diagram.spec.ts`: dismiss the expression-helper popup before clicking "Add Else Block" (popup intercepts pointer events) and fill conditions as quoted expressions
- `azure.spec.ts`: switch `entityConfig` to Expression mode before filling (Record mode resets the dispatched value, so the service was never created and "Edit Service" never appeared), quote the connection string, force-click submit
- `test-function.spec.ts`: wait for the BI webview before invoking the add-test-function command, bump form timeout to 20s

No helper or tester-library changes are required — `getWebview` is already exported on this branch and `playwright-vscode-tester` `Form.ts` is identical to the version these specs run against on main.

## Test plan
- [x] All affected suites pass locally on macOS: `DOWNLOAD_PRERELEASE=true pnpm exec playwright test -c e2e-test/playwright.config.js --grep "Flow Nodes|Azure Integration|Automation for Diagram|Test Function"` — 6 passed (6.6m)
- [ ] CI: group1 and group4 e2e jobs green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Tests
- Improved reliability of end-to-end test suite with save retry on form submission, more reliable editor input handling, and hover-driven diagram navigation
- Made expression helpers dismissible via Escape and stabilized form submission flows for Azure integrations
- Updated diagram and node test flows and extended initialization wait for consistent test function creation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->