### PR TITLE
Rename inbound-connectors to inbound-endpoints

### DIFF
--- a/workspaces/mi/mi-core/src/state-machine-types.ts
+++ b/workspaces/mi/mi-core/src/state-machine-types.ts
@@ -97,7 +97,7 @@ export enum MACHINE_VIEW {
     ProjectInformationForm = "Project Information Form",
     SETUP_ENVIRONMENT = "Setup Environment",
     ImportConnectorForm = "Import Connector",
-    ImportInboundConnectorForm = "Import Inbound Connector",
+    ImportInboundConnectorForm = "Import Inbound Endpoint",
     IdpConnectorSchemaGeneratorForm = "IDP Connector Schema Generator Form",
     DataMapperMigrationForm = "DataMapper Migration Form",
 }

--- a/workspaces/mi/mi-extension/src/ai-features/agent-mode/tools/connector_ls_client.ts
+++ b/workspaces/mi/mi-extension/src/ai-features/agent-mode/tools/connector_ls_client.ts
@@ -380,7 +380,7 @@ export async function readOutputSchema(
 /**
  * Discover inbound endpoint types known to the LS/runtime — splits bundled (runtime-shipped)
  * from Maven-or-custom (either in the store catalog or added under
- * `src/main/wso2mi/resources/inbound-connectors/`).
+ * `src/main/wso2mi/resources/inbound-endpoints/`).
  *
  * The bundled list is runtime-dependent — we do NOT hardcode it. Bundled `id`s are the
  * values passed to `getInboundInfo({id})`. Maven entries' `id`s are consumer class FQNs

--- a/workspaces/mi/mi-extension/src/rpc-managers/mi-diagram/rpc-manager.ts
+++ b/workspaces/mi/mi-extension/src/rpc-managers/mi-diagram/rpc-manager.ts
@@ -4128,14 +4128,14 @@ ${endpointAttributes}
         const langClient = await MILanguageClient.getInstance(this.projectUri);
         try {
             if (isInbound) {
-                const inboundConnectorDirectory = path.join(this.projectUri, 'src', 'main', 'wso2mi', 'resources', 'inbound-connectors');
+                const inboundConnectorDirectory = path.join(this.projectUri, 'src', 'main', 'wso2mi', 'resources', 'inbound-endpoints');
                 if (!fs.existsSync(inboundConnectorDirectory)) {
                     fs.mkdirSync(inboundConnectorDirectory, { recursive: true });
                 }
                 const inboundDestinationPath = path.join(inboundConnectorDirectory, path.basename(connectorPath));
 
                 if (fs.existsSync(inboundDestinationPath)) {
-                    return { success: false, error: `An inbound connector with the name '${path.basename(connectorPath)}' already exists.` };
+                    return { success: false, error: `An inbound endpoint with the name '${path.basename(connectorPath)}' already exists.` };
                 }
 
                 const deleteInboundZip = () => {
@@ -4150,7 +4150,7 @@ ${endpointAttributes}
                     const updateResult = await langClient.updateInboundConnectors();
                     if (updateResult !== "success") {
                         deleteInboundZip();
-                        return { success: false, error: updateResult || "Failed to import inbound connector." };
+                        return { success: false, error: updateResult || "Failed to import inbound endpoint." };
                     }
 
                     commands.executeCommand(COMMANDS.REFRESH_COMMAND);

--- a/workspaces/mi/mi-extension/src/test/e2e-playwright-tests/components/InboundEp.ts
+++ b/workspaces/mi/mi-extension/src/test/e2e-playwright-tests/components/InboundEp.ts
@@ -66,7 +66,7 @@ export class InboundEPForm {
             await confiramtionBtn.click();
             console.log('Download dependency confirmed');
             
-            const downloadingMessageLocator = inboundEPSection.locator(`span:text("Downloading connector... This might take a while")`);
+            const downloadingMessageLocator = inboundEPSection.locator(`span:text("Downloading inbound endpoint... This might take a while")`);
             try {
                 await downloadingMessageLocator.waitFor({ state: 'visible', timeout: 5000 });
                 console.log('Downloading connector message appeared');

--- a/workspaces/mi/mi-visualizer/src/Hooks.tsx
+++ b/workspaces/mi/mi-visualizer/src/Hooks.tsx
@@ -37,7 +37,7 @@ export interface ConnectorInfo {
 }
 
 /**
- * Manages the check-and-download lifecycle for a downloadable inbound connector.
+ * Manages the check-and-download lifecycle for a downloadable inbound endpoint.
  *
  * Two entry points:
  * - `requiresDownload(info)` – caller already knows the connector needs downloading

--- a/workspaces/mi/mi-visualizer/src/views/Forms/InboundEPform/ImportInboundConnector.tsx
+++ b/workspaces/mi/mi-visualizer/src/views/Forms/InboundEPform/ImportInboundConnector.tsx
@@ -70,11 +70,11 @@ export function ImportInboundConnectorForm(props: ImportInboundConnectorFormProp
                     isPopup: true
                 });
             } else {
-                setImportError(response.error || "Error importing inbound connector. Please try again...");
+                setImportError(response.error || "Error importing inbound endpoint. Please try again...");
             }
         } catch (error) {
             console.log(error);
-            setImportError("Error importing inbound connector. Please try again...");
+            setImportError("Error importing inbound endpoint. Please try again...");
         }
 
         setIsImporting(false);
@@ -92,12 +92,12 @@ export function ImportInboundConnectorForm(props: ImportInboundConnectorFormProp
 
     return (
         <>
-            <FormView title={`Import Inbound Connector`} onClose={handleCancel}>
+            <FormView title={`Import Inbound Endpoint`} onClose={handleCancel}>
                 {isImporting ?
                     (
                         <LoaderWrapper>
                             <ProgressRing />
-                            Importing inbound-connector...
+                            Importing inbound-endpoint...
                         </LoaderWrapper>
                     ) : (
                         <>
@@ -109,7 +109,7 @@ export function ImportInboundConnectorForm(props: ImportInboundConnectorFormProp
                                     <ErrorBanner errorMsg={"Please select a connector zip file"} />
                                 }
                                 <LocationSelector
-                                    label="Choose path to inbound connector zip"
+                                    label="Choose path to inbound endpoint zip"
                                     selectedFile={zipDir}
                                     required
                                     onSelect={handleSourceDirSelection}

--- a/workspaces/mi/mi-visualizer/src/views/Forms/InboundEPform/index.tsx
+++ b/workspaces/mi/mi-visualizer/src/views/Forms/InboundEPform/index.tsx
@@ -64,7 +64,7 @@ export interface Region {
 }
 
 // MCP servers are created through the dedicated MCP Server artifact flow,
-// so the raw MCP inbound connector is hidden from the event integration list.
+// so the raw MCP inbound endpoint is hidden from the event integration list.
 const HIDDEN_INBOUND_CONNECTORS = /^mcp\b/i;
 
 export interface InboundEPWizardProps {
@@ -121,7 +121,7 @@ export function InboundEPWizard(props: InboundEPWizardProps) {
             setLocalConnectors(localConnectors["inbound-connector-data"]?.filter((connector: any) => !HIDDEN_INBOUND_CONNECTORS.test(connector.name)));
             setStoreConnectors(data?.filter((connector: any) => !HIDDEN_INBOUND_CONNECTORS.test(connector.connectorName)));
         } catch (e) {
-            rpcClient.getMiVisualizerRpcClient().showNotification({message: "Error occurred while fetching inbound-connectors", type: "error"});
+            rpcClient.getMiVisualizerRpcClient().showNotification({message: "Error occurred while fetching inbound-endpoints", type: "error"});
             console.error("Error fetching connectors", e);
         }
         setIsFetchingConnectors(false);
@@ -251,7 +251,7 @@ export function InboundEPWizard(props: InboundEPWizardProps) {
                     depState === 'downloading' ? (
                         <LoaderWrapper>
                             <ProgressRing />
-                            <span>Downloading connector... This might take a while</span>
+                            <span>Downloading inbound endpoint... This might take a while</span>
                             {downloadProgress && (
                                 `Downloaded ${downloadProgress.downloadedAmount} of ${downloadProgress.downloadSize} (${downloadProgress.percentage}%). `
                             )}
@@ -284,10 +284,10 @@ export function InboundEPWizard(props: InboundEPWizardProps) {
                         <>
                             <HeaderRow>
                                 <span>Please select an event integration.</span>
-                                <Button appearance="secondary" onClick={importInboundConnector} tooltip="Import an inbound connector">
+                                <Button appearance="secondary" onClick={importInboundConnector} tooltip="Import an inbound endpoint">
                                     <div style={{ display: "flex", flexDirection: "row", gap: 10, alignItems: "center" }}>
                                         <Icon name="plus" isCodicon iconSx={{ fontSize: 20, fontWeight: 200 }} />
-                                        <span>Import Inbound Connector</span>
+                                        <span>Import Inbound Endpoint</span>
                                     </div>
                                 </Button>
                             </HeaderRow>

--- a/workspaces/mi/mi-visualizer/src/views/Forms/MCPServerForm/index.tsx
+++ b/workspaces/mi/mi-visualizer/src/views/Forms/MCPServerForm/index.tsx
@@ -231,14 +231,14 @@ export function MCPServerWizard(props: MCPServerWizardProps) {
             {depState === 'downloading' ? (
                 <LoaderWrapper>
                     <ProgressRing />
-                    <span>Downloading connector... This might take a while</span>
+                    <span>Downloading inbound endpoint... This might take a while</span>
                     {downloadProgress && (
                         `Downloaded ${downloadProgress.downloadedAmount} of ${downloadProgress.downloadSize} (${downloadProgress.percentage}%). `
                     )}
                 </LoaderWrapper>
             ) : depState === 'download-failed' ? (
                 <div style={{ display: 'flex', flexDirection: 'column', padding: '40px', gap: '15px' }}>
-                    <Typography variant="body2">Error downloading connector. Please try again...</Typography>
+                    <Typography variant="body2">Error downloading inbound endpoint. Please try again...</Typography>
                     <FormActions>
                         <Button appearance="primary" onClick={() => acceptDownload()}>
                             Retry
@@ -250,7 +250,7 @@ export function MCPServerWizard(props: MCPServerWizardProps) {
                 </div>
             ) : depState === 'needs-download' ? (
                 <div style={{ display: 'flex', flexDirection: 'column', padding: '40px', gap: '15px' }}>
-                    <Typography variant="body2">The MCP inbound connector will be added as a dependency to the project. Do you want to continue?</Typography>
+                    <Typography variant="body2">The MCP inbound endpoint will be added as a dependency to the project. Do you want to continue?</Typography>
                     <FormActions>
                         <Button appearance="secondary" onClick={declineDownload}>
                             No


### PR DESCRIPTION
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated user-facing text and messages to consistently refer to **Inbound Endpoint** instead of **Inbound Connector**.
  * Corrected the destination path used when importing so it matches the inbound endpoint location.
  * Adjusted error and notification wording to reflect the right feature name.

* **Style**
  * Refreshed labels, titles, tooltips, and helper text in the import flow for clearer terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->