### PR TITLE
Remove quota contact email from usage-limit messaging

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/features/ai/service/prompt-enhancement/promptEnhancement.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/service/prompt-enhancement/promptEnhancement.ts
@@ -16,7 +16,7 @@
 
 import { generateText } from "ai";
 import { getEnhancerSystemPrompt, getGeneratorSystemPrompt } from "./prompts";
-import { ANTHROPIC_HAIKU, getAnthropicClient, QUOTA_REQUEST_CONTACT_EMAIL } from "../../utils/ai-client";
+import { ANTHROPIC_HAIKU, getAnthropicClient } from "../../utils/ai-client";
 import { PromptMode, AIMachineEventType } from "@wso2/ballerina-core";
 import { window } from "vscode";
 import { AIStateMachine } from "../../../../views/ai-panel/aiMachine";
@@ -70,10 +70,9 @@ export async function enhancePrompt(
         // Handle specific error types
         if (error.name === "UsageLimitError" || error.statusCode === 429 ||
             error.statusCode === 400 && error.message?.includes("usage limit")) {
-            const baseMsg = error.message?.match(/You .+UTC\./)
+            const errorMsg = error.message?.match(/You .+UTC\./)
                 ? error.message.match(/You .+UTC\./)[0]
                 : "Usage limit exceeded. Please try again later or set your own API key.";
-            const errorMsg = `${baseMsg} To request additional quota, contact ${QUOTA_REQUEST_CONTACT_EMAIL}.`;
             window.showErrorMessage(errorMsg);
             throw new Error(errorMsg);
         }

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/utils/ai-client.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/utils/ai-client.ts
@@ -27,11 +27,8 @@ import { AIMachineEventType, AnthropicKeySecrets, LoginMethod, BIIntelSecrets } 
 export const ANTHROPIC_HAIKU = "claude-haiku-4-5-20251001";
 export const ANTHROPIC_SONNET_4 = "claude-sonnet-4-6";
 
-// Contact for requesting more Copilot quota once the usage limit is reached.
-// TODO: replace with the quota request portal once it is available.
-export const QUOTA_REQUEST_CONTACT_EMAIL = "devant-help@wso2.com";
-export const USAGE_LIMIT_EXCEEDED_MESSAGE =
-    `Usage limit exceeded. To request additional quota, contact ${QUOTA_REQUEST_CONTACT_EMAIL}.`;
+// TODO: add a quota request portal link once available so users can request more quota.
+export const USAGE_LIMIT_EXCEEDED_MESSAGE = "Usage limit exceeded.";
 
 type AnthropicModel =
     | typeof ANTHROPIC_HAIKU

--- a/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -97,8 +97,6 @@ const NO_DRIFT_FOUND = "No drift identified between the code and the documentati
 const DRIFT_CHECK_ERROR = "Failed to check drift between the code and the documentation. Please try again.";
 
 const USAGE_EXCEEDED_THRESHOLD_PERCENT = 3;
-// TODO: replace with the quota request portal once it is available.
-const QUOTA_CONTACT_EMAIL = "devant-help@wso2.com";
 
 //TODO: Add better error handling from backend. stream error type and non 200 status codes
 
@@ -2215,7 +2213,7 @@ const AIChat: React.FC = () => {
                             <span>
                                 You've reached your Integrator Copilot usage limit
                                 {usage && usage.resetsIn !== -1 ? `, which resets in ${formatResetsIn(usage.resetsIn)}` : ""}.
-                                {" "}Email <a href={`mailto:${QUOTA_CONTACT_EMAIL}`}>{QUOTA_CONTACT_EMAIL}</a> to request additional quota.
+                                {/* TODO: add a quota request portal link here once available. */}
                             </span>
                         </UsageLimitNoticeContainer>
                     )}


### PR DESCRIPTION
- Remove the quota contact email from the usage-limit banner, toast, and error message
- Leave TODOs to add a quota request portal link once available

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified AI usage limit exceeded error messages by removing outdated contact email references, providing users with a cleaner error notification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->