### PR TITLE
Allow MCP server creation from MI 4.6.0

### DIFF
--- a/workspaces/mi/mi-visualizer/src/constants/index.ts
+++ b/workspaces/mi/mi-visualizer/src/constants/index.ts
@@ -137,6 +137,7 @@ export enum InboundEndpointTypes {
 };
 
 export const connectorFailoverIconUrl = "https://mi-connectors.wso2.com/icons/wordpress.gif";
+export const RUNTIME_VERSION_460 = "4.6.0";
 export const RUNTIME_VERSION_440 = "4.4.0";
 export const RUNTIME_VERSION_410 = "4.1.0";
 

--- a/workspaces/mi/mi-visualizer/src/views/AddArtifact/index.tsx
+++ b/workspaces/mi/mi-visualizer/src/views/AddArtifact/index.tsx
@@ -26,7 +26,7 @@ import styled from "@emotion/styled";
 import { View, ViewContent, ViewHeader } from "../../components/View";
 import path from "path";
 import { handleFileAttach } from "../AIPanel/utils";
-import { RUNTIME_VERSION_440 } from "../../constants";
+import { RUNTIME_VERSION_440, RUNTIME_VERSION_460 } from "../../constants";
 import { compareVersions } from "@wso2/mi-diagram/lib/utils/commons";
 import { VALID_FILE_TYPES } from "../AIPanel/constants";
 import { FileObject, ImageObject } from "@wso2/mi-core";
@@ -142,6 +142,7 @@ export function AddArtifactView() {
     const [images, setImages] = useState<ImageObject[]>([]);
     const [fileUploadStatus, setFileUploadStatus] = useState({ type: '', text: '' });
     const [isResourceContentVisible, setIsResourceContentVisible] = useState(false);
+    const [isMcpServerVisible, setIsMcpServerVisible] = useState(false);
     const [projectUri, setProjectUri] = useState<string>("");
 
     const handleClick = async (key: string) => {
@@ -227,6 +228,7 @@ export function AddArtifactView() {
         rpcClient.getMiVisualizerRpcClient().getProjectDetails().then((response) => {
             const runtimeVersion = response.primaryDetails.runtimeVersion.value;
             setIsResourceContentVisible(compareVersions(runtimeVersion, RUNTIME_VERSION_440) >= 0);
+            setIsMcpServerVisible(compareVersions(runtimeVersion, RUNTIME_VERSION_460) >= 0);
         })
     }, []);
 
@@ -386,14 +388,16 @@ export function AddArtifactView() {
                                         description="Manage shared resources and configurations."
                                         onClick={() => handleClick("resources")}
                                     />
-                                    <Card
-                                        id="MCP Server"
-                                        icon="server"
-                                        isCodicon
-                                        title="MCP Server"
-                                        description="Create, expose, and manage MCP Servers."
-                                        onClick={() => handleClick("mcpServers")}
-                                    />
+                                    {isMcpServerVisible && (
+                                        <Card
+                                            id="MCP Server"
+                                            icon="server"
+                                            isCodicon
+                                            title="MCP Server"
+                                            description="Create, expose, and manage MCP Servers."
+                                            onClick={() => handleClick("mcpServers")}
+                                        />
+                                    )}
                                     <Card
                                         id="Message Processor"
                                         icon="message-processor"


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject

This pull request updates the `AddArtifactView` to conditionally display the MCP Server card based on the runtime version, and introduces a new runtime version constant. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP Server artifact is now conditionally available based on runtime version, appearing only when version 4.6.0 or later is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->