### PR TITLE
Update login button to "Login using WSO2 Integration Platform"

### DIFF
--- a/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/LoginPanel/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/LoginPanel/index.tsx
@@ -201,7 +201,7 @@ const LoginPanel: React.FC = () => {
             <FooterContent>
                 <LegalNotice />
                 {isPlatformAvailable ? (
-                    <StyledButton onClick={handleCopilotLogin}>Login using WSO2 Cloud</StyledButton>
+                    <StyledButton onClick={handleCopilotLogin}>Login using WSO2 Integration Platform</StyledButton>
                 ) : (
                     <InstallingContainer>  
                         Install WSO2 Integrator to sign in and use BI Copilot.


### PR DESCRIPTION
## Purpose
https://github.com/wso2/product-integrator/issues/1495

Update the BI Copilot login button label from "Login using WSO2 Cloud" to "Login using WSO2 Integration Platform".

This reverses the label change introduced by #2234 (which targeted `release/bi-1.8.x`), applied here as a fresh change against `release/ballerina-5.12.x`.

## Approach

Single string change in the AI Panel login footer (`LoginPanel/index.tsx`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated login button text in the authentication interface for consistency with current platform terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->