### PR TITLE
Improve usage-limit error handling and chat UX

### DIFF
--- a/workspaces/ballerina/ballerina-core/src/state-machine-types.ts
+++ b/workspaces/ballerina/ballerina-core/src/state-machine-types.ts
@@ -403,9 +403,12 @@ export interface SaveChat {
     messageId: string;
 }
 
+export type ChatErrorCode = "usage_limit";
+
 export interface ChatError {
     type: "error";
     content: string;
+    code?: ChatErrorCode;
 }
 
 export interface ToolCall {

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
@@ -21,7 +21,7 @@ import { Command, GenerateAgentCodeRequest, ProjectSource, ExecutionContext, Sem
 import { StateMachine } from '../../../stateMachine';
 import { ModelMessage, stepCountIs, streamText, TextStreamPart } from 'ai';
 import { getAnthropicClient, getProviderCacheControl, addCacheControlToMessages, ANTHROPIC_SONNET_4 } from '../utils/ai-client';
-import { populateHistoryForAgent, getErrorMessage } from '../utils/ai-utils';
+import { populateHistoryForAgent, getErrorMessage, buildChatError } from '../utils/ai-utils';
 import { sendAgentDidOpenForFreshProjects } from '../utils/project/ls-schema-notifications';
 import { getSystemPrompt, getUserPrompt } from './prompts';
 import { prepareAgentsMdForTurn } from './agents-md';
@@ -613,10 +613,7 @@ Generation stopped by user. The last in-progress task was not saved. Files have 
                 this.config.abortController.abort();
             }
 
-            this.config.eventHandler({
-                type: "error",
-                content: getErrorMessage(error)
-            });
+            this.config.eventHandler(buildChatError(error));
 
             // For other errors, return result with error
             return {
@@ -736,11 +733,6 @@ Generation stopped by user. The last in-progress task was not saved. Files have 
             });
             updateAndSaveChat(context.messageId, Command.Agent, context.eventHandler);
         }
