### PR TITLE
Change Copilot quota contact email to support@wso2.com

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/features/ai/utils/ai-client.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/ai/utils/ai-client.ts
@@ -28,7 +28,7 @@ export const ANTHROPIC_HAIKU = "claude-haiku-4-5-20251001";
 export const ANTHROPIC_SONNET_4 = "claude-sonnet-4-6";
 
 // Contact for requesting more Copilot quota once the usage limit is reached.
-export const QUOTA_REQUEST_CONTACT_EMAIL = "integration-platform-help@wso2.com";
+export const QUOTA_REQUEST_CONTACT_EMAIL = "support@wso2.com";
 export const USAGE_LIMIT_EXCEEDED_MESSAGE =
     `Usage limit exceeded. To request additional quota, contact ${QUOTA_REQUEST_CONTACT_EMAIL}.`;
 

--- a/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/AIPanel/components/AIChat/index.tsx
@@ -97,7 +97,7 @@ const NO_DRIFT_FOUND = "No drift identified between the code and the documentati
 const DRIFT_CHECK_ERROR = "Failed to check drift between the code and the documentation. Please try again.";
 
 const USAGE_EXCEEDED_THRESHOLD_PERCENT = 3;
-const QUOTA_CONTACT_EMAIL = "integration-platform-help@wso2.com";
+const QUOTA_CONTACT_EMAIL = "support@wso2.com";
 
 //TODO: Add better error handling from backend. stream error type and non 200 status codes
 


### PR DESCRIPTION
- Update the Copilot usage-limit contact email to `support@wso2.com` in the banner, error message, and prompt-enhancement toast

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the contact email shown in “usage limit exceeded” messages to `support@wso2.com`.
  * The same updated contact appears in related UI text and email links, ensuring users see the current support address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->