### PR TITLE
Fix Create Types from Scratch flakiness on slow runners

### DIFF
--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/type-editor/TypeEditorUtils.ts
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/type-editor/TypeEditorUtils.ts
@@ -206,9 +206,12 @@ export class TypeEditorUtils {
         await this.waitForElement(menuButton);
         await menuButton.click();
 
+        // The menu can briefly re-render after open on slow runners, detaching the
+        // Edit item between stability check and click. Force the click to bypass
+        // the stability retry that hits the detached node.
         const editMenuItem = this.webView.getByText('Edit', { exact: true });
         await this.waitForElement(editMenuItem);
-        await editMenuItem.click();
+        await editMenuItem.click({ force: true });
 
         // Wait for type editor to load
         const typeEditorContent = this.webView.locator('[data-testid="type-editor-container"]');

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/type-editor/type.spec.ts
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/type-editor/type.spec.ts
@@ -127,9 +127,19 @@ export default function createTests() {
             await typeUtils.verifyTypeNodeExists(serviceClassName);
             await typeUtils.verifyTypeLink(serviceClassName, 'employeeDetails', recordName);
 
-            // Verify the generated types.bal matches testOutput.bal
+            // Verify the generated types.bal matches testOutput.bal. The fixture is
+            // written against attempt 1; on retries, identifiers are suffixed with
+            // the attempt number to avoid clashing with leftover types, so
+            // substitute the expected identifiers to match.
             const expectedFilePath = path.join(__dirname, 'testOutput.bal');
-            await verifyGeneratedSource('types.bal', expectedFilePath);
+            const substitutions = testAttempt === 1 ? undefined : {
+                'Role1': enumName,
+                'Id1': unionName,
+                'Organization1': organizationName,
+                'Employee1': recordName,
+                'Project1': serviceClassName,
+            };
+            await verifyGeneratedSource('types.bal', expectedFilePath, substitutions);
 
         });
     });

--- a/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/utils/helpers/verification.ts
+++ b/workspaces/ballerina/ballerina-extension/e2e-test/e2e-playwright-tests/utils/helpers/verification.ts
@@ -38,8 +38,16 @@ function normalizeSource(source: string): string {
  * Compare a generated .bal file with an expected .bal file
  * @param generatedFileName - Name of the generated file (e.g., 'types.bal')
  * @param expectedFilePath - Path to the expected file (e.g., path to testOutput.bal)
+ * @param substitutions - Optional map of literal substrings to replace in the
+ *        expected content before comparison. Useful for tests that suffix
+ *        identifiers with a per-attempt counter (e.g. `Role${attempt}`) but
+ *        keep a single fixture file.
  */
-export async function verifyGeneratedSource(generatedFileName: string, expectedFilePath: string): Promise<void> {
+export async function verifyGeneratedSource(
+    generatedFileName: string,
+    expectedFilePath: string,
+    substitutions?: Record<string, string>
+): Promise<void> {
     const { expect } = await import('@playwright/test');
 
     // Generated file is in the current test project folder
@@ -54,7 +62,12 @@ export async function verifyGeneratedSource(generatedFileName: string, expectedF
     }
 
     const actualContent = fs.readFileSync(generatedFilePath, 'utf-8');
-    const expectedContent = fs.readFileSync(expectedFilePath, 'utf-8');
+    let expectedContent = fs.readFileSync(expectedFilePath, 'utf-8');
+    if (substitutions) {
+        for (const [from, to] of Object.entries(substitutions)) {
+            expectedContent = expectedContent.split(from).join(to);
+        }
+    }
 
     const normalizedActual = normalizeSource(actualContent);
     const normalizedExpected = normalizeSource(expectedContent);


### PR DESCRIPTION
## Summary
Follows up on #2359. The post-merge Release VSIX run (https://github.com/wso2/vscode-extensions/actions/runs/27440089427/job/81154149399) failed on \`type-editor/type.spec.ts\` › Create Types from Scratch (group4). Two compounding issues:

- \`TypeEditorUtils.editType\` clicks the floating "Edit" menu item; on slow runners the menu re-renders between Playwright's stability check and the click, detaching the element. Force the click to bypass the retry.
- The test suffixes type names with \`testAttempt\` to avoid clashing with leftover types on retry, but the assertion compares the generated \`types.bal\` to a fixed \`testOutput.bal\` (\`Role1\`, \`Id1\`, …). Any retry that creates \`Role2\` etc. cannot pass the diff. Added an optional \`substitutions\` map to \`verifyGeneratedSource\` and pass the per-attempt names from the spec so retries can actually succeed.

## Test plan
- [x] Local: \`pnpm exec playwright test --grep \"Create Types from Scratch\"\` — 1 passed (1.5m), no retry needed
- [ ] CI: group4 green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test stability on slower systems by enhancing UI interaction handling
  * Enhanced test retry mechanisms to properly manage identifier variations across attempts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->