### PR TITLE
Fix skill toggle and MCP tools config storage scopes

### DIFF
--- a/workspaces/ballerina/ballerina-core/src/rpc-types/ai-panel/index.ts
+++ b/workspaces/ballerina/ballerina-core/src/rpc-types/ai-panel/index.ts
@@ -60,7 +60,6 @@ import {
     DeleteSkillRequest,
     SkillEnableRequest,
     SkillEnableCancelRequest,
-    SetSkillsEnabledRequest,
     ParseSkillFileRequest,
     ParseSkillFileResponse,
     SkillTier,
@@ -168,8 +167,6 @@ export interface AIPanelAPI {
     enableSkillFromChat: (params: SkillEnableRequest) => Promise<boolean>;
     cancelSkillEnable: (params: SkillEnableCancelRequest) => Promise<void>;
     parseSkillFile: (params: ParseSkillFileRequest) => Promise<ParseSkillFileResponse>;
-    getSkillsEnabled: () => Promise<boolean>;
-    setSkillsEnabled: (params: SetSkillsEnabledRequest) => Promise<void>;
     // ==================================
     // MCP tool support
     // ==================================

--- a/workspaces/ballerina/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
+++ b/workspaces/ballerina/ballerina-core/src/rpc-types/ai-panel/interfaces.ts
@@ -737,9 +737,6 @@ export interface DeleteMcpServerRequest {
 export interface SetMcpToolsEnabledRequest {
     enabled: boolean;
 }
-export interface SetSkillsEnabledRequest {
-    enabled: boolean;
-}
 /** Per-scope parse / read errors for `mcp.json` files. Both fields are optional — missing means OK. */
 export interface McpLoadErrorsDTO {
     user?: string;

--- a/workspaces/ballerina/ballerina-core/src/rpc-types/ai-panel/rpc-type.ts
+++ b/workspaces/ballerina/ballerina-core/src/rpc-types/ai-panel/rpc-type.ts
@@ -62,7 +62,6 @@ import {
     DeleteSkillRequest,
     SkillEnableRequest,
     SkillEnableCancelRequest,
-    SetSkillsEnabledRequest,
     McpServerStatusDTO,
     SetMcpServerEnabledRequest,
     AddMcpServerRequest,
@@ -142,8 +141,6 @@ export const getSkills: RequestType<void, GetSkillsResponse> = { method: `${_pre
 export const addSkill: RequestType<AddSkillRequest, boolean> = { method: `${_preFix}/addSkill` };
 export const toggleSkill: RequestType<ToggleSkillRequest, boolean> = { method: `${_preFix}/toggleSkill` };
 export const deleteSkill: RequestType<DeleteSkillRequest, boolean> = { method: `${_preFix}/deleteSkill` };
-export const getSkillsEnabled: RequestType<void, boolean> = { method: `${_preFix}/getSkillsEnabled` };
-export const setSkillsEnabled: RequestType<SetSkillsEnabledRequest, void> = { method: `${_preFix}/setSkillsEnabled` };
 export const enableSkillFromChat: RequestType<SkillEnableRequest, boolean> = { method: `${_preFix}/enableSkillFromChat` };
 export const cancelSkillEnable: RequestType<SkillEnableCancelRequest, void> = { method: `${_preFix}/cancelSkillEnable` };
 export const parseSkillFile: RequestType<ParseSkillFileRequest, ParseSkillFileResponse> = { method: `${_preFix}/parseSkillFile` };

--- a/workspaces/ballerina/ballerina-extension/package.json
+++ b/workspaces/ballerina/ballerina-extension/package.json
@@ -269,14 +269,40 @@
                         "Trace request/response messages with parameters and content"
                     ]
                 },
+                "ballerina.copilot.enableMcpTools": {
+                    "type": "boolean",
+                    "default": false,
+                    "scope": "window",
+                    "description": "Enable Model Context Protocol (MCP) tool support in the WSO2 Integrator Copilot."
+                },
+                "ballerina.copilot.skills": {
+                    "type": "object",
+                    "scope": "resource",
+                    "default": {
+                        "disabled": [],
+                        "enabled": []
+                    },
+                    "description": "Copilot skill enable/disable state. 'disabled' lists skill IDs that are turned off; 'enabled' lists opt-in skill IDs that are explicitly turned on."
+                },
+                "ballerina.copilot.mcp": {
+                    "type": "object",
+                    "scope": "window",
+                    "default": {
+                        "disabledServers": [],
+                        "enabledServers": []
+                    },
+                    "description": "MCP server enable/disable overrides. Keys are 'scope:name' identifiers (e.g. 'user:myServer'). Managed automatically by the Copilot UI."
+                },
                 "ballerina.copilot.checkpoints.enabled": {
                     "type": "boolean",
                     "default": true,
+                    "scope": "resource",
                     "description": "Enable checkpoint mechanism for copilot chat to restore previous states."
                 },
                 "ballerina.copilot.checkpoints.maxCount": {
                     "type": "number",
                     "default": 3,
+                    "scope": "resource",
                     "description": "Maximum number of checkpoints to keep."
                 },
                 "ballerina.copilot.checkpoints.ignorePatterns": {
@@ -299,22 +325,20 @@
                         "**/*.tar",
                         "**/*.gz"
                     ],
+                    "scope": "resource",
                     "description": "File patterns to ignore when creating checkpoints."
                 },
                 "ballerina.copilot.checkpoints.maxSnapshotSize": {
                     "type": "number",
                     "default": 52428800,
+                    "scope": "resource",
                     "description": "Maximum snapshot size in bytes (default: 50MB)."
                 },
-                "ballerina.ai.showContextUsage": {
+                "ballerina.copilot.showContextUsage": {
                     "type": "boolean",
                     "default": false,
+                    "scope": "resource",
                     "description": "Show context usage indicator in the AI chat input footer."
-                },
-                "ballerina.copilot.enableMcpTools": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Enable Model Context Protocol (MCP) tool support in the WSO2 Integrator Copilot."
                 }
             }
         },

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/activator.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/activator.ts
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import * as vscode from 'vscode';
 import { commands, window, workspace as vscodeWorkspace } from 'vscode';
 import { BallerinaExtension, ExtendedLangClient } from '../../core';
 import { activateCopilotLoginCommand, resetBIAuth } from './completions';
@@ -242,7 +243,6 @@ export function activateAIFeatures(ballerinaExternalInstance: BallerinaExtension
     });
 }
 
-const MCP_ENABLED_OVERRIDE_KEY = 'ballerina.copilot.mcp.enabledOverrides';
 const MCP_ENABLE_SETTING = 'copilot.enableMcpTools';
 
 let mcpWatchDisposer: (() => void) | null = null;
@@ -259,26 +259,59 @@ function setupMcp(): void {
         return;
     }
     // Override store keys are `${scope}:${name}` (e.g. `workspace:foo`).
+    function readMcpOverrideMap(): Record<string, boolean> {
+        const mcp = vscodeWorkspace.getConfiguration('ballerina.copilot').get<any>('mcp', {});
+        const map: Record<string, boolean> = {};
+        for (const k of mcp.disabledServers ?? []) { map[k] = false; }
+        for (const k of mcp.enabledServers  ?? []) { map[k] = true;  }
+        return map;
+    }
+
+    function mcpConfigTarget(): vscode.ConfigurationTarget {
+        return vscodeWorkspace.workspaceFolders?.length
+            ? vscode.ConfigurationTarget.Workspace
+            : vscode.ConfigurationTarget.Global;
+    }
+
     const overrides: EnabledOverrideStore = {
         get(scopedKey) {
-            const map = extension.context?.globalState.get<Record<string, boolean>>(MCP_ENABLED_OVERRIDE_KEY) ?? {};
+            const map = readMcpOverrideMap();
             return Object.prototype.hasOwnProperty.call(map, scopedKey) ? map[scopedKey] : undefined;
         },
         async set(scopedKey, enabled) {
-            const map = { ...(extension.context?.globalState.get<Record<string, boolean>>(MCP_ENABLED_OVERRIDE_KEY) ?? {}) };
-            map[scopedKey] = enabled;
-            await extension.context?.globalState.update(MCP_ENABLED_OVERRIDE_KEY, map);
+            const cfg = vscodeWorkspace.getConfiguration('ballerina.copilot');
+            const target = mcpConfigTarget();
+            const di = cfg.inspect<any>('mcp');
+            const mcp = { ...(target === vscode.ConfigurationTarget.Workspace
+                ? (di?.workspaceValue ?? {}) : (di?.globalValue ?? {})) };
+            mcp.disabledServers = (mcp.disabledServers ?? []).filter((k: string) => k !== scopedKey);
+            mcp.enabledServers  = (mcp.enabledServers  ?? []).filter((k: string) => k !== scopedKey);
+            if (enabled) { mcp.enabledServers.push(scopedKey); } else { mcp.disabledServers.push(scopedKey); }
+            await cfg.update('mcp', mcp, target);
+            if (target === vscode.ConfigurationTarget.Workspace) {
+                const gv = { ...(di?.globalValue ?? {}) };
+                gv.disabledServers = (gv.disabledServers ?? []).filter((k: string) => k !== scopedKey);
+                gv.enabledServers  = (gv.enabledServers  ?? []).filter((k: string) => k !== scopedKey);
+                await cfg.update('mcp', gv, vscode.ConfigurationTarget.Global);
+            }
         },
         async delete(scopedKey) {
-            const current = extension.context?.globalState.get<Record<string, boolean>>(MCP_ENABLED_OVERRIDE_KEY) ?? {};
-            if (!Object.prototype.hasOwnProperty.call(current, scopedKey)) { return; }
-            const map = { ...current };
-            delete map[scopedKey];
-            await extension.context?.globalState.update(MCP_ENABLED_OVERRIDE_KEY, map);
+            const cfg = vscodeWorkspace.getConfiguration('ballerina.copilot');
+            const target = mcpConfigTarget();
+            const di = cfg.inspect<any>('mcp');
+            const mcp = { ...(target === vscode.ConfigurationTarget.Workspace
+                ? (di?.workspaceValue ?? {}) : (di?.globalValue ?? {})) };
+            mcp.disabledServers = (mcp.disabledServers ?? []).filter((k: string) => k !== scopedKey);
+            mcp.enabledServers  = (mcp.enabledServers  ?? []).filter((k: string) => k !== scopedKey);
+            await cfg.update('mcp', mcp, target);
+            if (target === vscode.ConfigurationTarget.Workspace) {
+                const gv = { ...(di?.globalValue ?? {}) };
+                gv.disabledServers = (gv.disabledServers ?? []).filter((k: string) => k !== scopedKey);
+                gv.enabledServers  = (gv.enabledServers  ?? []).filter((k: string) => k !== scopedKey);
+                await cfg.update('mcp', gv, vscode.ConfigurationTarget.Global);
+            }
         },
-        keys() {
-            return Object.keys(extension.context?.globalState.get<Record<string, boolean>>(MCP_ENABLED_OVERRIDE_KEY) ?? {});
-        },
+        keys() { return Object.keys(readMcpOverrideMap()); },
     };
     const workspacePath = resolveProjectRootPath() || undefined;
     const workspaceTrusted = vscodeWorkspace.isTrusted;

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/skills/context.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/skills/context.ts
@@ -14,11 +14,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import * as path from 'path';
 import { ProjectSkillMeta } from './types';
 import { getDisabledBuiltIns, REGISTERED_SKILLS } from './index';
 import { scanProjectSkills, scanUserSkills } from '../tools/skill-tool/skill-reader';
-import { getSkillsConfig, GLOBAL_SKILLS_CONFIG_PATH } from '../tools/skill-tool/skill-writer';
+import { getSkillsConfig } from '../tools/skill-tool/skill-writer';
 
 export interface SkillsContext {
     allDisabled: Set<string>;
@@ -27,20 +26,11 @@ export interface SkillsContext {
     disabledSkillMetas: Array<{ name: string; trigger: string }>;
 }
 
-/** Canonical path for a project's skills config file. */
-export function buildProjectSkillsConfigPath(projectRootPath: string): string {
-    return path.join(projectRootPath, '.copilot', 'skills.config.json');
-}
-
 /** Merged set of globally and project-disabled skill IDs, respecting built-in optional/default flags. */
 export function buildAllDisabledSet(projectRootPath: string | null): Set<string> {
-    const globalConfig = getSkillsConfig(GLOBAL_SKILLS_CONFIG_PATH);
-    const projectConfig = projectRootPath
-        ? getSkillsConfig(buildProjectSkillsConfigPath(projectRootPath))
-        : { disabledSkills: [], enabledSkills: [] };
-
-    const allDisabled = new Set([...globalConfig.disabledSkills, ...projectConfig.disabledSkills]);
-    const allEnabled = new Set([...globalConfig.enabledSkills, ...projectConfig.enabledSkills]);
+    const config = getSkillsConfig(projectRootPath);
+    const allDisabled = new Set(config.disabledSkills);
+    const allEnabled  = new Set(config.enabledSkills);
 
     for (const skill of REGISTERED_SKILLS) {
         if (skill.optional === false) {

--- a/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/skill-tool/skill-writer.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/agent/tools/skill-tool/skill-writer.ts
@@ -17,59 +17,117 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-
-export const GLOBAL_SKILLS_CONFIG_PATH = path.join(
-    os.homedir(), '.ballerina', 'copilot', 'skills.config.json'
-);
+import * as vscode from 'vscode';
 
 export interface SkillsConfig {
     disabledSkills: string[];
     enabledSkills: string[];
 }
 
-export function getSkillsConfig(configPath: string): SkillsConfig {
-    try {
-        if (fs.existsSync(configPath)) {
-            const raw = fs.readFileSync(configPath, 'utf-8');
-            const parsed = JSON.parse(raw);
-            return {
-                disabledSkills: Array.isArray(parsed.disabledSkills) ? parsed.disabledSkills : [],
-                enabledSkills: Array.isArray(parsed.enabledSkills) ? parsed.enabledSkills : [],
-            };
-        }
-    } catch { /* fall through to default */ }
-    return { disabledSkills: [], enabledSkills: [] };
+export function getSkillsConfig(projectRootPath: string | null): SkillsConfig {
+    const cfg = projectRootPath
+        ? vscode.workspace.getConfiguration('ballerina.copilot', vscode.Uri.file(projectRootPath))
+        : vscode.workspace.getConfiguration('ballerina.copilot');
+    const di = cfg.inspect<any>('skills');
+    const globalSkills = di?.globalValue ?? { disabled: [], enabled: [] };
+    const wsSkills     = di?.workspaceFolderValue ?? di?.workspaceValue ?? null;
+
+    if (!wsSkills) {
+        return {
+            disabledSkills: [...(globalSkills.disabled ?? [])],
+            enabledSkills:  [...(globalSkills.enabled  ?? [])],
+        };
+    }
+
+    // Workspace overrides global on a per-skill basis (not a plain union merge).
+    // workspace.disabled adds to the disabled set; workspace.enabled removes from it.
+    const disabled = new Set<string>(globalSkills.disabled ?? []);
+    const enabled  = new Set<string>(globalSkills.enabled  ?? []);
+    for (const k of wsSkills.disabled ?? []) { disabled.add(k);    enabled.delete(k); }
+    for (const k of wsSkills.enabled  ?? []) { enabled.add(k);     disabled.delete(k); }
+    return {
+        disabledSkills: [...disabled],
+        enabledSkills:  [...enabled],
+    };
 }
 
-/**
- * @param isDefaultFalse - When true, the skill uses the `enabledSkills` list for opt-in tracking
- *   (because its built-in default is disabled). Otherwise uses the `disabledSkills` list.
- */
-export function setSkillEnabled(configPath: string, skillId: string, enabled: boolean, isDefaultFalse = false): void {
-    const config = getSkillsConfig(configPath);
+export async function setSkillEnabled(
+    skillId: string,
+    enabled: boolean,
+    isDefaultFalse = false,
+    scope: 'user' | 'workspace' = 'user'
+): Promise<void> {
+    const target = scope === 'workspace'
+        ? vscode.ConfigurationTarget.Workspace
+        : vscode.ConfigurationTarget.Global;
+
+    const cfg = vscode.workspace.getConfiguration('ballerina.copilot');
+    const di  = cfg.inspect<any>('skills');
+    const scopedSkills = scope === 'workspace'
+        ? { ...(di?.workspaceFolderValue ?? di?.workspaceValue ?? {}) }
+        : { ...(di?.globalValue ?? {}) };
+    const disabledList = [...(scopedSkills.disabled ?? [])];
+    const enabledList  = [...(scopedSkills.enabled  ?? [])];
+
     if (isDefaultFalse) {
         if (enabled) {
-            if (!config.enabledSkills.includes(skillId)) {
-                config.enabledSkills.push(skillId);
-            }
-            config.disabledSkills = config.disabledSkills.filter(id => id !== skillId);
+            if (!enabledList.includes(skillId)) { enabledList.push(skillId); }
+            const i = disabledList.indexOf(skillId);
+            if (i !== -1) { disabledList.splice(i, 1); }
         } else {
-            config.enabledSkills = config.enabledSkills.filter(id => id !== skillId);
+            const i = enabledList.indexOf(skillId);
+            if (i !== -1) { enabledList.splice(i, 1); }
         }
     } else {
         if (enabled) {
-            config.disabledSkills = config.disabledSkills.filter(id => id !== skillId);
+            const i = disabledList.indexOf(skillId);
+            if (i !== -1) { disabledList.splice(i, 1); }
+            if (!enabledList.includes(skillId)) { enabledList.push(skillId); }
         } else {
-            if (!config.disabledSkills.includes(skillId)) {
-                config.disabledSkills.push(skillId);
+            if (!disabledList.includes(skillId)) { disabledList.push(skillId); }
+            const ei = enabledList.indexOf(skillId);
+            if (ei !== -1) { enabledList.splice(ei, 1); }
+        }
+    }
+
+    await cfg.update('skills', { disabled: disabledList, enabled: enabledList }, target);
+
+    // When writing a workspace-scope change, remove any stale global entry for
+    // this skill so global doesn't silently conflict with workspace state.
+    if (scope === 'workspace') {
+        const globalVal = di?.globalValue;
+        if (globalVal) {
+            const globalDisabled = (globalVal.disabled ?? []).filter((k: string) => k !== skillId);
+            const globalEnabled  = (globalVal.enabled  ?? []).filter((k: string) => k !== skillId);
+            const changed = globalDisabled.length !== (globalVal.disabled ?? []).length
+                         || globalEnabled.length  !== (globalVal.enabled  ?? []).length;
+            if (changed) {
+                try {
+                    await cfg.update('skills', { disabled: globalDisabled, enabled: globalEnabled }, vscode.ConfigurationTarget.Global);
+                } catch { /* best-effort */ }
             }
         }
     }
-    const dir = path.dirname(configPath);
-    if (!fs.existsSync(dir)) {
-        fs.mkdirSync(dir, { recursive: true });
+
+    // When writing a user-scope (global) change, remove any stale workspace entry for
+    // this skill so workspace doesn't silently override the global state.
+    if (scope === 'user') {
+        const wsVal = di?.workspaceFolderValue ?? di?.workspaceValue;
+        if (wsVal) {
+            const wsDisabled = (wsVal.disabled ?? []).filter((k: string) => k !== skillId);
+            const wsEnabled  = (wsVal.enabled  ?? []).filter((k: string) => k !== skillId);
+            const changed = wsDisabled.length !== (wsVal.disabled ?? []).length
+                         || wsEnabled.length  !== (wsVal.enabled  ?? []).length;
+            if (changed) {
+                const wsTarget = di?.workspaceFolderValue !== undefined
+                    ? vscode.ConfigurationTarget.WorkspaceFolder
+                    : vscode.ConfigurationTarget.Workspace;
+                try {
+                    await cfg.update('skills', { disabled: wsDisabled, enabled: wsEnabled }, wsTarget);
+                } catch { /* best-effort */ }
+            }
+        }
     }
-    fs.writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf-8');
 }
 
 function validatePathSegment(segment: string, label: string): void {

--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/ai-panel/rpc-handler.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/ai-panel/rpc-handler.ts
@@ -110,15 +110,12 @@ import {
     enableSkillFromChat,
     cancelSkillEnable,
     parseSkillFile,
-    getSkillsEnabled,
-    setSkillsEnabled,
     AddSkillRequest,
     ToggleSkillRequest,
     DeleteSkillRequest,
     SkillEnableRequest,
     SkillEnableCancelRequest,
     ParseSkillFileRequest,
-    SetSkillsEnabledRequest,
     listMcpServers,
     setMcpServerEnabled,
     SetMcpServerEnabledRequest,
@@ -199,8 +196,8 @@ export function registerAiPanelRpcHandlers(messenger: Messenger) {
 
     // Notify webview immediately when the showContextUsage setting is toggled
     workspace.onDidChangeConfiguration((e) => {
-        if (e.affectsConfiguration('ballerina.ai.showContextUsage')) {
-            const value = workspace.getConfiguration('ballerina').get<boolean>('ai.showContextUsage', false);
+        if (e.affectsConfiguration('ballerina.copilot.showContextUsage')) {
+            const value = workspace.getConfiguration('ballerina.copilot').get<boolean>('showContextUsage', false);
             sendConfigChangeNotification('showContextUsage', value);
         }
     });
@@ -219,8 +216,6 @@ export function registerAiPanelRpcHandlers(messenger: Messenger) {
     messenger.onRequest(enableSkillFromChat, (args: SkillEnableRequest) => rpcManger.enableSkillFromChat(args));
     messenger.onRequest(cancelSkillEnable, (args: SkillEnableCancelRequest) => rpcManger.cancelSkillEnable(args));
     messenger.onRequest(parseSkillFile, (args: ParseSkillFileRequest) => rpcManger.parseSkillFile(args));
-    messenger.onRequest(getSkillsEnabled, () => rpcManger.getSkillsEnabled());
-    messenger.onRequest(setSkillsEnabled, (args: SetSkillsEnabledRequest) => rpcManger.setSkillsEnabled(args));
     messenger.onRequest(listMcpServers, () => rpcManger.listMcpServers());
     messenger.onRequest(setMcpServerEnabled, (args: SetMcpServerEnabledRequest) => rpcManger.setMcpServerEnabled(args));
     messenger.onRequest(openMcpConfig, (args: OpenMcpConfigRequest) => rpcManger.openMcpConfig(args));

--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/ai-panel/rpc-manager.ts
@@ -60,7 +60,6 @@ import {
     SkillEnableRequest,
     SkillEnableCancelRequest,
     SkillEnableStage,
-    SetSkillsEnabledRequest,
     SkillEntry,
     SkillTier,
     ParseSkillFileRequest,
@@ -118,7 +117,6 @@ import { addToIntegration, searchDocumentation } from "./utils";
 
 import { createExecutorConfig, generateAgent, resolveProjectRootPath } from '../../features/ai/agent/index';
 import { REGISTERED_SKILLS } from '../../features/ai/agent/skills/index';
-import { buildProjectSkillsConfigPath } from '../../features/ai/agent/skills/context';
 import { scanProjectSkills, scanUserSkills, readUserSkillContent, readProjectSkillContent, parseSkillMd } from '../../features/ai/agent/tools/skill-tool/skill-reader';
 import * as unzipper from 'unzipper';
 import {
@@ -128,7 +126,6 @@ import {
     writeProjectSkill,
     deleteUserSkill,
     deleteProjectSkill,
-    GLOBAL_SKILLS_CONFIG_PATH,
 } from '../../features/ai/agent/tools/skill-tool/skill-writer';
 import { clearCompactionDisabledWarning } from '../../features/ai/agent/AgentExecutor';
 import { LLM_API_BASE_PATH, WI_EXTENSION_ID } from "../../features/ai/constants";
@@ -760,7 +757,7 @@ User reverted the last made changes. The files have been restored to the state b
     }
 
     async getShowContextUsage(): Promise<boolean> {
-        return workspace.getConfiguration('ballerina').get<boolean>('ai.showContextUsage', false);
+        return workspace.getConfiguration('ballerina.copilot').get<boolean>('showContextUsage', false);
     }
 
     async getUsage(): Promise<UsageResponse | undefined> {
@@ -896,14 +893,6 @@ User reverted the last made changes. The files have been restored to the state b
 
     // ── Skills helpers ────────────────────────────────────────────────────────
 
-    /** Returns the config file path for the given skill tier. */
-    private resolveSkillsConfigPath(tier: SkillTier, projectRootPath: string | null): string {
-        if (tier === SkillTier.PROJECT && projectRootPath) {
-            return buildProjectSkillsConfigPath(projectRootPath);
-        }
-        return GLOBAL_SKILLS_CONFIG_PATH;
-    }
-
     /** Extracts the bare skill name from a prefixed id such as "user/foo" → "foo". */
     private extractBareSkillName(skillId: string): string {
         const slash = skillId.indexOf('/');
@@ -963,11 +952,9 @@ User reverted the last made changes. The files have been restored to the state b
 
     async getSkills(): Promise<GetSkillsResponse> {
         const projectRootPath = resolveProjectRootPath();
-        const globalConfig = getSkillsConfig(GLOBAL_SKILLS_CONFIG_PATH);
-        const projectConfigPath = projectRootPath ? buildProjectSkillsConfigPath(projectRootPath) : null;
-        const projectConfig = projectConfigPath ? getSkillsConfig(projectConfigPath) : { disabledSkills: [], enabledSkills: [] };
-        const allDisabled = new Set([...globalConfig.disabledSkills, ...projectConfig.disabledSkills]);
-        const allEnabled = new Set([...globalConfig.enabledSkills, ...projectConfig.enabledSkills]);
+        const config = getSkillsConfig(projectRootPath);
+        const allDisabled = new Set(config.disabledSkills);
+        const allEnabled  = new Set(config.enabledSkills);
 
         return {
             skills: [
@@ -996,11 +983,15 @@ User reverted the last made changes. The files have been restored to the state b
 
     async toggleSkill(params: ToggleSkillRequest): Promise<boolean> {
         try {
-            const configPath = this.resolveSkillsConfigPath(params.tier, resolveProjectRootPath());
             const builtinSkill = params.tier === SkillTier.BUILTIN
                 ? REGISTERED_SKILLS.find(s => s.name === params.skillId)
                 : undefined;
-            setSkillEnabled(configPath, params.skillId, params.enabled, builtinSkill?.default === false);
+            const projectRootPath = resolveProjectRootPath();
+            // USER skills always go to global user settings.
+            // BUILTIN and PROJECT skills use workspace settings when in a project context.
+            const scope: 'user' | 'workspace' =
+                params.tier !== SkillTier.USER && !!projectRootPath ? 'workspace' : 'user';
+            await setSkillEnabled(params.skillId, params.enabled, builtinSkill?.default === false, scope);
             return true;
         } catch (error) {
             console.error('[Skills] toggleSkill failed:', error);
@@ -1029,15 +1020,12 @@ User reverted the last made changes. The files have been restored to the state b
         try {
             const projectRootPath = resolveProjectRootPath();
             const builtinSkill = REGISTERED_SKILLS.find(s => s.name === params.skillId);
+            const isUserSkill = !builtinSkill && scanUserSkills().some(s => s.name === params.skillId);
+            const resolvedScope = !isUserSkill && !!projectRootPath ? 'workspace' : 'user';
             if (builtinSkill?.default === false) {
-                if (projectRootPath) {
-                    setSkillEnabled(buildProjectSkillsConfigPath(projectRootPath), params.skillId, true, true);
-                }
+                await setSkillEnabled(params.skillId, true, true, resolvedScope);
             } else {
-                setSkillEnabled(GLOBAL_SKILLS_CONFIG_PATH, params.skillId, true);
-                if (projectRootPath) {
-                    setSkillEnabled(buildProjectSkillsConfigPath(projectRootPath), params.skillId, true);
-                }
+                await setSkillEnabled(params.skillId, true, false, resolvedScope);
             }
             sendSkillEnableNotification({ type: "skill_enable_event", requestId: params.requestId, stage: SkillEnableStage.ENABLED, skillName: params.skillId, skillId: params.skillId } as any);
             approvalManager.resolveSkillEnable(params.requestId, true);
@@ -1134,13 +1122,6 @@ User reverted the last made changes. The files have been restored to the state b
         return workspace.getConfiguration('ballerina').get<boolean>('copilot.enableMcpTools', false);
     }
 
-    async getSkillsEnabled(): Promise<boolean> {
-        return workspace.getConfiguration('ballerina').get<boolean>('copilot.enableSkills', true);
-    }
-
-    async setSkillsEnabled(params: SetSkillsEnabledRequest): Promise<void> {
-        await workspace.getConfiguration('ballerina').update('copilot.enableSkills', !!params?.enabled, ConfigurationTarget.Global);
-    }
 
     async getMcpWorkspaceContext(): Promise<McpWorkspaceContextResponse> {
         return { hasWorkspace: !!resolveProjectRootPath() && vscode.workspace.isTrusted };
@@ -1246,9 +1227,8 @@ User reverted the last made changes. The files have been restored to the state b
     }
 
     async setMcpToolsEnabled(params: SetMcpToolsEnabledRequest): Promise<void> {
-        await workspace.getConfiguration('ballerina').update('copilot.enableMcpTools', !!params?.enabled, ConfigurationTarget.Global);
-        // The existing onDidChangeConfiguration listener in activator.ts handles
-        // setup/teardown of the manager and pushes config_change + mcpServersChanged.
+        await workspace.getConfiguration('ballerina')
+            .update('copilot.enableMcpTools', !!params?.enabled, ConfigurationTarget.Global);
     }
 
     async getAgentsMdFileInfo(): Promise<AgentsMdFileInfoDTO> {

--- a/workspaces/ballerina/ballerina-rpc-client/src/rpc-clients/ai-panel/rpc-client.ts
+++ b/workspaces/ballerina/ballerina-rpc-client/src/rpc-clients/ai-panel/rpc-client.ts
@@ -121,8 +121,6 @@ import {
     enableSkillFromChat,
     cancelSkillEnable,
     parseSkillFile,
-    getSkillsEnabled,
-    setSkillsEnabled,
     GetSkillsResponse,
     AddSkillRequest,
     ToggleSkillRequest,
@@ -131,7 +129,6 @@ import {
     SkillEnableCancelRequest,
     ParseSkillFileRequest,
     ParseSkillFileResponse,
-    SetSkillsEnabledRequest,
     listMcpServers,
     setMcpServerEnabled,
     openMcpConfig,
@@ -422,14 +419,6 @@ export class AiPanelRpcClient implements AIPanelAPI {
 
     parseSkillFile(params: ParseSkillFileRequest): Promise<ParseSkillFileResponse> {
         return this._messenger.sendRequest(parseSkillFile, HOST_EXTENSION, params);
-    }
-
-    getSkillsEnabled(): Promise<boolean> {
-        return this._messenger.sendRequest(getSkillsEnabled, HOST_EXTENSION);
-    }
-
-    setSkillsEnabled(params: SetSkillsEnabledRequest): Promise<void> {
-        return this._messenger.sendRequest(setSkillsEnabled, HOST_EXTENSION, params);
     }
 
     listMcpServers(): Promise<McpServerStatusDTO[]> {


### PR DESCRIPTION
## Description
Corrects which settings file each Copilot UI toggle writes to:
  - **USER skills** (custom skills created by the user) — always written to the global user `settings.json`. These are personal preferences and must not appear in `.vscode/settings.json`.
  - **BUILTIN skills** (built-in `/` slash-command skills) and **PROJECT skills** — written to `.vscode/settings.json` (workspace scope) when a project is open, falling back to global when no workspace is open.
  - **MCP tools enable/disable** — reverted to always write to global `settings.json`. Enabling MCP tools is a user-wide preference, not project-specific.

Also adds bidirectional stale-entry cleanup in `setSkillEnabled`: when a toggle writes to workspace scope it removes any prior entry for that skill from global settings, and vice versa. This prevents the same skill key from appearing in both files simultaneously, which caused confusing duplicates after the storage layer was migrated.

It resolves: https://github.com/wso2/product-integrator/issues/1740

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## UI Component Development
> Specify the reason if following are not followed.
- [ ] Added reusable UI components to the ui-toolkit. Follow the [intructions](./workspaces/common-libs/ui-toolkit/README.md) when adding the componenent.
- [ ] Use ui-toolkit components wherever possible. Run `npm run storybook` from the root directory to view current components.
- [ ] Matches with the native VSCode look and feel.

## Manage Icons
> Specify the reason if following are not followed.
- [ ] Added Icons to the font-wso2-vscode. Follow the [instructions](./workspaces/common-libs/font-wso2-vscode/README.md).

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added chat-based skill enablement and skill file parsing for the AI panel.
  * Introduced MCP tools configuration support, including enabling/disabling MCP tools and managing MCP server lists.

* **Chores**
  * Migrated skill and MCP server enable/disable persistence to VS Code settings with proper user vs workspace scoping.
  * Renamed `ballerina.ai.showContextUsage` to `ballerina.copilot.showContextUsage`.
  * Updated checkpoint-related settings to use `resource` scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->