-
-        context.eventHandler({
-            type: "error",
-            content: getErrorMessage(error)
-        });
     }
 
     /**

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/data-mapper/orchestrator.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/data-mapper/orchestrator.ts
@@ -28,7 +28,7 @@ import { DataMapperModelResponse, DMModel, Mapping, repairCodeRequest, SourceFil
 import { getDataMappingPrompt } from "./prompts/mapping-prompt";
 import { getBallerinaCodeRepairPrompt } from "./prompts/repair-prompt";
 import { CopilotEventHandler, createWebviewEventHandler, updateAndSaveChat } from "../utils/events";
-import { getErrorMessage } from "../utils/ai-utils";
+import { getErrorMessage, buildChatError } from "../utils/ai-utils";
 import { generateTypesFromContext } from "./utils/types-generation";
 import { generateDataMapperModel } from "./utils/model";
 import { BiDiagramRpcManager } from "../../../rpc-managers/bi-diagram/rpc-manager";
@@ -325,7 +325,7 @@ export async function generateContextTypesCore(
                 content: `Integration failed: ${getErrorMessage(error)}\n\nPlease check file permissions and try again.`
             });
         } else {
-            eventHandler({ type: "error", content: getErrorMessage(error) });
+            eventHandler(buildChatError(error));
         }
         throw error;
     }

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/documentation/index.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/documentation/index.ts
@@ -22,7 +22,7 @@ import {
     createDocumentationGenMessages
 } from "./prompts";
 import { CopilotEventHandler, createWebviewEventHandler } from "../utils/events";
-import { getErrorMessage } from "../utils/ai-utils";
+import { buildChatError } from "../utils/ai-utils";
 import { chatStateStorage } from "../../../views/ai-panel/chatStateStorage";
 import { createExecutorConfig, resolveProjectRootPath } from "../agent/index";
 
@@ -71,7 +71,7 @@ export async function generateDocumentationCore(
             case "error": {
                 const error = part.error;
                 console.error("Error during documentation generation:", error);
-                eventHandler({ type: "error", content: getErrorMessage(error) });
+                eventHandler(buildChatError(error));
                 break;
             }
             case "finish": {
@@ -124,7 +124,7 @@ export async function generateDocumentation(params: DocumentationGenerationReque
             eventHandler({ type: "abort", command: Command.Doc });
         } else {
             console.error("Error during documentation generation:", error);
-            eventHandler({ type: "error", content: getErrorMessage(error) });
+            eventHandler(buildChatError(error));
         }
     } finally {
         // Clear active execution

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/executors/base/AICommandExecutor.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/executors/base/AICommandExecutor.ts
@@ -20,7 +20,7 @@ import { ExecutionContext, Command } from '@wso2/ballerina-core';
 import { CopilotEventHandler } from '../../utils/events';
 import { chatStateStorage, ChatStateStorage } from '../../../../views/ai-panel/chatStateStorage';
 import { getTempProject, cleanupTempProject } from '../../utils/project/temp-project';
-import { getErrorMessage } from '../../utils/ai-utils';
+import { buildChatError } from '../../utils/ai-utils';
 import { MigrationDebugLogger } from '../../migration/debug-logger';
 
 /**
@@ -182,7 +182,7 @@ export abstract class AICommandExecutor<TParams = any> {
             throw error;
         } finally {
             // Stage 6: Always clear active execution on completion (success or error)
-            chatStateStorage.clearActiveExecution(projectRootPath, threadId);
+        chatStateStorage.clearActiveExecution(projectRootPath, threadId);
         }
     }
 
@@ -312,13 +312,10 @@ export abstract class AICommandExecutor<TParams = any> {
             });
         } else {
             // Regular error - emit error event
-            const errorMsg = getErrorMessage(error);
-            console.error(`[AICommandExecutor] Error in ${this.getCommandType()}:`, errorMsg, error);
+            const chatError = buildChatError(error);
+            console.error(`[AICommandExecutor] Error in ${this.getCommandType()}:`, chatError.content, error);
 
-            this.config.eventHandler({
-                type: "error",
-                content: errorMsg
-            });
+            this.config.eventHandler(chatError);
         }
 
         // Attempt cleanup on error, but never delete an existingTempPath —

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/openapi/index.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/openapi/index.ts
@@ -17,7 +17,7 @@
 import { GenerateOpenAPIRequest, Command } from "@wso2/ballerina-core";
 import { streamText } from "ai";
 import { getAnthropicClient, ANTHROPIC_HAIKU, getProviderCacheControl } from "../utils/ai-client";
-import { getErrorMessage, populateHistory } from "../utils/ai-utils";
+import { buildChatError, populateHistory } from "../utils/ai-utils";
 import { CopilotEventHandler, createWebviewEventHandler } from "../utils/events";
 import { chatStateStorage } from "../../../views/ai-panel/chatStateStorage";
 import { createExecutorConfig, resolveProjectRootPath } from "../agent/index";
@@ -62,7 +62,7 @@ export async function generateOpenAPISpecCore(
             case "error": {
                 const error = part.error;
                 console.error("Error during OpenAPI generation:", error);
-                eventHandler({ type: "error", content: getErrorMessage(error) });
+                eventHandler(buildChatError(error));
                 break;
             }
             case "finish": {
@@ -102,7 +102,7 @@ export async function generateOpenAPISpec(params: GenerateOpenAPIRequest): Promi
             eventHandler({ type: "abort", command: Command.OpenAPI });
         } else {
             console.error("Error during openapi generation:", error);
-            eventHandler({ type: "error", content: getErrorMessage(error) });
+            eventHandler(buildChatError(error));
         }
     } finally {
         // Clear active execution

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/utils/ai-client.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/utils/ai-client.ts
@@ -28,7 +28,8 @@ export const ANTHROPIC_HAIKU = "claude-haiku-4-5-20251001";
 export const ANTHROPIC_SONNET_4 = "claude-sonnet-4-6";
 
 // Contact for requesting more Copilot quota once the usage limit is reached.
-export const QUOTA_REQUEST_CONTACT_EMAIL = "integration-platform-help@wso2.com";
+// TODO: replace with the quota request portal once it is available.
+export const QUOTA_REQUEST_CONTACT_EMAIL = "devant-help@wso2.com";
 export const USAGE_LIMIT_EXCEEDED_MESSAGE =
     `Usage limit exceeded. To request additional quota, contact ${QUOTA_REQUEST_CONTACT_EMAIL}.`;
 

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/utils/ai-utils.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/utils/ai-utils.ts
@@ -17,6 +17,7 @@
 import {
     ChatEntry,
     ChatError,
+    ChatErrorCode,
     ChatNotify,
     ChatStart,
     DiagnosticEntry,
@@ -212,12 +213,8 @@ export function sendMessageStopNotification(command: Command): void {
     sendAIPanelNotification(msg);
 }
 
-export function sendErrorNotification(errorMessage: string): void {
-    const msg: ChatError = {
-        type: "error",
-        content: errorMessage,
-    };
-    sendAIPanelNotification(msg);
+export function sendErrorNotification(error: ChatError): void {
+    sendAIPanelNotification(error);
 }
 
 export function sendMessageStartNotification(): void {
@@ -419,6 +416,29 @@ export function getErrorMessage(error: unknown): string {
     } catch {
         return String(error);
     }
+}
+
+export function getErrorCode(error: unknown): ChatErrorCode | undefined {
+    if (
+        typeof error === "object" &&
+        error !== null &&
+        ((error as any).name === "UsageLimitError" || (error as any).statusCode === 429)
+    ) {
+        return "usage_limit";
+    }
+    return undefined;
+}
+
+/**
+ * Build a ChatError event from a thrown value, tagging it with a code so the
+ * frontend can route it (e.g. usage_limit -> persistent banner, not inline box).
+ */
+export function buildChatError(error: unknown): ChatError {
+    return {
+        type: "error",
+        content: getErrorMessage(error),
+        code: getErrorCode(error),
+    };
 }
 
 export function isHttpPayloadContext(context: PayloadContext): context is HttpPayloadContext {

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/utils/events.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/utils/events.ts
@@ -134,7 +134,7 @@ export function createWebviewEventHandler(command: Command): CopilotEventHandler
                 sendContentReplaceNotification(event.content);
                 break;
             case "error":
-                sendErrorNotification(event.content);
+                sendErrorNotification(event);
                 break;
             case "stop":
                 sendMessageStopNotification(command);

--- a/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -1129,19 +1129,18 @@ const AIChat: React.FC = () => {
     }, [isReqFileExists]);
 
     useEffect(() => {
-        // Step 2: Scroll into view when messages state changes or review bar appears
-        // Use a small delay when the review bar just appeared to let the DOM settle
-        const doScroll = () => {
-            if (messagesEndRef.current) {
-                messagesEndRef.current.scrollIntoView({ behavior: "smooth", block: "end" });
-            }
+        const scrollToEnd = (behavior: ScrollBehavior) => {
+            messagesEndRef.current?.scrollIntoView({ behavior, block: "end" });
         };
-        if (hasActiveReview) {
-            setTimeout(doScroll, 50);
-        } else {
-            doScroll();
+        scrollToEnd("smooth");
+        // Once the turn settles the layout keeps growing (review/restore bar,
+        // markdown + code highlighting), so smooth-scroll lands on a stale
+        // bottom — snap to the true end after that late growth.
+        if (!isLoading && !isCodeLoading) {
+            const t = setTimeout(() => scrollToEnd("auto"), 120);
+            return () => clearTimeout(t);
         }
-    }, [messages, hasActiveReview]);
+    }, [messages, hasActiveReview, isLoading, isCodeLoading]);
 
     async function handleSendQuery(content: {
         input: Input[];

--- a/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -1166,6 +1166,8 @@ const AIChat: React.FC = () => {
             } else if (error?.name === "UsageLimitError" || error?.statusCode === 429) {
                 setIsUsageExceeded(true);
                 fetchUsage();
+                isErrorChunkReceivedRef.current = true;
+                activeScaffoldKeyRef.current = null;
             } else {
                 updateLastMessage((lastContent) => {
                     if (error && "message" in error) {

--- a/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -97,7 +97,8 @@ const NO_DRIFT_FOUND = "No drift identified between the code and the documentati
 const DRIFT_CHECK_ERROR = "Failed to check drift between the code and the documentation. Please try again.";
 
 const USAGE_EXCEEDED_THRESHOLD_PERCENT = 3;
-const QUOTA_CONTACT_EMAIL = "integration-platform-help@wso2.com";
+// TODO: replace with the quota request portal once it is available.
+const QUOTA_CONTACT_EMAIL = "devant-help@wso2.com";
 
 //TODO: Add better error handling from backend. stream error type and non 200 status codes
 

--- a/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -1835,7 +1835,7 @@ const AIChat: React.FC = () => {
                             </AuthProviderChip>
                         ) : (
                             <AuthProviderChip>
-                                Remaining Usage:
+                                Usage:
                                 {usage?.resetsIn === -1 ? (
                                     <Tooltip content="Subject to fair usage policy.">
                                         <UsageBadge>Unlimited</UsageBadge>
@@ -1844,7 +1844,7 @@ const AIChat: React.FC = () => {
                                     <UsageBadge>N/A</UsageBadge>
                                 ) : (
                                     <Tooltip content={`Resets in ${formatResetsInExact(usage.resetsIn)}`}>
-                                        <UsageBadge>{isUsageExceeded ? "0%" : `${Math.round(usage.remainingUsagePercentage)}%`}</UsageBadge>
+                                        <UsageBadge>{isUsageExceeded ? "100%" : `${Math.round(100 - usage.remainingUsagePercentage)}%`}</UsageBadge>
                                     </Tooltip>
                                 )}
                             </AuthProviderChip>

--- a/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -1840,13 +1840,9 @@ const AIChat: React.FC = () => {
                                     </Tooltip>
                                 ) : !usage ? (
                                     <UsageBadge>N/A</UsageBadge>
-                                ) : isUsageExceeded ? (
-                                    <Tooltip content={`Usage limit reached · resets in ${formatResetsInExact(usage.resetsIn)}`}>
-                                        <UsageBadge>Exceeded</UsageBadge>
-                                    </Tooltip>
                                 ) : (
                                     <Tooltip content={`Resets in ${formatResetsInExact(usage.resetsIn)}`}>
-                                        <UsageBadge>{`${Math.round(usage.remainingUsagePercentage)}%`}</UsageBadge>
+                                        <UsageBadge>{isUsageExceeded ? "0%" : `${Math.round(usage.remainingUsagePercentage)}%`}</UsageBadge>
                                     </Tooltip>
                                 )}
                             </AuthProviderChip>

--- a/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -422,10 +422,10 @@ const AIChat: React.FC = () => {
         const hours = Math.floor((seconds % 86400) / 3600);
         const mins = Math.floor((seconds % 3600) / 60);
         const parts: string[] = [];
-        if (days > 0) parts.push(`${days} day${days > 1 ? 's' : ''}`);
-        if (hours > 0) parts.push(`${hours} hour${hours > 1 ? 's' : ''}`);
-        if (mins > 0) parts.push(`${mins} minute${mins > 1 ? 's' : ''}`);
-        return parts.length > 0 ? parts.join(', ') : 'less than a minute';
+        if (days > 0) parts.push(`${days}d`);
+        if (hours > 0) parts.push(`${hours}h`);
+        if (mins > 0) parts.push(`${mins}m`);
+        return parts.length > 0 ? parts.join(' ') : 'less than a minute';
     };
 
     const fetchUsage = async () => {
@@ -1839,19 +1839,16 @@ const AIChat: React.FC = () => {
                                     <Tooltip content="Subject to fair usage policy.">
                                         <UsageBadge>Unlimited</UsageBadge>
                                     </Tooltip>
+                                ) : !usage ? (
+                                    <UsageBadge>N/A</UsageBadge>
                                 ) : isUsageExceeded ? (
-                                    <Tooltip content={`Usage limit reached. To request additional quota, contact ${QUOTA_CONTACT_EMAIL}.`}>
+                                    <Tooltip content={`Usage limit reached · resets in ${formatResetsInExact(usage.resetsIn)}`}>
                                         <UsageBadge>Exceeded</UsageBadge>
                                     </Tooltip>
                                 ) : (
-                                    <UsageBadge>
-                                        {!usage ? "N/A" : `${Math.round(usage.remainingUsagePercentage)}%`}
-                                    </UsageBadge>
-                                )}
-                                {usage && usage.resetsIn !== -1 && (
-                                    <span style={{ fontSize: 10, opacity: 0.7 }} title={formatResetsInExact(usage.resetsIn)}>
-                                        Resets in: {formatResetsIn(usage.resetsIn)}
-                                    </span>
+                                    <Tooltip content={`Resets in ${formatResetsInExact(usage.resetsIn)}`}>
+                                        <UsageBadge>{`${Math.round(usage.remainingUsagePercentage)}%`}</UsageBadge>
+                                    </Tooltip>
                                 )}
                             </AuthProviderChip>
                         )}

--- a/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -138,14 +138,33 @@ const UsageLimitNoticeContainer = styled.div`
     display: flex;
     align-items: flex-start;
     gap: 8px;
-    background: var(--vscode-inputValidation-warningBackground, var(--vscode-textCodeBlock-background));
+    margin: 8px 20px 0;
+    padding: 8px 10px;
     border: 1px solid var(--vscode-inputValidation-warningBorder, var(--vscode-panel-border));
-    border-radius: 4px;
-    padding: 8px 12px;
-    margin: 6px 0;
+    border-radius: 6px;
+    background: var(--vscode-inputValidation-warningBackground, var(--vscode-textCodeBlock-background));
+    color: var(--vscode-foreground);
     font-size: 12px;
     line-height: 1.5;
-    color: var(--vscode-foreground);
+
+    .codicon {
+        flex-shrink: 0;
+        font-size: 14px;
+        line-height: 18px;
+        color: var(--vscode-inputValidation-warningForeground, var(--vscode-charts-yellow, var(--vscode-foreground)));
+    }
+
+    a {
+        color: var(--vscode-textLink-foreground);
+        font-weight: 600;
+        word-break: break-all;
+        text-decoration: none;
+
+        &:hover {
+            color: var(--vscode-textLink-activeForeground);
+            text-decoration: underline;
+        }
+    }
 `;
 
 // ── Agent stream serialization ────────────────────────────────────────────────
@@ -1017,6 +1036,17 @@ const AIChat: React.FC = () => {
         } else if (type === "error") {
             console.log("Received error signal");
             const errorContent = response.content;
+
+            if (response.code === "usage_limit") {
+                setIsUsageExceeded(true);
+                fetchUsage();
+                setIsCompacting(false);
+                setIsCodeLoading(false);
+                setIsLoading(false);
+                isErrorChunkReceivedRef.current = true;
+                return;
+            }
+
             const errorTemplate = `\n\n<error data-system="true" data-auth="${SYSTEM_ERROR_SECRET}">${errorContent}</error>`;
             setMessages((prevMessages) => {
                 const newMessages = [...prevMessages];
@@ -1134,6 +1164,9 @@ const AIChat: React.FC = () => {
                 updateLastMessage((lastContent) =>
                     lastContent + `\n\n<error data-system="true" data-auth="${SYSTEM_ERROR_SECRET}">Generation stopped by the user</error>`
                 );
+            } else if (error?.name === "UsageLimitError" || error?.statusCode === 429) {
+                setIsUsageExceeded(true);
+                fetchUsage();
             } else {
                 updateLastMessage((lastContent) => {
                     if (error && "message" in error) {
@@ -2183,12 +2216,11 @@ const AIChat: React.FC = () => {
                     </main>
                     {isUsageExceeded && (
                         <UsageLimitNoticeContainer>
-                            <span className="codicon codicon-warning" role="img" style={{ marginTop: 1 }} />
+                            <span className="codicon codicon-warning" role="img" aria-hidden="true" />
                             <span>
                                 You've reached your Integrator Copilot usage limit
                                 {usage && usage.resetsIn !== -1 ? `, which resets in ${formatResetsIn(usage.resetsIn)}` : ""}.
-                                {" "}Email{" "}
-                                <strong>{QUOTA_CONTACT_EMAIL}</strong>{" "}to request additional quota.
+                                {" "}Email <a href={`mailto:${QUOTA_CONTACT_EMAIL}`}>{QUOTA_CONTACT_EMAIL}</a> to request additional quota.
                             </span>
                         </UsageLimitNoticeContainer>
                     )}


### PR DESCRIPTION
- Show usage-limit errors in a single banner instead of duplicate inline error messages
- Ensure every error surfaces exactly once in the chat
- Tidy the header usage readout — compact reset time in the tooltip and a clearer depleted state
- Snap the chat to the latest message when a turn finishes

Fixes wso2/product-integrator#1720

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `usage_limit`-aware handling in the chat flow to refresh usage, mark limits as exceeded, and avoid showing the generic error template.

* **Improvements**
  * Enhanced AI usage UI/UX: updated quota contact, improved reset countdown formatting, refined banner/badge messaging, and improved chat scroll-to-bottom behavior.
  * Streamlined quota styling and Integrator Copilot notice presentation.

* **Bug Fixes / Consistency**
  * Standardized AI error reporting across chat, documentation, and OpenAPI to use structured error events with optional error codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->