### PR TITLE
Add support to the binds-to attribute in APIs

### DIFF
--- a/workspaces/mi/mi-core/src/rpc-types/mi-diagram/types.ts
+++ b/workspaces/mi/mi-core/src/rpc-types/mi-diagram/types.ts
@@ -1438,11 +1438,14 @@ export type ResourceType =
     | "xslt"
     | "yaml"
     | "crt"
-    | "registry";
+    | "registry"
+    | "bindToInbound"
+    | "inbound-endpoint";
 
 export interface MultipleResourceType {
     type: ResourceType;
     needRegistry?: boolean;
+    protocols?: string[];
 }
 
 export interface GetAvailableResourcesRequest {

--- a/workspaces/mi/mi-diagram/src/components/Form/Keylookup/Keylookup.tsx
+++ b/workspaces/mi/mi-diagram/src/components/Form/Keylookup/Keylookup.tsx
@@ -57,6 +57,7 @@ export type FilterType =
     | "dssQuery"
     | "dssDataSource"
     | "configurable"
+    | "bindToInbound"
 
 // Interfaces
 interface IKeylookupBase {
@@ -270,7 +271,9 @@ export const Keylookup = (props: IKeylookup) => {
         }
 
         let resourceType: ResourceType | MultipleResourceType[];
-        if (Array.isArray(filterType)) {
+        if (filterType === "bindToInbound") {
+            resourceType = [{ type: "inbound-endpoint", protocols: ["http", "https", "ws", "wss"] }];
+        } else if (Array.isArray(filterType)) {
             resourceType = filterType.map((type) => {
                 return { type: type }
             });
@@ -289,7 +292,8 @@ export const Keylookup = (props: IKeylookup) => {
         const resources = artifactTypes.artifacts;
         if (resources && result?.resources) {
             result.resources.forEach((resource) => {
-                const item = { key: resource.name, item: getItemComponent(resource.name, resource.type), path: resource.absolutePath };
+                const displayType = filterType === "bindToInbound" ? "inbound-endpoint" : resource.type;
+                const item = { key: resource.name, item: getItemComponent(resource.name, displayType), path: resource.absolutePath };
                 if (resource.name === getValue(value)) {
                     initialItem = item;
                     return;

--- a/workspaces/mi/mi-visualizer/src/utils/form.ts
+++ b/workspaces/mi/mi-visualizer/src/utils/form.ts
@@ -24,6 +24,18 @@ import { EditProxyForm } from "../views/Forms/EditForms/EditProxyForm";
 import { XMLBuilder, XMLParser } from "fast-xml-parser";
 import { Method, Protocol, ResourceFormData, ResourceType } from "../views/Forms/ResourceForm";
 
+export const bindsToToList = (bindsTo?: string): string[] =>
+    bindsTo ? bindsTo.split(",").map((s) => s.trim()).filter(Boolean) : [];
+
+export const getApiBindsToOptions = async (rpcClient: RpcClient, documentUri: string): Promise<string[]> => {
+    try {
+        const st = await rpcClient.getMiDiagramRpcClient().getSyntaxTree({ documentUri });
+        return bindsToToList((st as any)?.syntaxTree?.api?.bindsTo);
+    } catch {
+        return [];
+    }
+};
+
 /**
  * Functions to generate data for forms
  */
@@ -64,6 +76,7 @@ export const generateResourceData = (model: APIResource): ResourceType => {
         outSequence: model.outSequenceAttribute,
         faultSequenceType: model.faultSequenceAttribute ? "named" : "inline",
         faultSequence: model.faultSequenceAttribute,
+        bindsTo: model.bindsTo,
     };
 
     return resourceData;
@@ -134,7 +147,7 @@ const inlineFormatter = (inlineWsdl: string) => {
  */
 
 export const onResourceCreate = (data: ResourceFormData, range: Range, documentUri: string, rpcClient: RpcClient) => {
-    const { uriTemplate, urlMapping, methods, protocol } = data;
+    const { uriTemplate, urlMapping, methods, protocol, bindsTo } = data;
     const formValues = {
         // Extract selected methods and create string containing the methods for the XML
         methods: Object.keys(methods)
@@ -147,6 +160,7 @@ export const onResourceCreate = (data: ResourceFormData, range: Range, documentU
             : Object.keys(protocol).find((key) => protocol[key as keyof typeof protocol]),
         uri_template: uriTemplate,
         url_mapping: urlMapping,
+        binds_to: bindsTo,
     };
 
     const xml = getXML(ARTIFACT_TEMPLATES.ADD_RESOURCE, formValues);
@@ -193,6 +207,7 @@ export const onResourceEdit = (
         faultSequence,
         faultSequenceType,
         isFaultSequenceDirty,
+        bindsTo,
     } = data;
     const formValues = {
         methods: Object.keys(methods)
@@ -212,7 +227,8 @@ export const onResourceEdit = (
         fault_sequence: faultSequence,
         appened_in_sequence: isInSequenceDirty && inSequenceType === "inline" ? true : false,
         appened_out_sequence: isOutSequenceDirty && outSequenceType === "inline" ? true : false,
-        appened_fault_sequence: isFaultSequenceDirty && faultSequenceType === "inline" ? true : false
+        appened_fault_sequence: isFaultSequenceDirty && faultSequenceType === "inline" ? true : false,
+        binds_to: bindsTo,
     };
 
     const xml = getXML(ARTIFACT_TEMPLATES.EDIT_RESOURCE, formValues);

--- a/workspaces/mi/mi-visualizer/src/utils/template-engine/mustache-templates/core/api.ts
+++ b/workspaces/mi/mi-visualizer/src/utils/template-engine/mustache-templates/core/api.ts
@@ -29,7 +29,7 @@ export function getAddAPITemplate() {
 }
 
 export function getEditAPITemplate() {
-    return `<api{{#hostName}} hostname="{{hostName}}"{{/hostName}} name="{{name}}"{{#port}} port="{{port}}"{{/port}}{{#statistics}} statistics="enable"{{/statistics}}{{#trace}} trace="enable"{{/trace}} context="{{context}}"{{#swaggerDef}} publishSwagger="{{swaggerDef}}"{{/swaggerDef}}{{#version}} version="{{version}}" version-type="{{version_type}}"{{/version}} xmlns="http://ws.apache.org/ns/synapse">`
+    return `<api{{#hostName}} hostname="{{hostName}}"{{/hostName}} name="{{name}}"{{#port}} port="{{port}}"{{/port}}{{#statistics}} statistics="enable"{{/statistics}}{{#trace}} trace="enable"{{/trace}} context="{{context}}"{{#swaggerDef}} publishSwagger="{{swaggerDef}}"{{/swaggerDef}}{{#version}} version="{{version}}" version-type="{{version_type}}"{{/version}}{{#bindsTo}} binds-to="{{bindsTo}}"{{/bindsTo}} xmlns="http://ws.apache.org/ns/synapse">`
 }
 
 export function getHandlersTemplate() {
@@ -41,7 +41,7 @@ export function getHandlersTemplate() {
 };
 
 export function getAddAPIResourceTemplate() {
-    return `<resource methods="{{methods}}"{{#protocol}} protocol="{{protocol}}"{{/protocol}}{{#uri_template}} uri-template="{{uri_template}}"{{/uri_template}}{{#url_mapping}} url-mapping="{{url_mapping}}"{{/url_mapping}}{{#version}} version="{{version}}" version-type="{{version_type}}"{{/version}}>
+    return `<resource methods="{{methods}}"{{#protocol}} protocol="{{protocol}}"{{/protocol}}{{#uri_template}} uri-template="{{uri_template}}"{{/uri_template}}{{#url_mapping}} url-mapping="{{url_mapping}}"{{/url_mapping}}{{#version}} version="{{version}}" version-type="{{version_type}}"{{/version}}{{#binds_to}} binds-to="{{binds_to}}"{{/binds_to}}>
     <inSequence>
     </inSequence>
     <faultSequence>
@@ -50,7 +50,7 @@ export function getAddAPIResourceTemplate() {
 }
 
 export const getEditAPIResourceTemplate = () => {
-    return `<resource methods="{{methods}}"{{#protocol}} protocol="{{protocol}}"{{/protocol}}{{#uri_template}} uri-template="{{uri_template}}"{{/uri_template}}{{#url_mapping}} url-mapping="{{url_mapping}}"{{/url_mapping}}{{#in_sequence}} inSequence="{{in_sequence}}"{{/in_sequence}}{{#out_sequence}} outSequence="{{out_sequence}}"{{/out_sequence}}{{#fault_sequence}} faultSequence="{{fault_sequence}}"{{/fault_sequence}}>{{#appened_in_sequence}}
+    return `<resource methods="{{methods}}"{{#protocol}} protocol="{{protocol}}"{{/protocol}}{{#uri_template}} uri-template="{{uri_template}}"{{/uri_template}}{{#url_mapping}} url-mapping="{{url_mapping}}"{{/url_mapping}}{{#in_sequence}} inSequence="{{in_sequence}}"{{/in_sequence}}{{#out_sequence}} outSequence="{{out_sequence}}"{{/out_sequence}}{{#fault_sequence}} faultSequence="{{fault_sequence}}"{{/fault_sequence}}{{#binds_to}} binds-to="{{binds_to}}"{{/binds_to}}>{{#appened_in_sequence}}
     <inSequence>
     </inSequence>{{/appened_in_sequence}}{{#appened_fault_sequence}}
     <faultSequence>

--- a/workspaces/mi/mi-visualizer/src/views/Diagram/Resource.tsx
+++ b/workspaces/mi/mi-visualizer/src/views/Diagram/Resource.tsx
@@ -15,7 +15,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React from "react";
+import React, { useEffect } from "react";
 import { Diagnostic } from "vscode-languageserver-types";
 import { APIResource, Range } from "@wso2/mi-syntax-tree/lib/src";
 import { Diagram } from "@wso2/mi-diagram";
@@ -24,7 +24,7 @@ import { useVisualizerContext } from "@wso2/mi-rpc-client";
 import { VSCodeTag } from "@vscode/webview-ui-toolkit/react";
 import { getColorByMethod } from "@wso2/service-designer";
 import { View, ViewContent, ViewHeader } from "../../components/View";
-import { generateResourceData, getResourceDeleteRanges, onResourceEdit } from "../../utils/form";
+import { generateResourceData, getApiBindsToOptions, getResourceDeleteRanges, onResourceEdit } from "../../utils/form";
 import styled from "@emotion/styled";
 import { ResourceForm, ResourceFormData, ResourceType } from "../Forms/ResourceForm";
 
@@ -52,6 +52,13 @@ export const ResourceView = ({ model: resourceModel, documentUri, diagnostics }:
     const flowStateKey = `flowState-${documentUri}-${model.uriTemplate || model.urlMapping}`;
     const [isFaultFlow, setFlow] = React.useState<boolean>(localStorage.getItem(flowStateKey) === 'true' ? true : false);
     const [isFormOpen, setFormOpen] = React.useState(false);
+    const [bindsToOptions, setBindsToOptions] = React.useState<string[]>([]);
+
+    useEffect(() => {
+        (async () => {
+            setBindsToOptions(await getApiBindsToOptions(rpcClient, documentUri));
+        })();
+    }, [documentUri]);
 
     const toggleFlow = () => {
         const newFlowState = !isFaultFlow;
@@ -60,7 +67,6 @@ export const ResourceView = ({ model: resourceModel, documentUri, diagnostics }:
     };
 
     const handleEditResource = () => {
-        console.log(model);
         setFormOpen(true);
     }
 
@@ -108,6 +114,7 @@ export const ResourceView = ({ model: resourceModel, documentUri, diagnostics }:
                     isOpen={isFormOpen}
                     formData={data}
                     documentUri={documentUri}
+                    bindsToOptions={bindsToOptions}
                     onCancel={() => setFormOpen(false)}
                     onSave={onSave}
                 />

--- a/workspaces/mi/mi-visualizer/src/views/Forms/APIform/index.tsx
+++ b/workspaces/mi/mi-visualizer/src/views/Forms/APIform/index.tsx
@@ -30,7 +30,7 @@ import { yupResolver } from "@hookform/resolvers/yup"
 import * as yup from "yup";
 import { useForm } from "react-hook-form";
 import * as pathLib from "path";
-import { FormKeylookup } from "@wso2/mi-diagram";
+import { FormKeylookup, ParamManager, ParamConfig, ParamField } from "@wso2/mi-diagram";
 import { compareVersions } from "@wso2/mi-diagram/lib/utils/commons";
 
 const TitleBar = styled.div({
@@ -70,6 +70,7 @@ export interface CORSSettings {
 export interface APIData {
     apiName: string;
     apiContext: string;
+    bindsTo?: string;
     hostName?: string;
     port?: string;
     trace?: boolean;
@@ -91,6 +92,7 @@ export interface APIData {
 const initialAPI: APIData = {
     apiName: "",
     apiContext: "",
+    bindsTo: "",
     hostName: "",
     port: "",
     trace: false,
@@ -116,6 +118,35 @@ const initialAPI: APIData = {
     }
 };
 
+const BINDS_TO_PARAM_FIELDS: ParamField[] = [
+    {
+        id: 0,
+        type: "KeyLookup",
+        label: "Inbound Endpoint",
+        filterType: "bindToInbound",
+        isRequired: true,
+    },
+];
+
+const bindsToToParamConfig = (bindsTo?: string): ParamConfig => ({
+    paramFields: BINDS_TO_PARAM_FIELDS,
+    paramValues: (bindsTo ? bindsTo.split(",") : [])
+        .map((value) => value.trim())
+        .filter(Boolean)
+        .map((value, index) => ({
+            id: index,
+            paramValues: [{ value }],
+            key: String(index + 1),
+            value,
+        })),
+});
+
+const paramConfigToBindsTo = (config: ParamConfig): string =>
+    config.paramValues
+        .map((param) => (param.paramValues[0]?.value as string)?.trim())
+        .filter(Boolean)
+        .join(",");
+
 export interface APIWizardProps {
     apiData?: APIData;
     path: string;
@@ -132,6 +163,7 @@ export function APIWizard({ apiData, path }: APIWizardProps) {
     const [runtimeVersion, setRuntimeVersion] = useState<string | null>(null);
     const [apiCreationError, setApiCreationError] = useState<string | null>(null);
     const [isCreating, setIsCreating] = useState(false);
+    const [bindsToParams, setBindsToParams] = useState<ParamConfig>(bindsToToParamConfig(""));
 
     const schema = yup.object({
         apiName: yup.string().required("API Name is required").matches(/^[^@\\^+;:!%&,=*#[\]$?'"<>{}() /]*$/, "Invalid characters in name")
@@ -150,6 +182,7 @@ export function APIWizard({ apiData, path }: APIWizardProps) {
                 const { versionType } = this.parent;
                 return versionType !== "none" || !APIContexts.includes(value);
             }),
+        bindsTo: yup.string(),
         hostName: yup.string(),
         port: yup.string(),
         trace: yup.boolean(),
@@ -320,10 +353,24 @@ export function APIWizard({ apiData, path }: APIWizardProps) {
             setValue("versionType", versionType);
             setValue("handlers", filteredHandlers);
             setValue("corsSettings", corsSettings);
+            setBindsToParams(bindsToToParamConfig(apiData.bindsTo));
         } else {
             reset(initialAPI);
+            setBindsToParams(bindsToToParamConfig(""));
         }
     }, [apiData]);
+
+    const handleBindsToChange = (config: ParamConfig) => {
+        const normalized: ParamConfig = {
+            ...config,
+            paramValues: config.paramValues.map((param, index) => {
+                const value = (param.paramValues[0]?.value as string) ?? "";
+                return { ...param, id: index, key: String(index + 1), value };
+            }),
+        };
+        setBindsToParams(normalized);
+        setValue("bindsTo", paramConfigToBindsTo(normalized), { shouldValidate: true, shouldDirty: true });
+    };
 
     useEffect(() => {
         (async () => {
@@ -461,6 +508,7 @@ export function APIWizard({ apiData, path }: APIWizardProps) {
                 port: values.port === "0" ? undefined : values.port,
                 trace: values.trace ? "enable" : undefined,
                 statistics: values.statistics ? "enable" : undefined,
+                bindsTo: values.bindsTo,
             }
             const xml = getXML(ARTIFACT_TEMPLATES.EDIT_API, formValues);
             // Combine regular handlers with CORS handler if enabled and version supports it
@@ -737,6 +785,14 @@ export function APIWizard({ apiData, path }: APIWizardProps) {
                                 />
                             ))}
                         </FieldGroup>
+                    </FormGroup>
+                    <FormGroup title="Bindings" isCollapsed={true}>
+                        <ParamManager
+                            paramConfigs={bindsToParams}
+                            onChange={handleBindsToChange}
+                            addParamText="Add Inbound Endpoint"
+                            allowDuplicates={false}
+                        />
                     </FormGroup>
                 </>
             )}

--- a/workspaces/mi/mi-visualizer/src/views/Forms/ResourceForm.tsx
+++ b/workspaces/mi/mi-visualizer/src/views/Forms/ResourceForm.tsx
@@ -36,7 +36,7 @@ import styled from "@emotion/styled";
 import { SIDE_PANEL_WIDTH } from "../../constants";
 import { Resolver, useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
-import { FormKeylookup } from "@wso2/mi-diagram";
+import { FormKeylookup, ParamManager, ParamConfig, ParamField } from "@wso2/mi-diagram";
 
 // Styles
 const ActionContainer = styled.div`
@@ -115,6 +115,7 @@ const schema = yup.object({
         then: (schema) => schema.required("Fault Sequence is required"),
         otherwise: (schema) => schema.transform(() => undefined),
     }),
+    bindsTo: yup.string(),
 });
 
 // Types
@@ -131,6 +132,7 @@ type ResourceFormProps = {
     formData?: ResourceType;
     isOpen: boolean;
     documentUri: string;
+    bindsToOptions?: string[];
     onCancel: () => void;
     onSave: (data: ResourceFormData) => void;
 };
@@ -163,9 +165,41 @@ const initialValues: ResourceType = {
     outSequence: "",
     faultSequenceType: "inline",
     faultSequence: "",
+    bindsTo: "",
 };
 
-export const ResourceForm = ({ isOpen, documentUri, onCancel, onSave, formData }: ResourceFormProps) => {
+const paramConfigToBindsTo = (config: ParamConfig): string =>
+    config.paramValues
+        .map((param) => (param.paramValues[0]?.value as string)?.trim())
+        .filter(Boolean)
+        .join(",");
+
+const bindsToToParamConfig = (bindsTo: string, options: string[]): ParamConfig => {
+    const paramFields: ParamField[] = [
+        {
+            id: 0,
+            type: "AutoComplete",
+            label: "Inbound Endpoint",
+            values: options,
+            isRequired: true,
+            allowItemCreate: false,
+        },
+    ];
+    return {
+        paramFields,
+        paramValues: (bindsTo ? bindsTo.split(",") : [])
+            .map((value) => value.trim())
+            .filter(Boolean)
+            .map((value, index) => ({
+                id: index,
+                paramValues: [{ value }],
+                key: String(index + 1),
+                value,
+            })),
+    };
+};
+
+export const ResourceForm = ({ isOpen, documentUri, onCancel, onSave, formData, bindsToOptions = [] }: ResourceFormProps) => {
     const {
         control,
         handleSubmit,
@@ -189,6 +223,19 @@ export const ResourceForm = ({ isOpen, documentUri, onCancel, onSave, formData }
     const [isHidden, setIsHidden] = useState(false);
     const [paramType, setParamType] = useState("");
     const [paramValue, setParamValue] = useState("");
+    const [bindsToParams, setBindsToParams] = useState<ParamConfig>(bindsToToParamConfig("", bindsToOptions));
+
+    const handleBindsToChange = (config: ParamConfig) => {
+        const normalized: ParamConfig = {
+            ...config,
+            paramValues: config.paramValues.map((param, index) => {
+                const value = (param.paramValues[0]?.value as string) ?? "";
+                return { ...param, id: index, key: String(index + 1), value };
+            }),
+        };
+        setBindsToParams(normalized);
+        setValue("bindsTo", paramConfigToBindsTo(normalized), { shouldValidate: true, shouldDirty: true });
+    };
 
     // Functions
     const handleCancel = () => {
@@ -254,13 +301,16 @@ export const ResourceForm = ({ isOpen, documentUri, onCancel, onSave, formData }
     };
 
     // useEffects
+    const bindsToOptionsKey = bindsToOptions.join(",");
     useEffect(() => {
         if (isOpen && formData) {
             reset(formData);
+            setBindsToParams(bindsToToParamConfig(formData.bindsTo ?? "", bindsToOptions));
         } else if (isOpen && !formData) {
             reset(initialValues);
+            setBindsToParams(bindsToToParamConfig("", bindsToOptions));
         }
-    }, [formData, isOpen])
+    }, [formData, isOpen, bindsToOptionsKey])
 
     return (
         <SidePanel
@@ -415,6 +465,29 @@ export const ResourceForm = ({ isOpen, documentUri, onCancel, onSave, formData }
                                                     />
                                                 )}
                                             </>
+                                        )}
+                                        {bindsToOptions.length > 0 && (
+                                            <CheckBoxContainer>
+                                                <label>Bindings</label>
+                                                <ParamManager
+                                                    paramConfigs={{
+                                                        ...bindsToParams,
+                                                        paramFields: [
+                                                            {
+                                                                id: 0,
+                                                                type: "AutoComplete",
+                                                                label: "Inbound Endpoint",
+                                                                values: bindsToOptions,
+                                                                isRequired: true,
+                                                                allowItemCreate: false,
+                                                            },
+                                                        ],
+                                                    }}
+                                                    onChange={handleBindsToChange}
+                                                    addParamText="Add Inbound Endpoint"
+                                                    allowDuplicates={false}
+                                                />
+                                            </CheckBoxContainer>
                                         )}
                                     </React.Fragment>
                                 </FormGroup>

--- a/workspaces/mi/mi-visualizer/src/views/ServiceDesigner/index.tsx
+++ b/workspaces/mi/mi-visualizer/src/views/ServiceDesigner/index.tsx
@@ -108,6 +108,7 @@ export function ServiceDesignerView({ syntaxTree, documentUri }: ServiceDesigner
         const serviceData: APIData = {
             apiName: st.name,
             apiContext: st.context,
+            bindsTo: st.bindsTo ?? '',
             version: st.version,
             hostName: st.hostname ?? '',
             port: st.port ?? '0',
@@ -322,6 +323,7 @@ export function ServiceDesignerView({ syntaxTree, documentUri }: ServiceDesigner
                 formData={mode === "edit" && formData}
                 onCancel={handleCancel}
                 documentUri={documentUri}
+                bindsToOptions={serviceData?.bindsTo ? serviceData.bindsTo.split(",").map((s) => s.trim()).filter(Boolean) : []}
                 onSave={handleResourceCreate}
             />
         </>

--- a/workspaces/mi/syntax-tree/src/syntax-tree-interfaces.ts
+++ b/workspaces/mi/syntax-tree/src/syntax-tree-interfaces.ts
@@ -683,6 +683,7 @@ export interface API extends STNode {
     description: string;
     statistics: string;
     trace: string;
+    bindsTo?: string;
 }
 
 export interface WSDLEndpointMarkForSuspension extends STNode {
@@ -1154,6 +1155,7 @@ export interface APIResource extends STNode {
     faultSequenceAttribute: string;
     uriTemplate: string;
     urlMapping: string;
+    bindsTo: string;
 }
 
 export interface DSSResource extends STNode {


### PR DESCRIPTION
This PR will fix the issue https://github.com/wso2/mi-vscode/issues/1512

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for inbound endpoint bindings in API and resource forms.
  * You can now select and edit binding targets through a new “Bindings” section.
  * Inbound endpoint resources are now shown as a distinct resource type in relevant pickers.

* **Bug Fixes**
  * Improved handling of binding data when loading, editing, and saving resources.
  * Binding values now carry through consistently across create/edit workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->