### PR TITLE
Fix agent-mode codegen guardrails (operator precedence, scope, connectors, variables)

### DIFF
--- a/workspaces/mi/mi-core/src/rpc-types/mi-diagram/types.ts
+++ b/workspaces/mi/mi-core/src/rpc-types/mi-diagram/types.ts
@@ -2309,6 +2309,13 @@ export interface GetArtifactTypeResponse {
 export interface XmlCode{
     fileName: string;
     code: string;
+    /**
+     * When true, the language server skips cross-file reference checks (unresolved
+     * endpoint/sequence/key/messageStore/dataService references) for this request. Used by
+     * per-file auto-validation after a write, where a referenced sibling artifact may not exist
+     * yet. Optional and ignored by language servers that don't support it.
+     */
+    skipCrossFileValidation?: boolean;
 }
 
 export interface SubmitFeedbackRequest {

--- a/workspaces/mi/mi-extension/src/ai-features/agent-mode/agents/main/agent.ts
+++ b/workspaces/mi/mi-extension/src/ai-features/agent-mode/agents/main/agent.ts
@@ -839,7 +839,7 @@ export async function executeAgent(
         // Configure Anthropic provider options.
         // - `adaptive` lets the model decide whether to think per step.
         // - `effort: 'low'` biases adaptive toward skipping for simple steps.
-        // - `display: 'summarized'` is required on Opus 4.7 (default changed to
+        // - `display: 'summarized'` is required on Opus 4.8 (default changed to
         //   'omitted' there) to actually surface reasoning text to the UI;
         //   harmless on Sonnet which already defaults to summarized.
         const anthropicOptions: AnthropicProviderOptions = request.thinking

--- a/workspaces/mi/mi-extension/src/ai-features/agent-mode/agents/main/system.ts
+++ b/workspaces/mi/mi-extension/src/ai-features/agent-mode/agents/main/system.ts
@@ -154,6 +154,7 @@ ${Object.entries(DEFERRED_TOOL_DESCRIPTIONS).map(([name, desc]) => `- ${name}: $
 - If the reminder ends with a \`[file truncated — ...]\` notice, rules beyond the cut are NOT in your persistent context. When a user request plausibly depends on rules past the cut, read \`AGENTS.md\` on demand with ${FILE_READ_TOOL_NAME}; its \`offset\`/\`limit\` options are line-based, so use them to fetch a specific section when needed. Do not pre-fetch — only read when the task actually needs it. Also tell the user once that AGENTS.md exceeds the in-context size limit and ask them to shorten the file (or split it into multiple smaller instruction files) so the full set stays in context every turn.
 
 ## Connectors and inbound endpoints (${CONNECTOR_TOOL_NAME}, ${MANAGE_CONNECTOR_TOOL_NAME})
+- **HARD RULE: never write a connector operation's XML without first calling ${CONNECTOR_TOOL_NAME} mode='details' for that operation in this session.** Your training data on connector parameters is unreliable — parameter names, casing, and required flags change between connector versions. Use only operations and parameters present in the details output; if a parameter you need is not listed there, say so instead of guessing.
 - Workflow: mode='summary' to learn operations / init style → mode='details' for the specific ops/connections you will actually use → write XML → ${MANAGE_CONNECTOR_TOOL_NAME} to add the artifact to the project.
 - Bundled inbound ids (http, jms, ...) skip ${MANAGE_CONNECTOR_TOOL_NAME} — reference them straight from Synapse XML.
 - For inbound endpoints, summary usually names every parameter — skip mode='details' unless you need types/defaults.
@@ -197,6 +198,7 @@ The user's IDE selection (if any) is included in the conversation context and ma
 
 ## Scope & Requirements
 - Assist with technical queries related to WSO2 Synapse integrations. Politely decline out-of-scope requests.
+- **Platform limitations**: When a requirement cannot be met with WSO2 MI's supported mediators, connectors, and transports, do NOT generate plausible-looking but invalid code. State clearly what MI cannot do, offer the closest supported alternative if one exists, and let the user decide. Never invent mediators, attributes, or connector operations that don't exist in the reference guides or tool outputs.
 - If a missing detail can change architecture, security, or external dependencies, ask via ${ASK_USER_TOOL_NAME}. Otherwise, make minimal assumptions and state them briefly.
 
 ## Design Guidelines
@@ -213,7 +215,8 @@ The user's IDE selection (if any) is included in the conversation context and ma
 - For AI integrations, use the AI connector. Create separate files for each artifact type.
 
 ## Validation
-- XML files are automatically validated on write/edit. Review feedback and fix errors. Use ${VALIDATE_CODE_TOOL_NAME} only for files you didn't just write/edit.
+- XML files are automatically validated on write/edit; review and fix the reported errors. This per-file pass omits cross-file reference checks (endpoint/sequence/key/messageStore/dataService references resolve only once their target files exist).
+- Before finishing any task that created or edited multiple artifacts, run ${VALIDATE_CODE_TOOL_NAME} on them together — this is when cross-file references are checked. Also use it for files you didn't just write/edit.
 
 ## Build and Test
 - ${BUILD_AND_DEPLOY_TOOL_NAME} modes: \`build\` (build only), \`deploy\` (deploy existing .car), \`build_and_deploy\` (full stop→build→deploy→start cycle).

--- a/workspaces/mi/mi-extension/src/ai-features/agent-mode/context/connectors_guide.ts
+++ b/workspaces/mi/mi-extension/src/ai-features/agent-mode/context/connectors_guide.ts
@@ -69,7 +69,7 @@ noInitializationNeeded? (HIGHEST PRECEDENCE — check this first)
 \`\`\`
 
 ### 2) General rules
-1. Only use operations defined in connector JSON signatures (via ${CONNECTOR_TOOL_NAME}).
+1. Only use operations AND parameters returned by ${CONNECTOR_TOOL_NAME} mode='details'. Never write connector XML from memory — parameter names and casing vary between connector versions.
 2. Never use \`<class name="..."/>\`. Use proper connector syntax.
 3. No placeholders — include all required parameters.
 4. \`configKey\` must exactly match the local entry \`key\`.

--- a/workspaces/mi/mi-extension/src/ai-features/agent-mode/context/synapse-core/synapse_edge_cases.ts
+++ b/workspaces/mi/mi-extension/src/ai-features/agent-mode/context/synapse-core/synapse_edge_cases.ts
@@ -69,9 +69,9 @@ false || true           → true   OK
 "text" or false         → THROWS
 0 and false             → THROWS
 \`\`\`
-**Workaround:** Use comparison to produce boolean:
+**Workaround:** Use comparisons to produce booleans, and parenthesize each one (\`and\`/\`or\` bind tighter than comparisons):
 \`\`\`xml
-\${payload.count > 0 and payload.active == "true"}
+\${(payload.count > 0) and (payload.active == "true")}
 \`\`\`
 
 ### Comparison operators are numeric-only
@@ -139,7 +139,7 @@ length(payload.middle)  → THROWS ("Null source value")
 \${not(exists(payload.field))}
 
 <!-- UNSAFE: will throw WARN if field is truly null -->
-\${payload.field == null or payload.field == ""}
+\${(payload.field == null) or (payload.field == "")}
 <!-- Use instead: -->
 \${not(exists(payload.field))}
 \`\`\`
@@ -182,7 +182,7 @@ Inside XML attribute values, these characters MUST be escaped:
 \`\`\`xml
 <!-- Comparison operators need XML escaping in attributes -->
 <variable name="isAdult" expression="\${payload.age &gt; 18}" type="BOOLEAN"/>
-<variable name="check" expression="\${payload.a &gt;= 5 &amp;&amp; payload.b &lt; 10}" type="BOOLEAN"/>
+<variable name="check" expression="\${(payload.a &gt;= 5) &amp;&amp; (payload.b &lt; 10)}" type="BOOLEAN"/>
 
 <!-- In text nodes (like log message), no escaping needed -->
 <log><message>\${payload.age > 18}</message></log>
@@ -324,11 +324,11 @@ error_catalog: `## Common Error Messages → Causes
 |--------------|-------|-----|
 | "Addition between non-numeric values" | Using \`+\` with string and number | Convert both to same type, or use inline template |
 | "Comparison between non-numeric values" | Using \`>\`/\`<\` with strings | Convert to numeric first: \`integer(x) > 5\` |
-| "Logical operation between non-boolean values" | Using \`and\`/\`or\` with non-boolean | Ensure both sides are boolean expressions |
+| "Logical operation between non-boolean values" | Using \`and\`/\`or\` with non-boolean — most often an unparenthesized comparison (\`a > 0 and b < 10\` parses as \`a > (0 and b) < 10\`) | Parenthesize each comparison: \`(a > 0) and (b < 10)\` |
 | "Condition is not a boolean" | Ternary \`?\` with non-boolean condition | Condition must be a comparison or boolean variable |
 | "Condition is null" | Ternary \`?\` where condition evaluates to null | Add \`exists()\` check |
 | "Null inputs for X operation" | Using arithmetic/comparison with null | Check with \`exists()\` first |
-| "Variable X is not defined" | Accessing unset variable | Set variable first or use \`exists()\` |
+| "Variable X is not defined" | Accessing unset variable | Declare it with a \`<variable>\` mediator (or connector \`responseVariable\`) earlier in the flow, or guard with \`exists()\` |
 | "Payload is empty" | Accessing payload when there's no body | Check payload exists before access |
 | "Could not fetch the value of the key" | Missing header/property/param | Verify the header/property is set |
 | "Invalid index for subString" | subString index out of bounds | Validate string length before calling |

--- a/workspaces/mi/mi-extension/src/ai-features/agent-mode/context/synapse-core/synapse_expression_spec.ts
+++ b/workspaces/mi/mi-extension/src/ai-features/agent-mode/context/synapse-core/synapse_expression_spec.ts
@@ -35,17 +35,13 @@ Extracted from the ANTLR parser grammar. Higher precedence binds tighter.
 |------------|----------------|----------------------------------|---------------|
 | 1 (highest)| Grouping       | \`( )\`                          | —             |
 | 2          | Unary          | \`-\` (signed)                   | Right         |
-| 3          | Multiplicative | \`*\`, \`/\`, \`%\`                  | Left          |
-| 4          | Additive       | \`+\`, \`-\`                       | Left          |
+| 3          | Multiplicative | \`*\`, \`/\`, \`%\`              | Left          |
+| 4          | Additive       | \`+\`, \`-\`                     | Left          |
 | 5          | Logical        | \`and\`/\`&&\`, \`or\`/\`||\`          | Right         |
 | 6          | Comparison     | \`>\`, \`<\`, \`>=\`, \`<=\`, \`==\`, \`!=\` | Left          |
 | 7 (lowest) | Conditional    | \`? :\` (ternary)                | Right         |
 
-**Key implication:** Arithmetic is evaluated before comparisons, which are evaluated before logical operators.
-\`\`\`
-\${vars.a + 5 > vars.b * 2 and vars.c == true}
-\`\`\`
-Evaluates as: \`((vars.a + 5) > (vars.b * 2)) and (vars.c == true)\``,
+**Key implication:** Logical operators (\`and\`/\`or\`) bind TIGHTER than comparison operators — the OPPOSITE of mainstream languages (arithmetic still binds tighter than both). So \`\${vars.a > 0 and vars.b < 10}\` parses as \`vars.a > (0 and vars.b) < 10\` (mis-evaluates/throws), NOT \`(vars.a > 0) and (vars.b < 10)\`. Always parenthesize each comparison that is an operand of \`and\`/\`or\`: \`\${(vars.a > 0) and (vars.b < 10)}\`. Already-boolean operands (\`vars.flag\`, \`exists(...)\`, \`not(...)\`) need no parentheses.`,
 
 type_system: `## Type System
 

--- a/workspaces/mi/mi-extension/src/ai-features/agent-mode/context/synapse_expression_guide.ts
+++ b/workspaces/mi/mi-extension/src/ai-features/agent-mode/context/synapse_expression_guide.ts
@@ -125,10 +125,11 @@ Headers, properties, params, and configs auto-parse string values: \`"200"\` →
 2. **\`==\` compares string representations**: \`1 == 1.0\` → false. Use \`float()\` for numeric comparison.
 3. **Logical ops need strict boolean**: \`1 and true\` THROWS. No truthy/falsy. \`not()\` argument MUST be boolean.
 4. **Comparison ops are numeric-only**: \`"abc" > "abd"\` THROWS. Convert to numbers first.
-5. **Ternary condition must be boolean**: \`null ? "a" : "b"\` THROWS.
-6. **PayloadFactory: NEVER use \`<args>\` with Synapse Expressions** — embed directly in \`<format>\`.
-7. **Single-line only**: no multi-line code inside \`\${}\`.
-8. **Hyphens in identifiers**: \`vars.my-var\` is valid (hyphens allowed in variable names).
+5. **\`and\`/\`or\` bind TIGHTER than comparisons — parenthesize each comparison**: \`\${(a > 0) and (b < 10)}\`, not \`\${a > 0 and b < 10}\` (which mis-parses as \`a > (0 and b) < 10\`). Already-boolean operands (\`vars.flag\`, \`exists(...)\`) need no parens.
+6. **Ternary condition must be boolean**: \`null ? "a" : "b"\` THROWS.
+7. **PayloadFactory: NEVER use \`<args>\` with Synapse Expressions** — embed directly in \`<format>\`.
+8. **Single-line only**: no multi-line code inside \`\${}\`.
+9. **Hyphens in identifiers**: \`vars.my-var\` is valid (hyphens allowed in variable names).
 
 ---
 
@@ -144,7 +145,7 @@ These are the EXACT attribute names — do not substitute.
 
 #### filter mediator — uses \`xpath=\` attribute (must evaluate to boolean)
 \`\`\`xml
-<filter xpath="\${payload.price &lt; 10 and payload.stock &gt; 0}">
+<filter xpath="\${(payload.price &lt; 10) and (payload.stock &gt; 0)}">
     <then>
         <log category="INFO"><message>In stock and affordable</message></log>
     </then>
@@ -173,7 +174,7 @@ These are the EXACT attribute names — do not substitute.
 \`\`\`xml
 <variable name="discountedPrice" type="DOUBLE" expression="\${payload.price * 0.9}"/>
 <variable name="userData" type="JSON" expression="\${payload.user}"/>
-<variable name="isEligible" type="BOOLEAN" expression="\${payload.age &gt;= 18 and exists(payload.email)}"/>
+<variable name="isEligible" type="BOOLEAN" expression="\${(payload.age &gt;= 18) and exists(payload.email)}"/>
 \`\`\`
 
 #### payloadFactory — inline \`\${}\` in \`<format>\`, NO \`<args>\`

--- a/workspaces/mi/mi-extension/src/ai-features/agent-mode/tools/file_tools.ts
+++ b/workspaces/mi/mi-extension/src/ai-features/agent-mode/tools/file_tools.ts
@@ -803,8 +803,11 @@ export function createWriteExecute(
 
         // Give language services a brief moment to settle before automatic validation.
         await delay(POST_WRITE_VALIDATION_DELAY_MS);
-        // Automatically validate the file and get structured diagnostics (include code actions for agent)
-        const validation = await validateXmlFile(fullPath, projectPath, true);
+        // Automatically validate the file and get structured diagnostics (include code actions for agent).
+        // Skip cross-file reference checks here: during multi-file generation a referenced sibling
+        // artifact may not exist yet, so those warnings would be transient false positives. The agent
+        // runs validate_code (no skip) once all related files are written to surface them.
+        const validation = await validateXmlFile(fullPath, projectPath, true, true);
 
         console.log(`[FileWriteTool] Successfully ${action} and synced file: ${file_path} with ${lineCount} lines`);
 
@@ -1102,7 +1105,9 @@ export function createEditExecute(
 
         // Give language services a brief moment to settle before automatic validation.
         await delay(POST_WRITE_VALIDATION_DELAY_MS);
-        const validation = await validateXmlFile(fullPath, projectPath, true);
+        // Skip cross-file reference checks for per-file auto-validation (see file_write rationale);
+        // validate_code surfaces them once all related files exist.
+        const validation = await validateXmlFile(fullPath, projectPath, true, true);
 
         const replacedCount = replace_all ? occurrences : 1;
         logDebug(`[FileEditTool] Successfully replaced ${replacedCount} occurrence(s) in: ${file_path}`);

--- a/workspaces/mi/mi-extension/src/ai-features/agent-mode/tools/lsp_tools.ts
+++ b/workspaces/mi/mi-extension/src/ai-features/agent-mode/tools/lsp_tools.ts
@@ -122,7 +122,8 @@ export function createValidateCodeTool(execute: ValidateCodeExecuteFn) {
             NOTE: file_write/file_edit already validate automatically. Only use to:
             - Validate files you haven't just written/edited
             - Batch-validate multiple files
-            - Re-validate after adding connectors via ${MANAGE_CONNECTOR_TOOL_NAME}`,
+            - Re-validate after adding connectors via ${MANAGE_CONNECTOR_TOOL_NAME}
+            - Check cross-file references (endpoint/sequence/key/messageStore/dataService) after all related files are written — these are NOT reported by per-file auto-validation, since the referenced files may not exist yet at write time`,
         inputSchema: validateCodeInputSchema,
         execute
     });

--- a/workspaces/mi/mi-extension/src/ai-features/agent-mode/tools/validation-utils.ts
+++ b/workspaces/mi/mi-extension/src/ai-features/agent-mode/tools/validation-utils.ts
@@ -108,12 +108,18 @@ function postProcessDiagnosticMessage(message: string): string {
  * @param absolutePath - Absolute path to the file
  * @param projectPath - Project root path
  * @param includeCodeActions - Whether to fetch LSP code actions for diagnostics
+ * @param skipCrossFileValidation - When true, ask the LS to skip cross-file reference checks
+ *   (unresolved endpoint/sequence/key/messageStore/dataService references). Used for per-file
+ *   auto-validation after a write, where a referenced sibling artifact may not exist yet. The
+ *   final validate_code call leaves this off so cross-file references are checked once all
+ *   related files exist. Unknown to older language servers, which simply ignore the flag.
  * @returns ValidationDiagnostics object or null if validation not performed
  */
 export async function validateXmlFile(
     absolutePath: string,
     projectPath: string,
-    includeCodeActions: boolean = false
+    includeCodeActions: boolean = false,
+    skipCrossFileValidation: boolean = false
 ): Promise<ValidationDiagnostics | null> {
     // Only validate XML files (incl. .dbs data services, which are XML in the SynapseXml language).
     const lowerPath = absolutePath.toLowerCase();
@@ -140,7 +146,8 @@ export async function validateXmlFile(
         // Get diagnostics from language server
         const diagnosticsResponse = await langClient.getCodeDiagnostics({
             fileName: absolutePath,
-            code: fileContent
+            code: fileContent,
+            skipCrossFileValidation
         });
 
         const lspDiagnostics = diagnosticsResponse.diagnostics || [];

--- a/workspaces/mi/mi-extension/src/ai-features/auth.ts
+++ b/workspaces/mi/mi-extension/src/ai-features/auth.ts
@@ -599,7 +599,7 @@ const validateBedrockRegion = (region: string): void => {
     if (region.startsWith('us-gov-') || region.startsWith('cn-')) {
         throw new Error(
             `AWS region "${region}" is not supported. The Anthropic models on Bedrock ` +
-            `(Haiku 4.5, Sonnet 4.6, Opus 4.7) are only available via the global. ` +
+            `(Haiku 4.5, Sonnet 4.6, Opus 4.8) are only available via the global. ` +
             `inference profile in the commercial AWS partition — GovCloud and China ` +
             `partitions are not supported. Use a commercial region like us-east-1 or eu-west-1.`
         );

--- a/workspaces/mi/mi-extension/src/ai-features/connection.ts
+++ b/workspaces/mi/mi-extension/src/ai-features/connection.ts
@@ -31,21 +31,21 @@ import { logInfo, logDebug, logError } from "./copilot/logger";
 
 export const ANTHROPIC_HAIKU_4_5 = "claude-haiku-4-5";
 export const ANTHROPIC_SONNET_4_6 = "claude-sonnet-4-6";
-export const ANTHROPIC_OPUS_4_7 = "claude-opus-4-7";
+export const ANTHROPIC_OPUS_4_8 = "claude-opus-4-8";
 // Backward-compatible alias for existing imports.
 export const ANTHROPIC_SONNET_4_5 = ANTHROPIC_SONNET_4_6;
 
 export type AnthropicModel =
     | typeof ANTHROPIC_HAIKU_4_5
     | typeof ANTHROPIC_SONNET_4_6
-    | typeof ANTHROPIC_OPUS_4_7;
+    | typeof ANTHROPIC_OPUS_4_8;
 
 // Bedrock inference-profile IDs (without the regional prefix).
 // Base IDs verified against `aws bedrock list-inference-profiles`.
 const BEDROCK_MODEL_MAP: Record<string, string> = {
     [ANTHROPIC_HAIKU_4_5]: "anthropic.claude-haiku-4-5-20251001-v1:0",
     [ANTHROPIC_SONNET_4_6]: "anthropic.claude-sonnet-4-6",
-    [ANTHROPIC_OPUS_4_7]: "anthropic.claude-opus-4-7",
+    [ANTHROPIC_OPUS_4_8]: "anthropic.claude-opus-4-8",
 };
 
 /**
@@ -372,7 +372,7 @@ export function resolveMainModelId(settings: { mainModelPreset: string; mainMode
     if (settings.mainModelCustomId) {
         return settings.mainModelCustomId;
     }
-    return settings.mainModelPreset === 'opus' ? ANTHROPIC_OPUS_4_7 : ANTHROPIC_SONNET_4_6;
+    return settings.mainModelPreset === 'opus' ? ANTHROPIC_OPUS_4_8 : ANTHROPIC_SONNET_4_6;
 }
 
 /**

--- a/workspaces/mi/mi-visualizer/src/views/AIPanel/component/MICopilotContext.tsx
+++ b/workspaces/mi/mi-visualizer/src/views/AIPanel/component/MICopilotContext.tsx
@@ -237,7 +237,7 @@ export function MICopilotContextProvider({ children }: MICopilotProviderProps) {
     });
 
     // Thinking mode state (persisted in localStorage per agent mode).
-    // Default ON: adaptive thinking + low effort + Opus 4.7 omitted-mode
+    // Default ON: adaptive thinking + low effort + Opus 4.8 omitted-mode
     // means it self-regulates and helps on multi-step reasoning. Users who
     // explicitly turned it OFF keep their preference.
     const THINKING_KEY_PREFIX = 'mi-agent-thinking-enabled';

--- a/workspaces/mi/mi-visualizer/src/views/AIPanel/component/SettingsPanel.tsx
+++ b/workspaces/mi/mi-visualizer/src/views/AIPanel/component/SettingsPanel.tsx
@@ -44,7 +44,7 @@ const TAVILY_AWS_MARKETPLACE_URL = 'https://aws.amazon.com/marketplace/pp/prodvi
 
 const MAIN_AGENT_OPTIONS: { value: MainModelPreset; label: string; model: string; description: string }[] = [
     { value: "sonnet", label: "Normal", model: "Claude Sonnet 4.6", description: "Balanced quality, speed, and quota usage for everyday requests." },
-    { value: "opus", label: "High", model: "Claude Opus 4.7", description: "Maximum reasoning capability for complex tasks. Higher quota usage." },
+    { value: "opus", label: "High", model: "Claude Opus 4.8", description: "Maximum reasoning capability for complex tasks. Higher quota usage." },
 ];
 
 const SUB_AGENT_OPTIONS: { value: SubModelPreset; label: string; model: string; description: string }[] = [


### PR DESCRIPTION
## Summary

Mirror of wso2/mi-vscode#1504 for the `release/mi-4.1.1` line of this repo (MI was removed from `main` here as part of the migration, so MI fixes land on `release/mi-4.1.1`).

Fixes the four classes of incorrect code reported in wso2/product-integrator#1640, all via the always-loaded **agent-mode** prompt/context guides, plus the Opus 4.7 → 4.8 main-agent model swap:

1. **Operator precedence**: Synapse's expression grammar makes `and`/`or` bind *tighter* than comparison operators, so `${a <= 0 or b > 10}` mis-parses (verified against the ANTLR grammar in `wso2/wso2-synapse`). Added a mandatory rule to parenthesize every comparison joined by `and`/`or`, fixed the contradictory precedence narrative in `synapse_expression_spec.ts`, and corrected all anti-pattern examples.
2. **Platform limitations**: added a scope rule telling the agent to state what MI cannot do instead of fabricating invalid code.
3. **Connector syntax**: added a hard rule to never write a connector operation's XML without first calling `get_connector_info mode='details'`, reinforced in `connectors_guide.ts`.
4. **Uninitialized variables**: added a declare-before-use rule plus a WRONG/CORRECT example.

Also includes the cross-file validation deferral (opt-in `skipCrossFileValidation` flag on `synapse/codeDiagnostic`, set by `file_write`/`file_edit` per-file auto-validation; `validate_code` leaves it off) and the `claude-opus-4-7` → `claude-opus-4-8` main-agent preset swap (direct + Bedrock inference profile, UI label, comments).

The net change set is identical to wso2/mi-vscode#1504 (paths remapped from `packages/` to `workspaces/mi/`).

Refs: https://github.com/wso2/product-integrator/issues/1640
Mirrors: https://github.com/wso2/mi-vscode/pull/1504