### PR TITLE
Lock model switching on WSO2 plan and surface proxy error messages

### DIFF
--- a/workspaces/mi/mi-extension/src/ai-features/agent-mode/agents/main/agent.ts
+++ b/workspaces/mi/mi-extension/src/ai-features/agent-mode/agents/main/agent.ts
@@ -30,7 +30,7 @@ const NATIVE_COMPACTION_TRIGGER_TOKENS = 200000;
 
 import { ModelMessage, streamText, stepCountIs, UserModelMessage, SystemModelMessage, wrapLanguageModel } from 'ai';
 import { AnthropicProviderOptions } from '@ai-sdk/anthropic';
-import { getAnthropicClient, getAnthropicClientForCustomModel, getAnthropicProvider, AnthropicModel, resolveMainModelId } from '../../../connection';
+import { getAnthropicClient, getAnthropicClientForCustomModel, getAnthropicProvider, AnthropicModel, resolveMainModelId, ANTHROPIC_OPUS_4_8, ANTHROPIC_SONNET_4_6 } from '../../../connection';
 import { getLoginMethod, getTavilyApiKey } from '../../../auth';
 import { getSystemPrompt } from '../main/system';
 import {
@@ -88,6 +88,7 @@ import {
     DEFAULT_STREAM_TOTAL_TIMEOUT_MS,
     getErrorDiagnostics,
     getErrorMessage,
+    getDisplayErrorMessage,
     isProxyTerminatedStreamError,
     isStreamTimeoutError,
     StreamWatchdog,
@@ -774,7 +775,19 @@ export async function executeAgent(
         let currentStepNumber = 0;
 
         // Get the model for prepareStep — resolve from model settings or default to Sonnet
-        const mainModelId = resolveMainModelId(request.modelSettings || { mainModelPreset: 'sonnet' });
+        let mainModelId = resolveMainModelId(request.modelSettings || { mainModelPreset: 'sonnet' });
+        // The WSO2 MI Copilot proxy blocks Opus models. If a stale 'opus' preset survives
+        // (e.g. carried over from a prior BYOK session), clamp the main agent to Sonnet so
+        // MI_INTEL requests don't 400 on every turn. Custom model IDs are left untouched —
+        // those surface the proxy error so the user can correct their override.
+        if (
+            loginMethod === LoginMethod.MI_INTEL &&
+            !request.modelSettings?.mainModelCustomId &&
+            mainModelId === ANTHROPIC_OPUS_4_8
+        ) {
+            logInfo('[Agent] MI_INTEL login: Opus is not available on the WSO2 plan — using Sonnet for the main agent.');
+            mainModelId = ANTHROPIC_SONNET_4_6;
+        }
         let model = request.modelSettings?.mainModelCustomId
             ? await getAnthropicClientForCustomModel(mainModelId)
             : await getAnthropicClient(mainModelId as AnthropicModel);
@@ -1335,7 +1348,9 @@ export async function executeAgent(
 
                 case 'error': {
                     cleanupStreamLifecycle?.();
-                    const errorMsg = getErrorMessage(part.error);
+                    // Surface the upstream provider/proxy message (e.g. a blocked-model
+                    // 400) rather than the SDK's generic status text.
+                    const errorMsg = getDisplayErrorMessage(part.error);
                     logError(`[Agent] Stream error: ${errorMsg}`);
                     // Structured diagnostics only — getErrorDiagnostics whitelists/truncates
                     // the safe provider fields. A raw JSON dump would re-introduce the leak
@@ -1460,6 +1475,10 @@ export async function executeAgent(
             requestAbortSignalAborted: request.abortSignal?.aborted || false,
         });
         const errorMsg = classifiedError.rawMessage;
+        // User-facing message: prefers the upstream provider/proxy detail (e.g. a
+        // blocked-model 400 body) over the SDK's generic status text. rawMessage is
+        // kept for classification/logging above.
+        const displayError = getDisplayErrorMessage(error);
 
         // Try to capture partial model messages even on error
         try {
@@ -1532,8 +1551,8 @@ export async function executeAgent(
             case 'model_error': {
                 const isCustomModel = !!request.modelSettings?.mainModelCustomId;
                 const modelErrorMessage = isCustomModel
-                    ? `Invalid model ID '${request.modelSettings!.mainModelCustomId}'. Check your model settings and try again.`
-                    : `The model used by this extension may be outdated or unavailable. Please update the WSO2 MI Extension to the latest version to get updated model support. (Error: ${errorMsg})`;
+                    ? `Invalid model ID '${request.modelSettings!.mainModelCustomId}'. Check your model settings and try again. (${displayError})`
+                    : `The model used by this extension may be outdated or unavailable. Please update the WSO2 MI Extension to the latest version to get updated model support. (Error: ${displayError})`;
                 logError(`[Agent] Model error (custom=${isCustomModel}): ${errorMsg}`, error);
                 emitEvent({ type: 'error', error: modelErrorMessage });
                 return {
@@ -1551,12 +1570,12 @@ export async function executeAgent(
 
                 emitEvent({
                     type: 'error',
-                    error: errorMsg,
+                    error: displayError,
                 });
                 return {
                     success: false,
                     modifiedFiles,
-                    error: errorMsg,
+                    error: displayError,
                     modelMessages: finalModelMessages,
                 };
         }

--- a/workspaces/mi/mi-extension/src/ai-features/agent-mode/agents/main/agent.ts
+++ b/workspaces/mi/mi-extension/src/ai-features/agent-mode/agents/main/agent.ts
@@ -1476,9 +1476,11 @@ export async function executeAgent(
         });
         const errorMsg = classifiedError.rawMessage;
         // User-facing message: prefers the upstream provider/proxy detail (e.g. a
-        // blocked-model 400 body) over the SDK's generic status text. rawMessage is
-        // kept for classification/logging above.
-        const displayError = getDisplayErrorMessage(error);
+        // blocked-model 400 body) over the SDK's generic status text. When the
+        // watchdog aborted the stream, the caught error is a generic abort wrapper
+        // while abortReason holds the original (body-bearing) error, so prefer it.
+        // rawMessage is kept for classification/logging above.
+        const displayError = getDisplayErrorMessage(abortReason ?? error);
 
         // Try to capture partial model messages even on error
         try {

--- a/workspaces/mi/mi-extension/src/ai-features/agent-mode/stream_guard.ts
+++ b/workspaces/mi/mi-extension/src/ai-features/agent-mode/stream_guard.ts
@@ -126,6 +126,47 @@ function pickProviderMessage(obj: Record<string, unknown>): string | undefined {
  * detail (e.g. "Opus models are not available on this plan") only lives in
  * `responseBody`. We look there so it can be surfaced to the user.
  */
+// Oversized bodies are unlikely to be well-formed provider envelopes and
+// JSON.parse-ing them on an already-failing path isn't worth the cost, so we
+// only attempt structured parsing below this threshold and surface shorter
+// plain-text bodies as-is.
+const MAX_PARSEABLE_BODY_LENGTH = 8000;
+const MAX_PLAINTEXT_BODY_LENGTH = 500;
+
+/**
+ * Extract a provider message from a raw body string. The string may be a JSON
+ * envelope, a JSON-quoted string, or plain text.
+ */
+function extractProviderErrorMessageFromBody(body: string): string | undefined {
+    const trimmed = body.trim();
+    if (!trimmed) {
+        return undefined;
+    }
+    if (trimmed.length <= MAX_PARSEABLE_BODY_LENGTH) {
+        try {
+            const parsed = JSON.parse(trimmed);
+            // A JSON-quoted string (e.g. "Opus is not available") parses to a string.
+            if (typeof parsed === 'string' && parsed.trim()) {
+                return parsed.trim();
+            }
+            if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+                const fromBody = pickProviderMessage(parsed as Record<string, unknown>);
+                if (fromBody) {
+                    return fromBody;
+                }
+            }
+            return undefined;
+        } catch {
+            // Fall through to plain-text handling below.
+        }
+    }
+    // Non-JSON (or oversized) body — surface short plain-text bodies as-is.
+    if (trimmed.length <= MAX_PLAINTEXT_BODY_LENGTH) {
+        return trimmed;
+    }
+    return undefined;
+}
+
 function extractProviderErrorMessageFrom(error: unknown): string | undefined {
     if (!error || typeof error !== 'object') {
         return undefined;
@@ -136,22 +177,17 @@ function extractProviderErrorMessageFrom(error: unknown): string | undefined {
         if (fromData) {
             return fromData;
         }
+    } else if (typeof r.data === 'string') {
+        // The AI SDK can surface APICallError.data as a raw string.
+        const fromData = extractProviderErrorMessageFromBody(r.data);
+        if (fromData) {
+            return fromData;
+        }
     }
-    if (typeof r.responseBody === 'string' && r.responseBody.trim()) {
-        const body = r.responseBody.trim();
-        try {
-            const parsed = JSON.parse(body);
-            if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-                const fromBody = pickProviderMessage(parsed as Record<string, unknown>);
-                if (fromBody) {
-                    return fromBody;
-                }
-            }
-        } catch {
-            // Non-JSON body — surface short plain-text bodies as-is.
-            if (body.length <= 500) {
-                return body;
-            }
+    if (typeof r.responseBody === 'string') {
+        const fromBody = extractProviderErrorMessageFromBody(r.responseBody);
+        if (fromBody) {
+            return fromBody;
         }
     }
     return undefined;

--- a/workspaces/mi/mi-extension/src/ai-features/agent-mode/stream_guard.ts
+++ b/workspaces/mi/mi-extension/src/ai-features/agent-mode/stream_guard.ts
@@ -83,6 +83,119 @@ export function getErrorMessage(error: unknown): string {
     return 'An unknown error occurred';
 }
 
+/**
+ * Pull a human-readable message out of a provider/proxy error body. Handles the
+ * common JSON envelopes:
+ *   { error: { message } }              (Anthropic / OpenAI style)
+ *   { error: "..." }                    (string error)
+ *   { message }                         (bare message)
+ *   { detail } / { detail: { message } } (FastAPI / proxy style)
+ */
+function pickProviderMessage(obj: Record<string, unknown>): string | undefined {
+    const err = obj.error;
+    if (err && typeof err === 'object' && typeof (err as { message?: unknown }).message === 'string') {
+        const msg = (err as { message: string }).message.trim();
+        if (msg) {
+            return msg;
+        }
+    }
+    if (typeof err === 'string' && err.trim()) {
+        return err.trim();
+    }
+    if (typeof obj.message === 'string' && obj.message.trim()) {
+        return obj.message.trim();
+    }
+    const detail = obj.detail;
+    if (typeof detail === 'string' && detail.trim()) {
+        return detail.trim();
+    }
+    if (detail && typeof detail === 'object' && typeof (detail as { message?: unknown }).message === 'string') {
+        const msg = (detail as { message: string }).message.trim();
+        if (msg) {
+            return msg;
+        }
+    }
+    return undefined;
+}
+
+/**
+ * Best-effort extraction of the message the upstream provider/proxy actually sent.
+ * The Vercel AI SDK's APICallError stores the parsed body in `data` and the raw
+ * body in `responseBody`; when the body doesn't match the provider's error schema
+ * the SDK falls back to the bare HTTP status text for `.message`, so actionable
+ * detail (e.g. "Opus models are not available on this plan") only lives in
+ * `responseBody`. We look there so it can be surfaced to the user.
+ */
+function extractProviderErrorMessageFrom(error: unknown): string | undefined {
+    if (!error || typeof error !== 'object') {
+        return undefined;
+    }
+    const r = error as Record<string, unknown>;
+    if (r.data && typeof r.data === 'object') {
+        const fromData = pickProviderMessage(r.data as Record<string, unknown>);
+        if (fromData) {
+            return fromData;
+        }
+    }
+    if (typeof r.responseBody === 'string' && r.responseBody.trim()) {
+        const body = r.responseBody.trim();
+        try {
+            const parsed = JSON.parse(body);
+            if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+                const fromBody = pickProviderMessage(parsed as Record<string, unknown>);
+                if (fromBody) {
+                    return fromBody;
+                }
+            }
+        } catch {
+            // Non-JSON body — surface short plain-text bodies as-is.
+            if (body.length <= 500) {
+                return body;
+            }
+        }
+    }
+    return undefined;
+}
+
+/**
+ * The AI SDK sometimes wraps the provider's APICallError, so the body-bearing
+ * error can sit on `.cause`. Walk a couple of levels of the cause chain.
+ */
+function extractProviderErrorMessage(error: unknown): string | undefined {
+    let current: unknown = error;
+    for (let depth = 0; depth < 3 && current && typeof current === 'object'; depth++) {
+        const found = extractProviderErrorMessageFrom(current);
+        if (found) {
+            return found;
+        }
+        current = (current as { cause?: unknown }).cause;
+    }
+    return undefined;
+}
+
+const MAX_DISPLAY_ERROR_LENGTH = 1000;
+
+/**
+ * Build the user-facing error string for the chat error card. Prefers the
+ * upstream provider/proxy message (which carries actionable detail such as a
+ * blocked-model notice) over the SDK's generic status text, falling back to the
+ * plain error message when no richer detail is available.
+ */
+export function getDisplayErrorMessage(error: unknown): string {
+    const base = getErrorMessage(error).trim();
+    const provider = extractProviderErrorMessage(error)?.trim();
+    let message = base;
+    // base is often just "Bad Request"/"Forbidden"; prefer the provider detail
+    // unless base already contains it (so we don't drop extra context).
+    if (provider && provider !== base && !base.includes(provider)) {
+        message = provider;
+    }
+    if (message.length > MAX_DISPLAY_ERROR_LENGTH) {
+        message = message.slice(0, MAX_DISPLAY_ERROR_LENGTH) + '…';
+    }
+    return message || 'An unknown error occurred';
+}
+
 function getErrorCode(error: unknown): string | undefined {
     if (!error || typeof error !== 'object') {
         return undefined;

--- a/workspaces/mi/mi-extension/src/rpc-managers/agent-mode/rpc-manager.ts
+++ b/workspaces/mi/mi-extension/src/rpc-managers/agent-mode/rpc-manager.ts
@@ -54,6 +54,7 @@ import * as vscode from 'vscode';
 import { AgentEventHandler } from './event-handler';
 import { executeAgent, createAgentAbortController, AgentEvent } from '../../ai-features/agent-mode';
 import { isToolInterruptionAbortError } from '../../ai-features/agent-mode/agents/main/agent';
+import { getDisplayErrorMessage } from '../../ai-features/agent-mode/stream_guard';
 import { logInfo, logError, logDebug } from '../../ai-features/copilot/logger';
 import {
     ChatHistoryManager,
@@ -929,7 +930,9 @@ export class MIAgentPanelRpcManager implements MIAgentPanelAPI {
             return {
                 success: false,
                 checkpointId: activeCheckpointId,
-                error: error instanceof Error ? error.message : 'Unknown error'
+                // Surface the upstream provider/proxy detail (e.g. a blocked-model 400)
+                // for errors that escape executeAgent's own handling.
+                error: getDisplayErrorMessage(error)
             };
         } finally {
             if (shouldRunCleanup) {

--- a/workspaces/mi/mi-visualizer/src/views/AIPanel/component/AICodeGenerator.tsx
+++ b/workspaces/mi/mi-visualizer/src/views/AIPanel/component/AICodeGenerator.tsx
@@ -60,12 +60,17 @@ export function AICodeGenerator({ isUsageExceeded = false }: AICodeGeneratorProp
   useEffect(() => {
       let cancelled = false;
       const checkByok = async () => {
+          // Re-gate from scratch on every lookup (e.g. rpcClient change) so a prior
+          // session's resolved state can't leak into the new one. Clear the auth
+          // flags too, not just the resolved gate — otherwise a failed/missing
+          // lookup would settle with stale isByok/isAwsBedrock and wrongly unlock
+          // the model controls. Runs before the rpcClient guard so it always applies.
+          setIsByok(false);
+          setIsAwsBedrock(false);
+          setByokResolved(false);
           if (!rpcClient) {
               return;
           }
-          // Re-gate from scratch on every lookup (e.g. rpcClient change) so a prior
-          // session's resolved state can't leak into the new one before this settles.
-          setByokResolved(false);
           try {
               const [hasApiKey, machineView] = await Promise.all([
                   rpcClient.getMiAiPanelRpcClient().hasAnthropicApiKey(),
@@ -82,7 +87,8 @@ export function AICodeGenerator({ isUsageExceeded = false }: AICodeGeneratorProp
               console.error('[AICodeGenerator] Failed to resolve BYOK / Bedrock state', error);
               if (!cancelled) {
                   // Settle even on failure so the settings UI doesn't stay pending
-                  // (controls disabled) forever; falls back to the managed-plan view.
+                  // (controls disabled) forever; the cleared flags above mean this
+                  // falls back to the managed-plan view rather than a stale unlock.
                   setByokResolved(true);
               }
           }

--- a/workspaces/mi/mi-visualizer/src/views/AIPanel/component/AICodeGenerator.tsx
+++ b/workspaces/mi/mi-visualizer/src/views/AIPanel/component/AICodeGenerator.tsx
@@ -44,6 +44,10 @@ export function AICodeGenerator({ isUsageExceeded = false }: AICodeGeneratorProp
   // Bedrock specifically — used by SettingsPanel to gate the Tavily/web-search controls.
   // Distinct from isByok (which is true for any "pays-per-request" auth method).
   const [isAwsBedrock, setIsAwsBedrock] = useState(false);
+  // Whether the BYOK / Bedrock check has completed. isByok starts false and
+  // resolves asynchronously, so SettingsPanel must wait for this before locking
+  // model switches — otherwise BYOK users briefly see the WSO2 lock state.
+  const [byokResolved, setByokResolved] = useState(false);
   const mainContainerRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -59,6 +63,9 @@ export function AICodeGenerator({ isUsageExceeded = false }: AICodeGeneratorProp
           if (!rpcClient) {
               return;
           }
+          // Re-gate from scratch on every lookup (e.g. rpcClient change) so a prior
+          // session's resolved state can't leak into the new one before this settles.
+          setByokResolved(false);
           try {
               const [hasApiKey, machineView] = await Promise.all([
                   rpcClient.getMiAiPanelRpcClient().hasAnthropicApiKey(),
@@ -70,8 +77,14 @@ export function AICodeGenerator({ isUsageExceeded = false }: AICodeGeneratorProp
               const isBedrock = machineView?.loginMethod === LoginMethod.AWS_BEDROCK;
               setIsByok(!!hasApiKey || isBedrock);
               setIsAwsBedrock(isBedrock);
+              setByokResolved(true);
           } catch (error) {
               console.error('[AICodeGenerator] Failed to resolve BYOK / Bedrock state', error);
+              if (!cancelled) {
+                  // Settle even on failure so the settings UI doesn't stay pending
+                  // (controls disabled) forever; falls back to the managed-plan view.
+                  setByokResolved(true);
+              }
           }
       };
       checkByok();
@@ -181,7 +194,7 @@ export function AICodeGenerator({ isUsageExceeded = false }: AICodeGeneratorProp
   if (showSettings) {
       return (
           <AIChatView>
-              <SettingsPanel onClose={() => setShowSettings(false)} isByok={isByok} isAwsBedrock={isAwsBedrock} />
+              <SettingsPanel onClose={() => setShowSettings(false)} isByok={isByok} byokResolved={byokResolved} isAwsBedrock={isAwsBedrock} />
           </AIChatView>
       );
   }

--- a/workspaces/mi/mi-visualizer/src/views/AIPanel/component/SettingsPanel.tsx
+++ b/workspaces/mi/mi-visualizer/src/views/AIPanel/component/SettingsPanel.tsx
@@ -218,7 +218,17 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({ onClose, isByok, isAwsBed
         !modelSettings.subModelCustomId &&
         isThinkingEnabled;
 
-    const currentMainOption = MAIN_AGENT_OPTIONS.find(o => o.value === modelSettings.mainModelPreset) || MAIN_AGENT_OPTIONS[0];
+    // WSO2 (MI Copilot / MI_INTEL) login is the only non-BYOK method. The MI Copilot
+    // proxy manages the model set (and blocks Opus), so model switching is locked here.
+    const isMiCopilotPlan = !isByok;
+
+    // On the WSO2 plan the main agent can't use Opus (proxy-blocked), so always show
+    // the non-Opus default — even if an 'opus' preset carried over from a prior BYOK
+    // session (the backend clamps the actual model to match). The sub-agent presets
+    // (Haiku/Sonnet) are both allowed on the plan, so its switch is locked but still
+    // reflects the model actually in use.
+    const effectiveMainPreset = isMiCopilotPlan ? DEFAULT_MAIN : modelSettings.mainModelPreset;
+    const currentMainOption = MAIN_AGENT_OPTIONS.find(o => o.value === effectiveMainPreset) || MAIN_AGENT_OPTIONS[0];
     const currentSubOption = SUB_AGENT_OPTIONS.find(o => o.value === modelSettings.subModelPreset) || SUB_AGENT_OPTIONS[0];
 
     return (
@@ -250,11 +260,33 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({ onClose, isByok, isAwsBed
 
             {/* Content */}
             <div className="flex-1 overflow-y-auto p-5 space-y-6">
+                {/* WSO2 plan: model selection is managed by the proxy and locked here. */}
+                {isMiCopilotPlan && (
+                    <div
+                        className="flex items-start gap-1.5 px-3 py-2 rounded-md"
+                        style={{
+                            fontSize: "11px",
+                            lineHeight: 1.4,
+                            color: "var(--vscode-foreground)",
+                            backgroundColor: "color-mix(in srgb, var(--vscode-foreground) 6%, transparent)",
+                            border: "1px solid var(--vscode-panel-border)",
+                        }}
+                    >
+                        <span className="shrink-0 mt-px" style={{ color: "var(--vscode-editorInfo-foreground, #3794ff)" }}>
+                            <Codicon name="lock" />
+                        </span>
+                        <span>
+                            Sign in with your own Anthropic API key or AWS Bedrock to change models.
+                        </span>
+                    </div>
+                )}
+
                 {/* Main Agent Intelligence */}
                 <SettingsSection title="Main Agent Intelligence">
                     <ToggleGroup
                         options={MAIN_AGENT_OPTIONS.map(o => o.label)}
                         selected={currentMainOption.label}
+                        disabled={isMiCopilotPlan}
                         onSelect={(label) => {
                             const option = MAIN_AGENT_OPTIONS.find(o => o.label === label);
                             if (option) {
@@ -277,6 +309,7 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({ onClose, isByok, isAwsBed
                     <ToggleGroup
                         options={SUB_AGENT_OPTIONS.map(o => o.label)}
                         selected={currentSubOption.label}
+                        disabled={isMiCopilotPlan}
                         onSelect={(label) => {
                             const option = SUB_AGENT_OPTIONS.find(o => o.label === label);
                             if (option) {
@@ -294,8 +327,9 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({ onClose, isByok, isAwsBed
                     </div>
                 </SettingsSection>
 
-                {/* High intelligence warning */}
-                {(modelSettings.mainModelPreset === "opus" || modelSettings.subModelPreset === "sonnet") && (
+                {/* High intelligence warning — not shown on the WSO2 plan, where the
+                    model is locked to the plan default. */}
+                {!isMiCopilotPlan && (modelSettings.mainModelPreset === "opus" || modelSettings.subModelPreset === "sonnet") && (
                     <InfoNote
                         icon="info"
                         variant="info"

--- a/workspaces/mi/mi-visualizer/src/views/AIPanel/component/SettingsPanel.tsx
+++ b/workspaces/mi/mi-visualizer/src/views/AIPanel/component/SettingsPanel.tsx
@@ -77,11 +77,11 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({ onClose, isByok, byokReso
     const handleResetDefaults = () => {
         updateModelSettings({
             ...modelSettings,
-            // On the locked MI Copilot plan the model presets are managed by the
-            // proxy and the selectors are disabled, so reset must leave them as-is —
-            // otherwise it's a hidden model-switch path. Only reset what the user can
-            // actually control here (thinking, below).
-            ...(isMiCopilotPlan ? {} : {
+            // When the model controls are disabled — the locked MI Copilot plan, or
+            // while plan resolution is still pending — reset must leave the presets
+            // as-is, otherwise it's a hidden model-switch path. Only reset what the
+            // user can actually control here (thinking, below).
+            ...(modelControlsDisabled ? {} : {
                 mainModelPreset: DEFAULT_MAIN,
                 subModelPreset: DEFAULT_SUB,
                 mainModelCustomId: undefined,
@@ -240,11 +240,11 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({ onClose, isByok, byokReso
         modelSettings.subModelPreset === DEFAULT_SUB &&
         !modelSettings.mainModelCustomId &&
         !modelSettings.subModelCustomId;
-    // On the locked MI Copilot plan the presets aren't user-controllable, so a
-    // carried-over preset must not keep the reset button active — clicking it would
-    // rewrite the (locked) presets, a hidden model-switch path. There, "default"
-    // depends only on the thinking toggle.
-    const isDefault = (isMiCopilotPlan || modelSettingsAreDefault) && isThinkingEnabled;
+    // When model controls are disabled (locked plan or pending resolution) the
+    // presets aren't user-controllable, so a carried-over preset must not keep the
+    // reset button active — clicking it would rewrite the (locked) presets, a
+    // hidden model-switch path. There, "default" depends only on the thinking toggle.
+    const isDefault = (modelControlsDisabled || modelSettingsAreDefault) && isThinkingEnabled;
 
     // On the WSO2 plan the main agent can't use Opus (proxy-blocked), so always show
     // the non-Opus default — even if an 'opus' preset carried over from a prior BYOK

--- a/workspaces/mi/mi-visualizer/src/views/AIPanel/component/SettingsPanel.tsx
+++ b/workspaces/mi/mi-visualizer/src/views/AIPanel/component/SettingsPanel.tsx
@@ -29,6 +29,12 @@ interface SettingsPanelProps {
      */
     isByok: boolean;
     /**
+     * True once the BYOK / Bedrock check has completed. Until then `isByok` is
+     * still at its default, so model-switch locking is deferred to avoid briefly
+     * showing BYOK users the WSO2 lock state.
+     */
+    byokResolved: boolean;
+    /**
      * True only for AWS Bedrock auth. Gates the Tavily / web-search controls
      * since Bedrock has no first-party web tools.
      */
@@ -55,7 +61,7 @@ const SUB_AGENT_OPTIONS: { value: SubModelPreset; label: string; model: string; 
 const DEFAULT_MAIN: MainModelPreset = "sonnet";
 const DEFAULT_SUB: SubModelPreset = "haiku";
 
-const SettingsPanel: React.FC<SettingsPanelProps> = ({ onClose, isByok, isAwsBedrock }) => {
+const SettingsPanel: React.FC<SettingsPanelProps> = ({ onClose, isByok, byokResolved, isAwsBedrock }) => {
     const {
         rpcClient,
         modelSettings,
@@ -71,10 +77,16 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({ onClose, isByok, isAwsBed
     const handleResetDefaults = () => {
         updateModelSettings({
             ...modelSettings,
-            mainModelPreset: DEFAULT_MAIN,
-            subModelPreset: DEFAULT_SUB,
-            mainModelCustomId: undefined,
-            subModelCustomId: undefined,
+            // On the locked MI Copilot plan the model presets are managed by the
+            // proxy and the selectors are disabled, so reset must leave them as-is —
+            // otherwise it's a hidden model-switch path. Only reset what the user can
+            // actually control here (thinking, below).
+            ...(isMiCopilotPlan ? {} : {
+                mainModelPreset: DEFAULT_MAIN,
+                subModelPreset: DEFAULT_SUB,
+                mainModelCustomId: undefined,
+                subModelCustomId: undefined,
+            }),
         });
         setIsThinkingEnabled(true);
     };
@@ -211,16 +223,28 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({ onClose, isByok, isAwsBed
     // Bedrock: web search is "enabled" when a key is saved or the user is in the middle of entering one.
     const isBedrockWebSearchOn = !!tavilyKey || tavilyInputOpen;
 
-    const isDefault =
+    // WSO2 (MI Copilot / MI_INTEL) login is the only non-BYOK method. The MI Copilot
+    // proxy manages the model set (and blocks Opus), so model switching is locked here.
+    // Gate on byokResolved so we don't lock (or flash the lock note) before the auth
+    // method is known — isByok resolves asynchronously and starts false.
+    const isMiCopilotPlan = byokResolved && !isByok;
+    // While the auth method is still being resolved, keep the model controls
+    // neutral — disabled, but without the WSO2 lock note — so neither plan can
+    // toggle a preset (or see the high-intelligence warning) before we know which
+    // applies. Once resolved, isMiCopilotPlan drives the lock as usual.
+    const isPlanResolutionPending = !byokResolved;
+    const modelControlsDisabled = isMiCopilotPlan || isPlanResolutionPending;
+
+    const modelSettingsAreDefault =
         modelSettings.mainModelPreset === DEFAULT_MAIN &&
         modelSettings.subModelPreset === DEFAULT_SUB &&
         !modelSettings.mainModelCustomId &&
-        !modelSettings.subModelCustomId &&
-        isThinkingEnabled;
-
-    // WSO2 (MI Copilot / MI_INTEL) login is the only non-BYOK method. The MI Copilot
-    // proxy manages the model set (and blocks Opus), so model switching is locked here.
-    const isMiCopilotPlan = !isByok;
+        !modelSettings.subModelCustomId;
+    // On the locked MI Copilot plan the presets aren't user-controllable, so a
+    // carried-over preset must not keep the reset button active — clicking it would
+    // rewrite the (locked) presets, a hidden model-switch path. There, "default"
+    // depends only on the thinking toggle.
+    const isDefault = (isMiCopilotPlan || modelSettingsAreDefault) && isThinkingEnabled;
 
     // On the WSO2 plan the main agent can't use Opus (proxy-blocked), so always show
     // the non-Opus default — even if an 'opus' preset carried over from a prior BYOK
@@ -286,7 +310,7 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({ onClose, isByok, isAwsBed
                     <ToggleGroup
                         options={MAIN_AGENT_OPTIONS.map(o => o.label)}
                         selected={currentMainOption.label}
-                        disabled={isMiCopilotPlan}
+                        disabled={modelControlsDisabled}
                         onSelect={(label) => {
                             const option = MAIN_AGENT_OPTIONS.find(o => o.label === label);
                             if (option) {
@@ -309,7 +333,7 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({ onClose, isByok, isAwsBed
                     <ToggleGroup
                         options={SUB_AGENT_OPTIONS.map(o => o.label)}
                         selected={currentSubOption.label}
-                        disabled={isMiCopilotPlan}
+                        disabled={modelControlsDisabled}
                         onSelect={(label) => {
                             const option = SUB_AGENT_OPTIONS.find(o => o.label === label);
                             if (option) {
@@ -327,9 +351,9 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({ onClose, isByok, isAwsBed
                     </div>
                 </SettingsSection>
 
-                {/* High intelligence warning — not shown on the WSO2 plan, where the
-                    model is locked to the plan default. */}
-                {!isMiCopilotPlan && (modelSettings.mainModelPreset === "opus" || modelSettings.subModelPreset === "sonnet") && (
+                {/* High intelligence warning — not shown on the WSO2 plan (model is
+                    locked to the plan default) nor while plan resolution is pending. */}
+                {byokResolved && !isMiCopilotPlan && (modelSettings.mainModelPreset === "opus" || modelSettings.subModelPreset === "sonnet") && (
                     <InfoNote
                         icon="info"
                         variant="info"


### PR DESCRIPTION
## Summary

Mirror of wso2/mi-vscode#1515 for the `release/mi-4.1.1` line of this repo (MI was removed from `main` here as part of the migration, so MI fixes land on `release/mi-4.1.1`).

The MI Copilot proxy blocks Opus models and returns a 400 with an explanatory body, but the chat error card only showed the SDK's generic status text, and WSO2 users could still pick Opus in Settings.

**Settings (WSO2 / MI_INTEL login only)**
- Disable both the Main and Sub-Agent model switches (greyed out) with a note: *"Sign in with your own Anthropic API key or AWS Bedrock to change models."* BYOK (Anthropic key / Bedrock) is unaffected.
- The Main switch always shows the non-Opus default; the high-intelligence warning is suppressed.

**Backend**
- Clamp the main agent to Sonnet for MI_INTEL when a stale `opus` preset carried over from a prior BYOK session, so it can't 400 every turn. Custom model IDs are left untouched.

**Error surfacing**
- `getDisplayErrorMessage()` extracts the upstream provider/proxy message from `APICallError` `responseBody`/`data` (walking the cause chain) instead of the bare HTTP status text, wired into the agent stream `error` path, execution catch, and the rpc-manager fallback catch.

The net change set is identical to wso2/mi-vscode#1515 (paths remapped from `packages/` to `workspaces/mi/`). Rebased on top of #2388 (now merged), so it references `ANTHROPIC_OPUS_4_8`.

Mirrors: https://github.com/wso2/mi-vscode/pull/1515

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added asynchronous auth/plan resolution support to the Settings panel, including a lock notice for fixed model plans.
* **Bug Fixes**
  * Automatically falls back from unsupported “Opus” selection to a supported “Sonnet” model on constrained plans.
  * Improved end-user error rendering for both streamed and RPC agent failures using provider/proxy-friendly, actionable messages.
* **UI Updates**
  * Disables model selection controls while plan resolution is pending or when the plan locks model options.
  * Updated high-intelligence warning visibility for resolved, non-locked plans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->