### PR TITLE
Move opt-in builtin skill toggle state to workspace-scoped config

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -569,6 +569,9 @@ importers:
       '@ai-sdk/anthropic':
         specifier: 3.0.64
         version: 3.0.64(zod@4.1.8)
+      '@ai-sdk/anthropic-aws':
+        specifier: 1.0.3
+        version: 1.0.3(zod@4.1.8)
       '@ai-sdk/google-vertex':
         specifier: 4.0.94
         version: 4.0.94(zod@4.1.8)
@@ -4921,6 +4924,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/anthropic-aws@1.0.3':
+    resolution: {integrity: sha512-Q0Xkg/1gflbl4mbztupbQ5SHxChpTUD23rjANdVAA8Q0TNJzGLwKu5xBf4O3CEx4+rVPPpIV2GIZUGImuy0jbQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/anthropic@2.0.35':
     resolution: {integrity: sha512-R0HtYqnKhxH67qpfKJwPCzRJLeW6M/adFM0E4YyF2+m80UvaigmiVwEODcODHEhsA3hQdf1hLNXzq4AEbkz8xw==}
     engines: {node: '>=18'}
@@ -4935,6 +4944,12 @@ packages:
 
   '@ai-sdk/anthropic@3.0.64':
     resolution: {integrity: sha512-rwLi/Rsuj2pYniQXIrvClHvXDzgM4UQHHnvHTWEF14efnlKclG/1ghpNC+adsRujAbCTr6gRsSbDE2vEqriV7g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/anthropic@3.0.81':
+    resolution: {integrity: sha512-B1JDd9Ugq9R5AgIaW3674lhGCMMYJcPUxnrZh8fzbGojgg4QvHFRv6eZahGQAUsmGHbcf74G9bdSBDLWQGY2GA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -4981,12 +4996,18 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@4.0.27':
+    resolution: {integrity: sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider@2.0.0':
     resolution: {integrity: sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==}
     engines: {node: '>=18'}
 
-  '@ai-sdk/provider@2.0.3':
-    resolution: {integrity: sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==}
+  '@ai-sdk/provider@3.0.10':
+    resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
     engines: {node: '>=18'}
 
   '@ai-sdk/provider@3.0.8':
@@ -11600,6 +11621,7 @@ packages:
   '@xmldom/xmldom@0.8.10':
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
@@ -23114,6 +23136,14 @@ snapshots:
       aws4fetch: 1.0.20
       zod: 4.1.8
 
+  '@ai-sdk/anthropic-aws@1.0.3(zod@4.1.8)':
+    dependencies:
+      '@ai-sdk/anthropic': 3.0.81(zod@4.1.8)
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.1.8)
+      aws4fetch: 1.0.20
+      zod: 4.1.8
+
   '@ai-sdk/anthropic@2.0.35(zod@4.1.11)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
@@ -23130,6 +23160,12 @@ snapshots:
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.21(zod@4.1.8)
+      zod: 4.1.8
+
+  '@ai-sdk/anthropic@3.0.81(zod@4.1.8)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.1.8)
       zod: 4.1.8
 
   '@ai-sdk/gateway@2.0.0(zod@4.1.11)':
@@ -23184,11 +23220,18 @@ snapshots:
       eventsource-parser: 3.1.0
       zod: 4.1.8
 
+  '@ai-sdk/provider-utils@4.0.27(zod@4.1.8)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.8
+      zod: 4.1.8
+
   '@ai-sdk/provider@2.0.0':
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/provider@2.0.3':
+  '@ai-sdk/provider@3.0.10':
     dependencies:
       json-schema: 0.4.0
 
@@ -43752,7 +43795,10 @@ snapshots:
       pretty-format: 25.5.0
       throat: 5.0.0
     transitivePeerDependencies:
+      - bufferutil
+      - canvas
       - supports-color
+      - utf-8-validate
 
   jest-leak-detector@25.5.0:
     dependencies:

--- a/workspaces/ballerina/ballerina-core/src/state-machine-types.ts
+++ b/workspaces/ballerina/ballerina-core/src/state-machine-types.ts
@@ -610,7 +610,7 @@ export const approvalOverlayState: NotificationType<ApprovalOverlayState> = { me
 export type AIMachineStateValue =
     | 'Initialize'          // (checking auth, first load)
     | 'Unauthenticated'     // (show login window)
-    | { Authenticating: 'determineFlow' | 'ssoFlow' | 'apiKeyFlow' | 'validatingApiKey' | 'awsBedrockFlow' | 'validatingAwsCredentials' | 'vertexAiFlow' | 'validatingVertexAiCredentials' } // hierarchical substates
+    | { Authenticating: 'determineFlow' | 'ssoFlow' | 'apiKeyFlow' | 'validatingApiKey' | 'awsBedrockFlow' | 'validatingAwsCredentials' | 'vertexAiFlow' | 'validatingVertexAiCredentials' | 'anthropicAwsFlow' | 'validatingAnthropicAwsCredentials' | 'awsUnifiedFlow' } // hierarchical substates
     | 'Authenticated'       // (ready, main view)
     | 'Disabled';           // (optional: if AI Chat is globally unavailable)
 
@@ -623,6 +623,9 @@ export enum AIMachineEventType {
     SUBMIT_AWS_CREDENTIALS = 'SUBMIT_AWS_CREDENTIALS',
     AUTH_WITH_VERTEX_AI = 'AUTH_WITH_VERTEX_AI',
     SUBMIT_VERTEX_AI_CREDENTIALS = 'SUBMIT_VERTEX_AI_CREDENTIALS',
+    AUTH_WITH_ANTHROPIC_AWS = 'AUTH_WITH_ANTHROPIC_AWS',
+    SUBMIT_ANTHROPIC_AWS_CREDENTIALS = 'SUBMIT_ANTHROPIC_AWS_CREDENTIALS',
+    AUTH_WITH_AWS = 'AUTH_WITH_AWS',
     LOGOUT = 'LOGOUT',
     SILENT_LOGOUT = "SILENT_LOGOUT",
     COMPLETE_AUTH = 'COMPLETE_AUTH',
@@ -648,6 +651,17 @@ export type AIMachineEventMap = {
         projectId: string;
         location: string;
         keyFile: string;
+    };
+    [AIMachineEventType.AUTH_WITH_ANTHROPIC_AWS]: undefined;
+    [AIMachineEventType.AUTH_WITH_AWS]: undefined;
+    [AIMachineEventType.SUBMIT_ANTHROPIC_AWS_CREDENTIALS]: {
+        region: string;
+        workspaceId: string;
+        authMode: 'sigv4' | 'apikey';
+        accessKeyId?: string;
+        secretAccessKey?: string;
+        sessionToken?: string;
+        apiKey?: string;
     };
     [AIMachineEventType.LOGOUT]: undefined;
     [AIMachineEventType.SILENT_LOGOUT]: undefined;
@@ -859,7 +873,9 @@ export enum LoginMethod {
     BI_INTEL = 'biIntel',
     ANTHROPIC_KEY = 'anthropic_key',
     AWS_BEDROCK = 'aws_bedrock',
-    VERTEX_AI = 'vertex_ai'
+    VERTEX_AI = 'vertex_ai',
+    ANTHROPIC_AWS = 'anthropic_aws',
+    AWS_UNIFIED = 'aws_unified'
 }
 
 export interface BIIntelSecrets {
@@ -884,6 +900,16 @@ export interface VertexAiSecrets {
     keyFile: string;
 }
 
+export interface AnthropicAwsSecrets {
+    region: string;
+    workspaceId: string;
+    authMode: 'sigv4' | 'apikey';
+    accessKeyId?: string;
+    secretAccessKey?: string;
+    sessionToken?: string;
+    apiKey?: string;
+}
+
 export type AuthCredentials =
     | {
         loginMethod: LoginMethod.BI_INTEL;
@@ -900,6 +926,10 @@ export type AuthCredentials =
     | {
         loginMethod: LoginMethod.VERTEX_AI;
         secrets: VertexAiSecrets;
+    }
+    | {
+        loginMethod: LoginMethod.ANTHROPIC_AWS;
+        secrets: AnthropicAwsSecrets;
     };
 
 export interface AIUserToken {

--- a/workspaces/ballerina/ballerina-extension/package.json
+++ b/workspaces/ballerina/ballerina-extension/package.json
@@ -1457,6 +1457,7 @@
     },
     "dependencies": {
         "@ai-sdk/amazon-bedrock": "4.0.83",
+        "@ai-sdk/anthropic-aws": "1.0.3",
         "@ai-sdk/anthropic": "3.0.64",
         "@ai-sdk/google-vertex": "4.0.94",
         "@iarna/toml": "2.2.5",

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/AgentExecutor.ts
@@ -81,7 +81,8 @@ function supportsCompaction(loginMethod: LoginMethod): boolean {
     // support the `compact-2026-01-12` beta, so server-side compaction is disabled there.
     return loginMethod === LoginMethod.ANTHROPIC_KEY
         || loginMethod === LoginMethod.BI_INTEL
-        || loginMethod === LoginMethod.VERTEX_AI;
+        || loginMethod === LoginMethod.VERTEX_AI
+        || loginMethod === LoginMethod.ANTHROPIC_AWS;
 }
 
 function buildCompactionProviderOptions(loginMethod: LoginMethod, floorTokens: number) {

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/skills/context.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/skills/context.ts
@@ -18,7 +18,7 @@ import * as path from 'path';
 import { ProjectSkillMeta } from './types';
 import { getDisabledBuiltIns, REGISTERED_SKILLS } from './index';
 import { scanProjectSkills, scanUserSkills } from '../tools/skill-tool/skill-reader';
-import { getSkillsConfig, GLOBAL_SKILLS_CONFIG_PATH } from '../tools/skill-tool/skill-writer';
+import { getSkillsConfig, GLOBAL_SKILLS_CONFIG_PATH, buildWorkspaceSkillsConfigPath } from '../tools/skill-tool/skill-writer';
 
 export interface SkillsContext {
     allDisabled: Set<string>;
@@ -40,13 +40,15 @@ export function buildAllDisabledSet(projectRootPath: string | null): Set<string>
         : { disabledSkills: [], enabledSkills: [] };
 
     const allDisabled = new Set([...globalConfig.disabledSkills, ...projectConfig.disabledSkills]);
-    const allEnabled = new Set([...globalConfig.enabledSkills, ...projectConfig.enabledSkills]);
+    const workspaceConfig = projectRootPath
+        ? getSkillsConfig(buildWorkspaceSkillsConfigPath(projectRootPath))
+        : { disabledSkills: [], enabledSkills: [] };
 
     for (const skill of REGISTERED_SKILLS) {
         if (skill.optional === false) {
             allDisabled.delete(skill.name);
         } else if (skill.default === false) {
-            if (allEnabled.has(skill.name)) {
+            if (workspaceConfig.enabledSkills.includes(skill.name)) {
                 allDisabled.delete(skill.name);
             } else {
                 allDisabled.add(skill.name);

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/skill-tool/skill-writer.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/skill-tool/skill-writer.ts
@@ -17,10 +17,18 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { computeWorkspaceHash } from '@wso2/copilot-utilities/chat-persistence';
 
 export const GLOBAL_SKILLS_CONFIG_PATH = path.join(
     os.homedir(), '.ballerina', 'copilot', 'skills.config.json'
 );
+
+/** Per-workspace skills config stored alongside workspace.meta.json — never inside the project folder. */
+export function buildWorkspaceSkillsConfigPath(projectRootPath: string): string {
+    const workspaceId = process.env.CLOUD_INITIAL_PROJECT_ID ?? path.resolve(projectRootPath);
+    const hash = computeWorkspaceHash(workspaceId);
+    return path.join(os.homedir(), '.ballerina', 'copilot', 'workspaces', hash, 'skills.config.json');
+}
 
 export interface SkillsConfig {
     disabledSkills: string[];

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/utils/ai-client.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/utils/ai-client.ts
@@ -17,12 +17,13 @@
 import { createAnthropic } from "@ai-sdk/anthropic";
 import { LanguageModel, ModelMessage, JSONValue } from "ai";
 import { createAmazonBedrock } from "@ai-sdk/amazon-bedrock";
+import { createAnthropicAws } from "@ai-sdk/anthropic-aws";
 import { createVertexAnthropic } from "@ai-sdk/google-vertex/anthropic";
-import { getAccessToken, getLoginMethod, getRefreshedAccessToken, getAwsBedrockCredentials, getVertexAiCredentials } from "../../../utils/ai/auth";
+import { getAccessToken, getLoginMethod, getRefreshedAccessToken, getAwsBedrockCredentials, getVertexAiCredentials, getAnthropicAwsCredentials } from "../../../utils/ai/auth";
 import { AIStateMachine } from "../../../views/ai-panel/aiMachine";
 import { BACKEND_URL } from "../utils";
 import { LLM_API_BASE_PATH } from "../constants";
-import { AIMachineEventType, AnthropicKeySecrets, LoginMethod, BIIntelSecrets } from "@wso2/ballerina-core";
+import { AIMachineEventType, AnthropicKeySecrets, AnthropicAwsSecrets, LoginMethod, BIIntelSecrets } from "@wso2/ballerina-core";
 
 export const ANTHROPIC_HAIKU = "claude-haiku-4-5-20251001";
 export const ANTHROPIC_SONNET_4 = "claude-sonnet-4-6";
@@ -231,6 +232,19 @@ export const getAnthropicClient = async (model: AnthropicModel): Promise<any> =>
             }
 
             return vertexAnthropic(vertexModelId);
+        } else if (loginMethod === LoginMethod.ANTHROPIC_AWS) {
+            const awsCredentials = await getAnthropicAwsCredentials();
+            if (!awsCredentials) {
+                throw new Error('Claude Platform on AWS credentials not found');
+            }
+
+            const { region, workspaceId, authMode, accessKeyId, secretAccessKey, sessionToken, apiKey } = awsCredentials as AnthropicAwsSecrets;
+            const effectiveMode = authMode ?? 'sigv4';
+            const anthropicAws = effectiveMode === 'apikey'
+                ? createAnthropicAws({ region, workspaceId, apiKey })
+                : createAnthropicAws({ region, workspaceId, accessKeyId, secretAccessKey, sessionToken });
+
+            return anthropicAws(model);
         } else {
             throw new Error(`Unsupported login method: ${loginMethod}`);
         }
@@ -259,6 +273,7 @@ export const getProviderCacheControl = async (): Promise<ProviderCacheOptions> =
     switch (loginMethod) {
         case LoginMethod.AWS_BEDROCK:
             return { bedrock: { cachePoint: { type: 'default' } } };
+        case LoginMethod.ANTHROPIC_AWS:
         case LoginMethod.VERTEX_AI:
         case LoginMethod.ANTHROPIC_KEY:
         case LoginMethod.BI_INTEL:

--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
@@ -129,6 +129,7 @@ import {
     deleteUserSkill,
     deleteProjectSkill,
     GLOBAL_SKILLS_CONFIG_PATH,
+    buildWorkspaceSkillsConfigPath,
 } from '../../features/ai/agent/tools/skill-tool/skill-writer';
 import { clearCompactionDisabledWarning } from '../../features/ai/agent/AgentExecutor';
 import { LLM_API_BASE_PATH, WI_EXTENSION_ID } from "../../features/ai/constants";
@@ -910,13 +911,13 @@ User reverted the last made changes. The files have been restored to the state b
         return slash !== -1 ? skillId.slice(slash + 1) : skillId;
     }
 
-    private buildBuiltinSkillEntries(allDisabled: Set<string>, allEnabled: Set<string>): SkillEntry[] {
+    private buildBuiltinSkillEntries(allDisabled: Set<string>, globalEnabled: Set<string>): SkillEntry[] {
         return REGISTERED_SKILLS.map(s => {
             let enabled: boolean;
             if (s.optional === false) {
                 enabled = true;
             } else if (s.default === false) {
-                enabled = allEnabled.has(s.name);
+                enabled = globalEnabled.has(s.name);
             } else {
                 enabled = !allDisabled.has(s.name);
             }
@@ -967,11 +968,13 @@ User reverted the last made changes. The files have been restored to the state b
         const projectConfigPath = projectRootPath ? buildProjectSkillsConfigPath(projectRootPath) : null;
         const projectConfig = projectConfigPath ? getSkillsConfig(projectConfigPath) : { disabledSkills: [], enabledSkills: [] };
         const allDisabled = new Set([...globalConfig.disabledSkills, ...projectConfig.disabledSkills]);
-        const allEnabled = new Set([...globalConfig.enabledSkills, ...projectConfig.enabledSkills]);
+        const workspaceConfigPath = projectRootPath ? buildWorkspaceSkillsConfigPath(projectRootPath) : null;
+        const workspaceConfig = workspaceConfigPath ? getSkillsConfig(workspaceConfigPath) : { disabledSkills: [], enabledSkills: [] };
+        const globalEnabled = new Set(workspaceConfig.enabledSkills);
 
         return {
             skills: [
-                ...this.buildBuiltinSkillEntries(allDisabled, allEnabled),
+                ...this.buildBuiltinSkillEntries(allDisabled, globalEnabled),
                 ...(projectRootPath ? this.buildProjectSkillEntries(projectRootPath, allDisabled) : []),
                 ...this.buildUserSkillEntries(allDisabled),
             ],
@@ -996,11 +999,18 @@ User reverted the last made changes. The files have been restored to the state b
 
     async toggleSkill(params: ToggleSkillRequest): Promise<boolean> {
         try {
-            const configPath = this.resolveSkillsConfigPath(params.tier, resolveProjectRootPath());
+            const projectRootPath = resolveProjectRootPath();
             const builtinSkill = params.tier === SkillTier.BUILTIN
                 ? REGISTERED_SKILLS.find(s => s.name === params.skillId)
                 : undefined;
-            setSkillEnabled(configPath, params.skillId, params.enabled, builtinSkill?.default === false);
+            if (builtinSkill?.default === false) {
+                if (projectRootPath) {
+                    setSkillEnabled(buildWorkspaceSkillsConfigPath(projectRootPath), params.skillId, params.enabled, true);
+                }
+            } else {
+                const configPath = this.resolveSkillsConfigPath(params.tier, projectRootPath);
+                setSkillEnabled(configPath, params.skillId, params.enabled, false);
+            }
             return true;
         } catch (error) {
             console.error('[Skills] toggleSkill failed:', error);
@@ -1031,7 +1041,7 @@ User reverted the last made changes. The files have been restored to the state b
             const builtinSkill = REGISTERED_SKILLS.find(s => s.name === params.skillId);
             if (builtinSkill?.default === false) {
                 if (projectRootPath) {
-                    setSkillEnabled(buildProjectSkillsConfigPath(projectRootPath), params.skillId, true, true);
+                    setSkillEnabled(buildWorkspaceSkillsConfigPath(projectRootPath), params.skillId, true, true);
                 }
             } else {
                 setSkillEnabled(GLOBAL_SKILLS_CONFIG_PATH, params.skillId, true);

--- a/workspaces/ballerina/ballerina-extension/src/utils/ai/auth.ts
+++ b/workspaces/ballerina/ballerina-extension/src/utils/ai/auth.ts
@@ -20,7 +20,7 @@ import * as vscode from 'vscode';
 import { extension } from "../../BalExtensionContext";
 import { DEVANT_TOKEN_EXCHANGE_URL } from '../../features/ai/utils';
 import axios from 'axios';
-import { AuthCredentials, BIIntelSecrets, LoginMethod } from '@wso2/ballerina-core';
+import { AuthCredentials, BIIntelSecrets, LoginMethod, AnthropicAwsSecrets } from '@wso2/ballerina-core';
 import { IWso2PlatformExtensionAPI } from '@wso2/wso2-platform-core';
 import { jwtDecode, JwtPayload } from 'jwt-decode';
 import { WI_EXTENSION_ID } from '../config';
@@ -314,6 +314,10 @@ export const getAccessToken = async (): Promise<AuthCredentials | undefined> => 
                         resolve(credentials);
                         return;
 
+                    case LoginMethod.ANTHROPIC_AWS:
+                        resolve(credentials);
+                        return;
+
                     default:
                         const { loginMethod }: AuthCredentials = credentials;
                         reject(new Error(`Unsupported login method: ${loginMethod}`));
@@ -371,6 +375,14 @@ export const getVertexAiCredentials = async (): Promise<{
         return undefined;
     }
     return credentials.secrets;
+};
+
+export const getAnthropicAwsCredentials = async (): Promise<AnthropicAwsSecrets | undefined> => {
+    const credentials = await getAuthCredentials();
+    if (!credentials || credentials.loginMethod !== LoginMethod.ANTHROPIC_AWS) {
+        return undefined;
+    }
+    return credentials.secrets as AnthropicAwsSecrets;
 };
 
 export const getRefreshedAccessToken = async (): Promise<string> => {

--- a/workspaces/ballerina/ballerina-extension/src/views/ai-panel/aiMachine.ts
+++ b/workspaces/ballerina/ballerina-extension/src/views/ai-panel/aiMachine.ts
@@ -22,7 +22,7 @@ import { AIMachineStateValue, AIPanelPrompt, AIMachineEventType, AIMachineContex
 import { AiPanelWebview } from './webview';
 import { extension } from '../../BalExtensionContext';
 import { getAccessToken, getLoginMethod } from '../../utils/ai/auth';
-import { checkToken, initiateDevantAuth, logout, validateApiKey, validateAwsCredentials, validateVertexAiCredentials } from './utils';
+import { checkToken, initiateDevantAuth, logout, validateApiKey, validateAwsCredentials, validateVertexAiCredentials, validateAnthropicAwsCredentials } from './utils';
 import {
     isDevantUserLoggedIn,
     getPlatformStsToken,
@@ -183,6 +183,18 @@ const aiMachine = createMachine<AIMachineContext, AIMachineSendableEvent>({
                     actions: assign({
                         loginMethod: (_ctx) => LoginMethod.VERTEX_AI
                     })
+                },
+                [AIMachineEventType.AUTH_WITH_ANTHROPIC_AWS]: {
+                    target: 'Authenticating',
+                    actions: assign({
+                        loginMethod: (_ctx) => LoginMethod.ANTHROPIC_AWS
+                    })
+                },
+                [AIMachineEventType.AUTH_WITH_AWS]: {
+                    target: 'Authenticating',
+                    actions: assign({
+                        loginMethod: (_ctx) => LoginMethod.AWS_UNIFIED
+                    })
                 }
             }
         },
@@ -206,6 +218,14 @@ const aiMachine = createMachine<AIMachineContext, AIMachineSendableEvent>({
                         {
                             cond: (context) => context.loginMethod === LoginMethod.VERTEX_AI,
                             target: 'vertexAiFlow'
+                        },
+                        {
+                            cond: (context) => context.loginMethod === LoginMethod.ANTHROPIC_AWS,
+                            target: 'anthropicAwsFlow'
+                        },
+                        {
+                            cond: (context) => context.loginMethod === LoginMethod.AWS_UNIFIED,
+                            target: 'awsUnifiedFlow'
                         },
                         {
                             target: 'ssoFlow' // default
@@ -344,6 +364,66 @@ const aiMachine = createMachine<AIMachineContext, AIMachineSendableEvent>({
                             })
                         }
                     }
+                },
+                anthropicAwsFlow: {
+                    on: {
+                        [AIMachineEventType.SUBMIT_ANTHROPIC_AWS_CREDENTIALS]: {
+                            target: 'validatingAnthropicAwsCredentials',
+                            actions: assign({
+                                errorMessage: (_ctx) => undefined
+                            })
+                        },
+                        [AIMachineEventType.CANCEL_LOGIN]: {
+                            target: '#ballerina-ai.Unauthenticated',
+                            actions: assign({
+                                loginMethod: (_ctx) => undefined,
+                                errorMessage: (_ctx) => undefined,
+                            })
+                        }
+                    }
+                },
+                validatingAnthropicAwsCredentials: {
+                    invoke: {
+                        id: 'validateAnthropicAwsCredentials',
+                        src: 'validateAnthropicAwsCredentials',
+                        onDone: {
+                            target: '#ballerina-ai.Authenticated',
+                            actions: assign({
+                                errorMessage: (_ctx) => undefined,
+                            })
+                        },
+                        onError: {
+                            target: 'anthropicAwsFlow',
+                            actions: assign({
+                                errorMessage: (_ctx, event) => event.data?.message || 'Claude Platform on AWS credentials validation failed'
+                            })
+                        }
+                    }
+                },
+                awsUnifiedFlow: {
+                    on: {
+                        [AIMachineEventType.SUBMIT_AWS_CREDENTIALS]: {
+                            target: 'validatingAwsCredentials',
+                            actions: assign({
+                                loginMethod: (_ctx) => LoginMethod.AWS_BEDROCK,
+                                errorMessage: (_ctx) => undefined
+                            })
+                        },
+                        [AIMachineEventType.SUBMIT_ANTHROPIC_AWS_CREDENTIALS]: {
+                            target: 'validatingAnthropicAwsCredentials',
+                            actions: assign({
+                                loginMethod: (_ctx) => LoginMethod.ANTHROPIC_AWS,
+                                errorMessage: (_ctx) => undefined
+                            })
+                        },
+                        [AIMachineEventType.CANCEL_LOGIN]: {
+                            target: '#ballerina-ai.Unauthenticated',
+                            actions: assign({
+                                loginMethod: (_ctx) => undefined,
+                                errorMessage: (_ctx) => undefined,
+                            })
+                        }
+                    }
                 }
             }
         },
@@ -475,6 +555,19 @@ const validateVertexAiCredentialsService = async (_context: AIMachineContext, ev
     });
 };
 
+const validateAnthropicAwsCredentialsService = async (_context: AIMachineContext, event: any) => {
+    const { region, workspaceId, authMode, accessKeyId, secretAccessKey, sessionToken, apiKey } = event.payload || {};
+    return await validateAnthropicAwsCredentials({
+        region,
+        workspaceId,
+        authMode: authMode ?? 'sigv4',
+        accessKeyId,
+        secretAccessKey,
+        sessionToken,
+        apiKey,
+    });
+};
+
 const getTokenAfterAuth = async () => {
     const result = await getAccessToken();
     const loginMethod = await getLoginMethod();
@@ -491,6 +584,7 @@ const aiStateService = interpret(aiMachine.withConfig({
         validateApiKey: validateApiKeyService,
         validateAwsCredentials: validateAwsCredentialsService,
         validateVertexAiCredentials: validateVertexAiCredentialsService,
+        validateAnthropicAwsCredentials: validateAnthropicAwsCredentialsService,
         getTokenAfterAuth: getTokenAfterAuth,
     },
     actions: {

--- a/workspaces/ballerina/ballerina-extension/src/views/ai-panel/utils.ts
+++ b/workspaces/ballerina/ballerina-extension/src/views/ai-panel/utils.ts
@@ -21,6 +21,7 @@ import * as fs from 'fs';
 import { AIUserToken, LoginMethod, AuthCredentials } from '@wso2/ballerina-core';
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
+import { createAnthropicAws } from '@ai-sdk/anthropic-aws';
 import { createVertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
 import { generateText } from 'ai';
 import { extension } from '../../BalExtensionContext';
@@ -311,5 +312,84 @@ export const validateVertexAiCredentials = async (credentials: {
             throw new Error(`Quota exceeded. Your GCP project may have 0 quota for this Anthropic model — request a quota increase in GCP Console → IAM & Admin → Quotas. (${detail})`);
         }
         throw new Error(`Validation failed: ${detail}`);
+    }
+};
+
+export const validateAnthropicAwsCredentials = async (credentials: {
+    region: string;
+    workspaceId: string;
+    authMode: 'sigv4' | 'apikey';
+    accessKeyId?: string;
+    secretAccessKey?: string;
+    sessionToken?: string;
+    apiKey?: string;
+}): Promise<AIUserToken> => {
+    const { region, workspaceId, authMode, accessKeyId, secretAccessKey, sessionToken, apiKey } = credentials;
+
+    if (!region || !workspaceId) {
+        throw new Error('Region and workspace ID are required.');
+    }
+
+    if (!workspaceId.startsWith('wrkspc_')) {
+        throw new Error('Please enter a valid workspace ID (format: wrkspc_...).');
+    }
+
+    let anthropicAws: ReturnType<typeof createAnthropicAws>;
+
+    if (authMode === 'apikey') {
+        if (!apiKey) {
+            throw new Error('API key is required.');
+        }
+        if (!apiKey.startsWith('aws-external-anthropic-api-key-') || apiKey.length < 20) {
+            throw new Error('Please enter a valid API key (format: aws-external-anthropic-api-key-...).');
+        }
+        anthropicAws = createAnthropicAws({ region, workspaceId, apiKey });
+    } else {
+        if (!accessKeyId || !secretAccessKey) {
+            throw new Error('Access key ID and secret access key are required.');
+        }
+        if (!accessKeyId.startsWith('AKIA') && !accessKeyId.startsWith('ASIA')) {
+            throw new Error('Please enter a valid AWS access key ID.');
+        }
+        if (secretAccessKey.length < 20) {
+            throw new Error('Please enter a valid AWS secret access key.');
+        }
+        anthropicAws = createAnthropicAws({ region, workspaceId, accessKeyId, secretAccessKey, sessionToken });
+    }
+
+    try {
+        await generateText({
+            model: anthropicAws('claude-haiku-4-5-20251001'),
+            maxOutputTokens: 1,
+            messages: [{ role: 'user', content: 'Hi' }]
+        });
+
+        const authCredentials: AuthCredentials = {
+            loginMethod: LoginMethod.ANTHROPIC_AWS,
+            secrets: { region, workspaceId, authMode, accessKeyId, secretAccessKey, sessionToken, apiKey }
+        };
+        await storeAuthCredentials(authCredentials);
+
+        return { credentials: authCredentials };
+
+    } catch (error) {
+        console.error('Claude Platform on AWS validation failed:', error);
+        const detail = error instanceof Error ? error.message : String(error);
+        if (detail.includes('401') || detail.includes('UnauthorizedException') || detail.includes('InvalidSignatureException') || detail.includes('authentication_error')) {
+            if (authMode === 'apikey') {
+                throw new Error('Invalid API key. Please check your key and try again.');
+            }
+            throw new Error('Invalid AWS credentials. Please check your access key ID and secret access key.');
+        } else if (detail.includes('403') || detail.includes('AccessDeniedException')) {
+            if (authMode === 'apikey') {
+                throw new Error('Access denied. Ensure your workspace ID is correct and your API key has access.');
+            }
+            throw new Error('Access denied. Ensure your IAM user has AnthropicInferenceAccess policy and the workspace ID is correct.');
+        } else if (detail.includes('404') || detail.includes('ResourceNotFoundException')) {
+            throw new Error('Workspace not found. Please verify your workspace ID from the Claude Console.');
+        } else if (detail.includes('429') || detail.includes('ThrottlingException')) {
+            throw new Error('Too many requests. Please wait a moment and try again.');
+        }
+        throw new Error(`Validation failed. Please check your credentials and try again. (${detail})`);
     }
 };

--- a/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/AIPanel.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/AIPanel.tsx
@@ -78,11 +78,11 @@ const AIPanel = (props: { state: AIMachineStateValue }) => {
 
                     if (subState === "determineFlow") {
                         component = <LoadingRing />;
-                    } else if (["ssoFlow", "apiKeyFlow", "validatingApiKey", "awsBedrockFlow", "validatingAwsCredentials", "vertexAiFlow", "validatingVertexAiCredentials"].includes(subState)) {
+                    } else if (["ssoFlow", "apiKeyFlow", "validatingApiKey", "awsBedrockFlow", "validatingAwsCredentials", "vertexAiFlow", "validatingVertexAiCredentials", "anthropicAwsFlow", "validatingAnthropicAwsCredentials", "awsUnifiedFlow"].includes(subState)) {
                         component = (
                             <WaitingForLogin
                                 loginMethod={snapshot.context.loginMethod}
-                                isValidating={subState === "validatingApiKey" || subState === "validatingAwsCredentials" || subState === "validatingVertexAiCredentials"}
+                                isValidating={subState === "validatingApiKey" || subState === "validatingAwsCredentials" || subState === "validatingVertexAiCredentials" || subState === "validatingAnthropicAwsCredentials"}
                                 errorMessage={snapshot.context.errorMessage}
                             />
                         );

--- a/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/LoginPanel/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/LoginPanel/index.tsx
@@ -167,8 +167,8 @@ const LoginPanel: React.FC = () => {
         rpcClient.sendAIStateEvent(AIMachineEventType.AUTH_WITH_API_KEY);
     };
 
-    const handleAwsBedrockClick = () => {
-        rpcClient.sendAIStateEvent(AIMachineEventType.AUTH_WITH_AWS_BEDROCK);
+    const handleAwsClick = () => {
+        rpcClient.sendAIStateEvent(AIMachineEventType.AUTH_WITH_AWS);
     };
 
     const handleVertexAiClick = () => {
@@ -222,7 +222,7 @@ const LoginPanel: React.FC = () => {
                 )}
                 <Divider>or</Divider>
                 <TextButton onClick={handleAnthropicKeyClick}>Enter your Anthropic API key</TextButton>
-                <TextButton onClick={handleAwsBedrockClick}>Enter your AWS Bedrock credentials</TextButton>
+                <TextButton onClick={handleAwsClick}>Enter your AWS credentials</TextButton>
                 <TextButton onClick={handleVertexAiClick}>Enter your Google Vertex AI credentials</TextButton>
             </FooterContent>
             <EndSpacer />

--- a/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/WaitingForLoginSection/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/WaitingForLoginSection/index.tsx
@@ -170,6 +170,32 @@ const ErrorMessage = styled.div`
     width: 100%;
 `;
 
+const AuthModeToggle = styled.div`
+    display: flex;
+    gap: 0;
+    border: 1px solid var(--vscode-editorWidget-border);
+    border-radius: 4px;
+    overflow: hidden;
+    width: 100%;
+`;
+
+const AuthModeButton = styled.button<{ active: boolean }>`
+    flex: 1;
+    padding: 5px 8px;
+    font-size: 12px;
+    cursor: pointer;
+    border: none;
+    background: ${(props: { active: boolean }) => props.active ? 'var(--vscode-button-background)' : 'transparent'};
+    color: ${(props: { active: boolean }) => props.active ? 'var(--vscode-button-foreground)' : 'var(--vscode-foreground)'};
+    &:hover {
+        background: ${(props: { active: boolean }) => props.active ? 'var(--vscode-button-hoverBackground)' : 'var(--vscode-toolbar-hoverBackground)'};
+    }
+    &:disabled {
+        opacity: 0.5;
+        cursor: default;
+    }
+`;
+
 interface WaitingForLoginProps {
     loginMethod?: LoginMethod;
     isValidating?: boolean;
@@ -189,6 +215,20 @@ const WaitingForLogin = ({ loginMethod, isValidating = false, errorMessage }: Wa
     const [showAccessKey, setShowAccessKey] = useState(false);
     const [showSecretKey, setShowSecretKey] = useState(false);
     const [showSessionToken, setShowSessionToken] = useState(false);
+    const [awsServiceMode, setAwsServiceMode] = useState<'bedrock' | 'anthropic_aws'>('bedrock');
+    const [anthropicAwsAuthMode, setAnthropicAwsAuthMode] = useState<'sigv4' | 'apikey'>('sigv4');
+    const [anthropicAwsCredentials, setAnthropicAwsCredentials] = useState({
+        region: "",
+        workspaceId: "",
+        accessKeyId: "",
+        secretAccessKey: "",
+        sessionToken: "",
+        apiKey: ""
+    });
+    const [showAnthropicAwsSecretKey, setShowAnthropicAwsSecretKey] = useState(false);
+    const [showAnthropicAwsAccessKey, setShowAnthropicAwsAccessKey] = useState(false);
+    const [showAnthropicAwsSessionToken, setShowAnthropicAwsSessionToken] = useState(false);
+    const [showAnthropicAwsApiKey, setShowAnthropicAwsApiKey] = useState(false);
     const [vertexAiCredentials, setVertexAiCredentials] = useState({
         projectId: "",
         location: "global",
@@ -285,6 +325,38 @@ const WaitingForLogin = ({ loginMethod, isValidating = false, errorMessage }: Wa
         }));
     };
 
+    const connectWithAnthropicAwsCredentials = () => {
+        const { region, workspaceId, accessKeyId, secretAccessKey, sessionToken, apiKey } = anthropicAwsCredentials;
+        const commonValid = region.trim() && workspaceId.trim();
+        const modeValid = anthropicAwsAuthMode === 'apikey'
+            ? apiKey.trim()
+            : (accessKeyId.trim() && secretAccessKey.trim());
+        if (commonValid && modeValid) {
+            rpcClient.sendAIStateEvent({
+                type: AIMachineEventType.SUBMIT_ANTHROPIC_AWS_CREDENTIALS,
+                payload: {
+                    region: region.trim(),
+                    workspaceId: workspaceId.trim(),
+                    authMode: anthropicAwsAuthMode,
+                    ...(anthropicAwsAuthMode === 'apikey'
+                        ? { apiKey: apiKey.trim() }
+                        : {
+                            accessKeyId: accessKeyId.trim(),
+                            secretAccessKey: secretAccessKey.trim(),
+                            sessionToken: sessionToken.trim() || undefined
+                        })
+                },
+            });
+        }
+    };
+
+    const handleAnthropicAwsCredentialChange = (field: keyof typeof anthropicAwsCredentials) => (e: any) => {
+        setAnthropicAwsCredentials(prev => ({
+            ...prev,
+            [field]: e.target.value
+        }));
+    };
+
     if (loginMethod === LoginMethod.ANTHROPIC_KEY) {
         return (
             <Container>
@@ -343,9 +415,289 @@ const WaitingForLogin = ({ loginMethod, isValidating = false, errorMessage }: Wa
         );
     }
 
+    if (loginMethod === LoginMethod.AWS_UNIFIED) {
+        const isBedrockFormValid = !!(
+            awsCredentials.accessKeyId.trim() &&
+            awsCredentials.secretAccessKey.trim() &&
+            awsCredentials.region.trim()
+        );
+        const isAnthropicAwsFormValid = !!(
+            anthropicAwsCredentials.region.trim() &&
+            anthropicAwsCredentials.workspaceId.trim() &&
+            (anthropicAwsAuthMode === 'apikey'
+                ? anthropicAwsCredentials.apiKey.trim()
+                : (anthropicAwsCredentials.accessKeyId.trim() && anthropicAwsCredentials.secretAccessKey.trim()))
+        );
+        const isFormValid = awsServiceMode === 'bedrock' ? isBedrockFormValid : isAnthropicAwsFormValid;
+
+        return (
+            <Container>
+                <AlertContainer variant="primary">
+                    <Title>Connect with AWS</Title>
+                    <SubTitle>
+                        Choose your AWS-based AI provider. Use AWS Bedrock to access Claude via Amazon's inference service,
+                        or Claude Platform on AWS for Anthropic's native API with same-day feature parity.
+                    </SubTitle>
+
+                    <AuthModeToggle>
+                        <AuthModeButton
+                            active={awsServiceMode === 'bedrock'}
+                            onClick={() => setAwsServiceMode('bedrock')}
+                            disabled={isValidating}
+                        >
+                            AWS Bedrock
+                        </AuthModeButton>
+                        <AuthModeButton
+                            active={awsServiceMode === 'anthropic_aws'}
+                            onClick={() => setAwsServiceMode('anthropic_aws')}
+                            disabled={isValidating}
+                        >
+                            Claude Platform on AWS
+                        </AuthModeButton>
+                    </AuthModeToggle>
+
+                    {awsServiceMode === 'bedrock' && (
+                        <>
+                            <InputContainer>
+                                <InputRow>
+                                    <StyledTextField
+                                        type={showAccessKey ? "text" : "password"}
+                                        placeholder="AWS Access Key ID (AKIA...)"
+                                        value={awsCredentials.accessKeyId}
+                                        onInput={handleAwsCredentialChange('accessKeyId')}
+                                        disabled={isValidating}
+                                    />
+                                    <EyeButton
+                                        type="button"
+                                        onClick={toggleAccessKeyVisibility}
+                                        title={showAccessKey ? "Hide access key" : "Show access key"}
+                                        disabled={isValidating}
+                                    >
+                                        <Codicon name={showAccessKey ? "eye-closed" : "eye"} />
+                                    </EyeButton>
+                                </InputRow>
+                            </InputContainer>
+
+                            <InputContainer>
+                                <InputRow>
+                                    <StyledTextField
+                                        type={showSecretKey ? "text" : "password"}
+                                        placeholder="AWS Secret Access Key"
+                                        value={awsCredentials.secretAccessKey}
+                                        onInput={handleAwsCredentialChange('secretAccessKey')}
+                                        disabled={isValidating}
+                                    />
+                                    <EyeButton
+                                        type="button"
+                                        onClick={toggleSecretKeyVisibility}
+                                        title={showSecretKey ? "Hide secret key" : "Show secret key"}
+                                        disabled={isValidating}
+                                    >
+                                        <Codicon name={showSecretKey ? "eye-closed" : "eye"} />
+                                    </EyeButton>
+                                </InputRow>
+                            </InputContainer>
+
+                            <InputContainer>
+                                <InputRow>
+                                    <StyledTextField
+                                        type="text"
+                                        placeholder="AWS Region (e.g., us-east-1)"
+                                        value={awsCredentials.region}
+                                        onInput={handleAwsCredentialChange('region')}
+                                        disabled={isValidating}
+                                    />
+                                </InputRow>
+                            </InputContainer>
+
+                            <InputContainer>
+                                <InputRow>
+                                    <StyledTextField
+                                        type={showSessionToken ? "text" : "password"}
+                                        placeholder="Session Token (optional)"
+                                        value={awsCredentials.sessionToken}
+                                        onInput={handleAwsCredentialChange('sessionToken')}
+                                        disabled={isValidating}
+                                    />
+                                    <EyeButton
+                                        type="button"
+                                        onClick={toggleSessionTokenVisibility}
+                                        title={showSessionToken ? "Hide session token" : "Show session token"}
+                                        disabled={isValidating}
+                                    >
+                                        <Codicon name={showSessionToken ? "eye-closed" : "eye"} />
+                                    </EyeButton>
+                                </InputRow>
+                            </InputContainer>
+                        </>
+                    )}
+
+                    {awsServiceMode === 'anthropic_aws' && (
+                        <>
+                            <InputContainer>
+                                <InputRow>
+                                    <StyledTextField
+                                        type="text"
+                                        placeholder="AWS Region (e.g., us-west-2)"
+                                        value={anthropicAwsCredentials.region}
+                                        onInput={handleAnthropicAwsCredentialChange('region')}
+                                        disabled={isValidating}
+                                    />
+                                </InputRow>
+                            </InputContainer>
+
+                            <InputContainer>
+                                <InputRow>
+                                    <StyledTextField
+                                        type="text"
+                                        placeholder="Workspace ID (e.g., wrkspc_...)"
+                                        value={anthropicAwsCredentials.workspaceId}
+                                        onInput={handleAnthropicAwsCredentialChange('workspaceId')}
+                                        disabled={isValidating}
+                                    />
+                                </InputRow>
+                            </InputContainer>
+
+                            <AuthModeToggle>
+                                <AuthModeButton
+                                    active={anthropicAwsAuthMode === 'sigv4'}
+                                    onClick={() => setAnthropicAwsAuthMode('sigv4')}
+                                    disabled={isValidating}
+                                >
+                                    IAM Credentials
+                                </AuthModeButton>
+                                <AuthModeButton
+                                    active={anthropicAwsAuthMode === 'apikey'}
+                                    onClick={() => setAnthropicAwsAuthMode('apikey')}
+                                    disabled={isValidating}
+                                >
+                                    API Key
+                                </AuthModeButton>
+                            </AuthModeToggle>
+
+                            {anthropicAwsAuthMode === 'sigv4' && (
+                                <>
+                                    <InputContainer>
+                                        <InputRow>
+                                            <StyledTextField
+                                                type={showAnthropicAwsAccessKey ? "text" : "password"}
+                                                placeholder="AWS Access Key ID (AKIA...)"
+                                                value={anthropicAwsCredentials.accessKeyId}
+                                                onInput={handleAnthropicAwsCredentialChange('accessKeyId')}
+                                                disabled={isValidating}
+                                            />
+                                            <EyeButton
+                                                type="button"
+                                                onClick={() => setShowAnthropicAwsAccessKey(v => !v)}
+                                                title={showAnthropicAwsAccessKey ? "Hide access key" : "Show access key"}
+                                                disabled={isValidating}
+                                            >
+                                                <Codicon name={showAnthropicAwsAccessKey ? "eye-closed" : "eye"} />
+                                            </EyeButton>
+                                        </InputRow>
+                                    </InputContainer>
+
+                                    <InputContainer>
+                                        <InputRow>
+                                            <StyledTextField
+                                                type={showAnthropicAwsSecretKey ? "text" : "password"}
+                                                placeholder="AWS Secret Access Key"
+                                                value={anthropicAwsCredentials.secretAccessKey}
+                                                onInput={handleAnthropicAwsCredentialChange('secretAccessKey')}
+                                                disabled={isValidating}
+                                            />
+                                            <EyeButton
+                                                type="button"
+                                                onClick={() => setShowAnthropicAwsSecretKey(v => !v)}
+                                                title={showAnthropicAwsSecretKey ? "Hide secret key" : "Show secret key"}
+                                                disabled={isValidating}
+                                            >
+                                                <Codicon name={showAnthropicAwsSecretKey ? "eye-closed" : "eye"} />
+                                            </EyeButton>
+                                        </InputRow>
+                                    </InputContainer>
+
+                                    <InputContainer>
+                                        <InputRow>
+                                            <StyledTextField
+                                                type={showAnthropicAwsSessionToken ? "text" : "password"}
+                                                placeholder="Session Token (optional)"
+                                                value={anthropicAwsCredentials.sessionToken}
+                                                onInput={handleAnthropicAwsCredentialChange('sessionToken')}
+                                                disabled={isValidating}
+                                            />
+                                            <EyeButton
+                                                type="button"
+                                                onClick={() => setShowAnthropicAwsSessionToken(v => !v)}
+                                                title={showAnthropicAwsSessionToken ? "Hide session token" : "Show session token"}
+                                                disabled={isValidating}
+                                            >
+                                                <Codicon name={showAnthropicAwsSessionToken ? "eye-closed" : "eye"} />
+                                            </EyeButton>
+                                        </InputRow>
+                                    </InputContainer>
+                                </>
+                            )}
+
+                            {anthropicAwsAuthMode === 'apikey' && (
+                                <InputContainer>
+                                    <InputRow>
+                                        <StyledTextField
+                                            type={showAnthropicAwsApiKey ? "text" : "password"}
+                                            placeholder="API Key (aws-external-anthropic-api-key-...)"
+                                            value={anthropicAwsCredentials.apiKey}
+                                            onInput={handleAnthropicAwsCredentialChange('apiKey')}
+                                            disabled={isValidating}
+                                        />
+                                        <EyeButton
+                                            type="button"
+                                            onClick={() => setShowAnthropicAwsApiKey(v => !v)}
+                                            title={showAnthropicAwsApiKey ? "Hide API key" : "Show API key"}
+                                            disabled={isValidating}
+                                        >
+                                            <Codicon name={showAnthropicAwsApiKey ? "eye-closed" : "eye"} />
+                                        </EyeButton>
+                                    </InputRow>
+                                </InputContainer>
+                            )}
+                        </>
+                    )}
+
+                    {errorMessage && (
+                        <ErrorMessage>
+                            <Codicon name="error" />
+                            <span>{errorMessage}</span>
+                        </ErrorMessage>
+                    )}
+
+                    <ButtonContainer>
+                        <VSCodeButton
+                            appearance="primary"
+                            onClick={awsServiceMode === 'bedrock' ? connectWithAwsCredentials : connectWithAnthropicAwsCredentials}
+                            disabled={isValidating || !isFormValid}
+                        >
+                            {isValidating
+                                ? "Validating..."
+                                : awsServiceMode === 'bedrock'
+                                    ? "Connect with AWS Bedrock"
+                                    : "Connect with Claude Platform on AWS"}
+                        </VSCodeButton>
+                        <VSCodeButton
+                            appearance="secondary"
+                            onClick={cancelLogin}
+                            disabled={isValidating}
+                        >
+                            Cancel
+                        </VSCodeButton>
+                    </ButtonContainer>
+                </AlertContainer>
+            </Container>
+        );
+    }
+
     if (loginMethod === LoginMethod.AWS_BEDROCK) {
-        const isFormValid = awsCredentials.accessKeyId.trim() && 
-                           awsCredentials.secretAccessKey.trim() && 
+        const isFormValid = awsCredentials.accessKeyId.trim() &&
+                           awsCredentials.secretAccessKey.trim() &&
                            awsCredentials.region.trim();
 
         return (
@@ -361,7 +713,7 @@ const WaitingForLogin = ({ loginMethod, isValidating = false, errorMessage }: Wa
                         <InputRow>
                             <StyledTextField
                                 type={showAccessKey ? "text" : "password"}
-                                placeholder="AWS Access Key ID"
+                                placeholder="AWS Access Key ID (AKIA...)"
                                 value={awsCredentials.accessKeyId}
                                 onInput={handleAwsCredentialChange('accessKeyId')}
                                 disabled={isValidating}
@@ -522,6 +874,179 @@ const WaitingForLogin = ({ loginMethod, isValidating = false, errorMessage }: Wa
                             disabled={submitDisabled}
                         >
                             {isValidating ? "Validating..." : "Validate & Connect"}
+                        </VSCodeButton>
+                        <VSCodeButton
+                            appearance="secondary"
+                            onClick={cancelLogin}
+                            disabled={isValidating}
+                        >
+                            Cancel
+                        </VSCodeButton>
+                    </ButtonContainer>
+                </AlertContainer>
+            </Container>
+        );
+    }
+
+    if (loginMethod === LoginMethod.ANTHROPIC_AWS) {
+        const isFormValid = !!(
+            anthropicAwsCredentials.region.trim() &&
+            anthropicAwsCredentials.workspaceId.trim() &&
+            (anthropicAwsAuthMode === 'apikey'
+                ? anthropicAwsCredentials.apiKey.trim()
+                : (anthropicAwsCredentials.accessKeyId.trim() && anthropicAwsCredentials.secretAccessKey.trim()))
+        );
+
+        return (
+            <Container>
+                <AlertContainer variant="primary">
+                    <Title>Connect with Claude Platform on AWS</Title>
+                    <SubTitle>
+                        Anthropic's native API through AWS with same-day feature parity and AWS Marketplace billing.
+                        Use IAM credentials or an API key provisioned by your Anthropic account representative.
+                    </SubTitle>
+
+                    <InputContainer>
+                        <InputRow>
+                            <StyledTextField
+                                type="text"
+                                placeholder="AWS Region (e.g., us-west-2)"
+                                value={anthropicAwsCredentials.region}
+                                onInput={handleAnthropicAwsCredentialChange('region')}
+                                disabled={isValidating}
+                            />
+                        </InputRow>
+                    </InputContainer>
+
+                    <InputContainer>
+                        <InputRow>
+                            <StyledTextField
+                                type="text"
+                                placeholder="Workspace ID (e.g., wrkspc_...)"
+                                value={anthropicAwsCredentials.workspaceId}
+                                onInput={handleAnthropicAwsCredentialChange('workspaceId')}
+                                disabled={isValidating}
+                            />
+                        </InputRow>
+                    </InputContainer>
+
+                    <AuthModeToggle>
+                        <AuthModeButton
+                            active={anthropicAwsAuthMode === 'sigv4'}
+                            onClick={() => setAnthropicAwsAuthMode('sigv4')}
+                            disabled={isValidating}
+                        >
+                            IAM Credentials
+                        </AuthModeButton>
+                        <AuthModeButton
+                            active={anthropicAwsAuthMode === 'apikey'}
+                            onClick={() => setAnthropicAwsAuthMode('apikey')}
+                            disabled={isValidating}
+                        >
+                            API Key
+                        </AuthModeButton>
+                    </AuthModeToggle>
+
+                    {anthropicAwsAuthMode === 'sigv4' && (
+                        <>
+                            <InputContainer>
+                                <InputRow>
+                                    <StyledTextField
+                                        type={showAnthropicAwsAccessKey ? "text" : "password"}
+                                        placeholder="AWS Access Key ID (AKIA...)"
+                                        value={anthropicAwsCredentials.accessKeyId}
+                                        onInput={handleAnthropicAwsCredentialChange('accessKeyId')}
+                                        disabled={isValidating}
+                                    />
+                                    <EyeButton
+                                        type="button"
+                                        onClick={() => setShowAnthropicAwsAccessKey(v => !v)}
+                                        title={showAnthropicAwsAccessKey ? "Hide access key" : "Show access key"}
+                                        disabled={isValidating}
+                                    >
+                                        <Codicon name={showAnthropicAwsAccessKey ? "eye-closed" : "eye"} />
+                                    </EyeButton>
+                                </InputRow>
+                            </InputContainer>
+
+                            <InputContainer>
+                                <InputRow>
+                                    <StyledTextField
+                                        type={showAnthropicAwsSecretKey ? "text" : "password"}
+                                        placeholder="AWS Secret Access Key"
+                                        value={anthropicAwsCredentials.secretAccessKey}
+                                        onInput={handleAnthropicAwsCredentialChange('secretAccessKey')}
+                                        disabled={isValidating}
+                                    />
+                                    <EyeButton
+                                        type="button"
+                                        onClick={() => setShowAnthropicAwsSecretKey(v => !v)}
+                                        title={showAnthropicAwsSecretKey ? "Hide secret key" : "Show secret key"}
+                                        disabled={isValidating}
+                                    >
+                                        <Codicon name={showAnthropicAwsSecretKey ? "eye-closed" : "eye"} />
+                                    </EyeButton>
+                                </InputRow>
+                            </InputContainer>
+
+                            <InputContainer>
+                                <InputRow>
+                                    <StyledTextField
+                                        type={showAnthropicAwsSessionToken ? "text" : "password"}
+                                        placeholder="Session Token (optional)"
+                                        value={anthropicAwsCredentials.sessionToken}
+                                        onInput={handleAnthropicAwsCredentialChange('sessionToken')}
+                                        disabled={isValidating}
+                                    />
+                                    <EyeButton
+                                        type="button"
+                                        onClick={() => setShowAnthropicAwsSessionToken(v => !v)}
+                                        title={showAnthropicAwsSessionToken ? "Hide session token" : "Show session token"}
+                                        disabled={isValidating}
+                                    >
+                                        <Codicon name={showAnthropicAwsSessionToken ? "eye-closed" : "eye"} />
+                                    </EyeButton>
+                                </InputRow>
+                            </InputContainer>
+                        </>
+                    )}
+
+                    {anthropicAwsAuthMode === 'apikey' && (
+                        <InputContainer>
+                            <InputRow>
+                                <StyledTextField
+                                    type={showAnthropicAwsApiKey ? "text" : "password"}
+                                    placeholder="API Key (aws-external-anthropic-api-key-...)"
+                                    value={anthropicAwsCredentials.apiKey}
+                                    onInput={handleAnthropicAwsCredentialChange('apiKey')}
+                                    disabled={isValidating}
+                                />
+                                <EyeButton
+                                    type="button"
+                                    onClick={() => setShowAnthropicAwsApiKey(v => !v)}
+                                    title={showAnthropicAwsApiKey ? "Hide API key" : "Show API key"}
+                                    disabled={isValidating}
+                                >
+                                    <Codicon name={showAnthropicAwsApiKey ? "eye-closed" : "eye"} />
+                                </EyeButton>
+                            </InputRow>
+                        </InputContainer>
+                    )}
+
+                    {errorMessage && (
+                        <ErrorMessage>
+                            <Codicon name="error" />
+                            <span>{errorMessage}</span>
+                        </ErrorMessage>
+                    )}
+
+                    <ButtonContainer>
+                        <VSCodeButton
+                            appearance="primary"
+                            onClick={connectWithAnthropicAwsCredentials}
+                            disabled={isValidating || !isFormValid}
+                        >
+                            {isValidating ? "Validating..." : "Connect with Claude Platform on AWS"}
                         </VSCodeButton>
                         <VSCodeButton
                             appearance="secondary"

--- a/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -1823,12 +1823,13 @@ const AIChat: React.FC = () => {
                         </ApprovalOverlay>
                     )}
                     <Header>
-                        {loginMethod === LoginMethod.ANTHROPIC_KEY || loginMethod === LoginMethod.AWS_BEDROCK || loginMethod === LoginMethod.VERTEX_AI ? (
+                        {loginMethod === LoginMethod.ANTHROPIC_KEY || loginMethod === LoginMethod.AWS_BEDROCK || loginMethod === LoginMethod.VERTEX_AI || loginMethod === LoginMethod.ANTHROPIC_AWS ? (
                             <AuthProviderChip>
                                 <UsageBadge>
                                     <span className="codicon codicon-key" style={{ fontSize: 11 }} />
                                     {loginMethod === LoginMethod.ANTHROPIC_KEY ? "Anthropic (own key)"
                                         : loginMethod === LoginMethod.AWS_BEDROCK ? "AWS Bedrock (own key)"
+                                        : loginMethod === LoginMethod.ANTHROPIC_AWS ? "Anthropic AWS (own key)"
                                         : "Vertex AI (own key)"}
                                 </UsageBadge>
                             </AuthProviderChip>


### PR DESCRIPTION
## Description

It resolves: https://github.com/wso2/product-integrator/issues/1740

Opt-in builtin skills (default: false, e.g. Skill Creator) had their enabled/disabled toggle state persisted in the project-level
config file inside the project directory. This caused personal skill preferences to pollute the project's git working tree, risking
accidental commits into shared repositories. The toggle state was also read by merging enabledSkills from both global and project configs, making scope ambiguous.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## UI Component Development
> Specify the reason if following are not followed.
- [ ] Added reusable UI components to the ui-toolkit. Follow the [intructions](./workspaces/common-libs/ui-toolkit/README.md) when adding the componenent.
- [ ] Use ui-toolkit components wherever possible. Run `npm run storybook` from the root directory to view current components.
- [ ] Matches with the native VSCode look and feel.

## Manage Icons
> Specify the reason if following are not followed.
- [ ] Added Icons to the font-wso2-vscode. Follow the [instructions](./workspaces/common-libs/font-wso2-vscode/README.md).

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.