### PR TITLE
Improve startup time of extension activation

### DIFF
--- a/workspaces/mi/mi-extension/src/lang-client/activator.ts
+++ b/workspaces/mi/mi-extension/src/lang-client/activator.ts
@@ -50,7 +50,7 @@ import { FormattingProvider } from './FormattingProvider';
 
 import util = require('util');
 import { log } from '../util/logger';
-import { getJavaHomeFromConfig, getProjectSetupDetails, isMISetup, isJavaSetup } from '../util/onboardingUtils';
+import { getJavaHomeFromConfig, getJavaVersion, getMIVersionFromPom, isMISetup, isJavaSetup } from '../util/onboardingUtils';
 import { SELECTED_SERVER_PATH } from '../debugger/constants';
 import { extension } from '../MIExtensionContext';
 import { loadCAppResources } from '../visualizer/activate';
@@ -202,6 +202,12 @@ export class MILanguageClient {
     }
 
     public async checkJDKCompatibility(javaHome: string): Promise<boolean> {
+        // Fast path: reuse the memoized `java -version` result — the same JDK path was
+        // already probed during environment setup, so this avoids a ~500ms shell spawn.
+        const majorVersion = getJavaVersion(path.join(javaHome, 'bin'));
+        if (majorVersion) {
+            return parseInt(majorVersion) >= parseInt(this.COMPATIBLE_JDK_VERSION);
+        }
         const env = { ...process.env };
         env.PATH = `${path.join(javaHome, 'bin')}${path.delimiter}${env.PATH}`;
         const { stderr } = await exec('java -version',
@@ -213,7 +219,10 @@ export class MILanguageClient {
 
     private async launch(projectUri: string) {
         try {
-            const { miVersionFromPom } = await getProjectSetupDetails(projectUri);
+            // Only the runtime version is needed here — the full getProjectSetupDetails
+            // probe (java -version spawn, MI path resolution, update check) already ran
+            // in setupEnvironment and costs 250ms+ per call.
+            const miVersionFromPom = await getMIVersionFromPom(projectUri);
             if (!miVersionFromPom) {
                 const errorMessage = `Runtime version not found in the pom file of project ${projectUri}. Please add the runtime version and reload to continue.`;
                 window.showErrorMessage(errorMessage);

--- a/workspaces/mi/mi-extension/src/stateMachine.ts
+++ b/workspaces/mi/mi-extension/src/stateMachine.ts
@@ -49,6 +49,14 @@ const stateMachine = createMachine<MachineContext>({
         dependenciesResolved: false,
         isInWI: false
     },
+    // Allow re-initialization from any state (e.g. when the deferred server-update
+    // prompt is accepted after startup). Nested states with their own
+    // REFRESH_ENVIRONMENT handler take precedence over this root handler.
+    on: {
+        REFRESH_ENVIRONMENT: {
+            target: '.initialize'
+        }
+    },
     states: {
         initialize: {
             entry: () => logDebug("State Machine: Entering 'initialize' state"),
@@ -399,6 +407,12 @@ const stateMachine = createMachine<MachineContext>({
             return new Promise(async (resolve, reject) => {
                 console.log("Waiting for LS to be ready " + new Date().toLocaleTimeString());
                 try {
+                    // Create the webview panel now so its JS bundle loads in parallel
+                    // with the language-server startup; openWebPanel later waits on the
+                    // ready latch before advancing the machine.
+                    if (context.displayOverview !== false) {
+                        createWebviewPanelWithReadyLatch(context);
+                    }
                     vscode.commands.executeCommand(`${MI_PROJECT_EXPLORER_VIEW_ID}.focus`);
                     const ls = await MILanguageClient.getInstance(context.projectUri!);
                     vscode.commands.executeCommand('setContext', 'MI.status', 'projectLoaded');
@@ -419,16 +433,15 @@ const stateMachine = createMachine<MachineContext>({
                 }
 
                 if (!webviews.has(context.projectUri)) {
-                    const panel = new VisualizerWebview(context.view!, context.projectUri, extension.webviewReveal);
-                    webviews.set(context.projectUri!, panel);
-
-                    const messenger = RPCLayer._messengers.get(context.projectUri);
-                    if (messenger) {
-                        messenger.onNotification(webviewReady, () => {
-                            resolve(true);
-                        });
-                    }
+                    createWebviewPanelWithReadyLatch(context);
+                    await webviewReadyLatches.get(context.projectUri);
+                    resolve(true);
                 } else {
+                    // The panel may have been pre-created (in parallel with LS startup)
+                    // and still be loading its bundle: wait until the webview announced
+                    // readiness before advancing the machine — resolveMissingDependencies
+                    // relies on the NEXT webviewReady notification.
+                    await webviewReadyLatches.get(context.projectUri);
                     const webview = webviews.get(context.projectUri)?.getWebview();
                     if (webview) {
                         webview.reveal(ViewColumn.Active);
@@ -681,6 +694,29 @@ const stateMachine = createMachine<MachineContext>({
     }
 });
 
+
+// Resolves once a project's webview has loaded its JS bundle and sent webviewReady.
+// Lets the panel be created early (in parallel with LS startup) while openWebPanel
+// still blocks the state machine until the webview is actually interactive.
+const webviewReadyLatches: Map<string, Promise<boolean>> = new Map();
+
+function createWebviewPanelWithReadyLatch(context: { projectUri?: string | null, view?: MACHINE_VIEW | null }): void {
+    if (!context.projectUri || webviews.has(context.projectUri)) {
+        return;
+    }
+    const projectUri = context.projectUri;
+    const panel = new VisualizerWebview(context.view!, projectUri, extension.webviewReveal);
+    webviews.set(projectUri, panel);
+
+    const messenger = RPCLayer._messengers.get(projectUri);
+    if (messenger) {
+        webviewReadyLatches.set(projectUri, new Promise((resolve) => {
+            messenger.onNotification(webviewReady, () => {
+                resolve(true);
+            });
+        }));
+    }
+}
 
 // Create a service to interpret the machine
 const stateMachines: Map<string, any> = new Map();

--- a/workspaces/mi/mi-extension/src/util/onboardingUtils.ts
+++ b/workspaces/mi/mi-extension/src/util/onboardingUtils.ts
@@ -67,6 +67,23 @@ export function isWso2IntegratorRuntime(): boolean {
 
 let ballerinaOutputChannel: vscode.OutputChannel | undefined;
 
+// Projects where the user accepted a server update from the deferred background
+// prompt; consumed by the next setupEnvironment run to open the environment-setup view.
+const pendingServerUpdates = new Set<string>();
+
+function promptServerUpdateInBackground(projectUri: string): void {
+    isServerUpdateRequested(projectUri).then(async (isUpdateRequested) => {
+        if (isUpdateRequested) {
+            pendingServerUpdates.add(projectUri);
+            // Dynamic import to avoid a circular dependency (stateMachine imports this module).
+            const { getStateMachine } = await import('../stateMachine');
+            getStateMachine(projectUri).service().send({ type: 'REFRESH_ENVIRONMENT' });
+        }
+    }).catch((error) => {
+        console.error('Background server-update check failed:', error);
+    });
+}
+
 export async function setupEnvironment(projectUri: string, isOldProject: boolean): Promise<boolean> {
     try {
         const wrapperFiles = await vscode.workspace.findFiles(
@@ -83,7 +100,7 @@ export async function setupEnvironment(projectUri: string, isOldProject: boolean
             }
             setupConfigFiles(projectUri);
         }
-        const { miVersionFromPom } = await getProjectSetupDetails(projectUri);
+        const { miVersionFromPom } = await getProjectSetupDetails(projectUri, { skipUpdateCheck: true });
         if (!miVersionFromPom) {
             return false;
         }
@@ -95,14 +112,22 @@ export async function setupEnvironment(projectUri: string, isOldProject: boolean
         const isJavaSet = await isJavaSetup(projectUri, miVersionFromPom);
 
         if (isMISet && isJavaSet) {
-            const isUpdateRequested = await isServerUpdateRequested(projectUri);
+            // A server update was accepted from the deferred background prompt and the
+            // state machine re-initialized: route to the environment-setup view now.
+            if (pendingServerUpdates.has(projectUri)) {
+                pendingServerUpdates.delete(projectUri);
+                return false;
+            }
             await updateCarPluginVersion(projectUri);
             const config = vscode.workspace.getConfiguration('MI', vscode.Uri.parse(projectUri));
             const currentState = config.inspect<string>("useLocalMaven");
             if (currentState?.workspaceFolderValue === undefined) {
                 config.update("useLocalMaven", currentState?.globalValue ?? false, vscode.ConfigurationTarget.WorkspaceFolder);
             }
-            return !isUpdateRequested;
+            // The server-update check needs a network round trip (~1s cold), so it must
+            // not block startup: prompt in the background after the UI is up.
+            promptServerUpdateInBackground(projectUri);
+            return true;
         }
         return isMISet && isJavaSet;
     } catch (error) {
@@ -129,7 +154,7 @@ export async function isMIUpToDate(): Promise<boolean> {
     return false;
 }
 
-export async function getProjectSetupDetails(projectUri: string): Promise<SetupDetails> {
+export async function getProjectSetupDetails(projectUri: string, options?: { skipUpdateCheck?: boolean }): Promise<SetupDetails> {
     const miVersion = await getMIVersionFromPom(projectUri);
     if (!miVersion) {
         vscode.window.showWarningMessage('Failed to get WSO2 Integrator: MI version from pom.xml.');
@@ -138,7 +163,7 @@ export async function getProjectSetupDetails(projectUri: string): Promise<SetupD
     if (isSupportedMIVersion(miVersion)) {
         const highestSupportedJavaVersion = javaVersionCompatibilityMap[miVersion].supportedRange.max;
         const recommendedVersions = { miVersion, javaVersion: highestSupportedJavaVersion };
-        const setupDetails = await getJavaAndMIPathsFromWorkspace(projectUri, miVersion);
+        const setupDetails = await getJavaAndMIPathsFromWorkspace(projectUri, miVersion, options);
         return { ...setupDetails, miVersionStatus: 'valid', showDownloadButtons: isDownloadableMIVersion(miVersion), recommendedVersions, miVersionFromPom: miVersion };
     }
 
@@ -581,7 +606,17 @@ function isDownloadableMIVersion(version: string): boolean {
     return miDownloadUrls[version] !== undefined;
 }
 
-function getJavaVersion(javaBinPath: string): string | null {
+// spawnSync blocks the extension host event loop for 100ms+ per call, and the same
+// JDK path is checked repeatedly during startup. A JDK's version cannot change at a
+// given path within a session, so cache successful lookups (failures are not cached
+// so a JDK installed mid-session at the same path is picked up).
+const javaVersionCache = new Map<string, string>();
+
+export function getJavaVersion(javaBinPath: string): string | null {
+    const cached = javaVersionCache.get(javaBinPath);
+    if (cached !== undefined) {
+        return cached;
+    }
     const javaExecutableName = process.platform === 'win32' ? 'java.exe' : 'java';
     const javaExecutable = path.join(javaBinPath, javaExecutableName);
     const result = spawnSync(javaExecutable, ['-version'], { encoding: 'utf8' });
@@ -590,7 +625,11 @@ function getJavaVersion(javaBinPath: string): string | null {
         return null;
     }
     const versionMatch = result.stderr.match(/(\d+\.\d+\.\d+)/);
-    return versionMatch ? versionMatch[0].split('.')[0] : null;
+    const version = versionMatch ? versionMatch[0].split('.')[0] : null;
+    if (version) {
+        javaVersionCache.set(javaBinPath, version);
+    }
+    return version;
 }
 function getMIVersion(miPath: string): string | null {
     const miVersionFile = path.join(miPath, 'bin', 'version.txt');
@@ -682,7 +721,7 @@ export async function setPathsInWorkSpace(request: SetPathRequest): Promise<Path
     return response;
 }
 
-async function getJavaAndMIPathsFromWorkspace(projectUri: string, projectMiVersion: string): Promise<SetupDetails> {
+async function getJavaAndMIPathsFromWorkspace(projectUri: string, projectMiVersion: string, options?: { skipUpdateCheck?: boolean }): Promise<SetupDetails> {
     const compatibleJavaVersion = javaVersionCompatibilityMap[projectMiVersion];
     const highestSupportedJavaVersion = compatibleJavaVersion && compatibleJavaVersion.supportedRange.max;
     const response: SetupDetails = {
@@ -713,7 +752,9 @@ async function getJavaAndMIPathsFromWorkspace(projectUri: string, projectMiVersi
             const miVersion = getMIVersion(validServerPath);
             if (projectMiVersion === miVersion) {
                 let status: "valid" | "valid-not-updated" | "mismatch" | "not-valid" = "valid";
-                if (miVersion === "4.4.0") {
+                // The 4.4.0 freshness check needs a network round trip (~1s cold); startup
+                // callers skip it and rely on the deferred background update prompt instead.
+                if (miVersion === "4.4.0" && !options?.skipUpdateCheck) {
                     const isUpdatedPack = await isMIUpToDate();
                     status = isUpdatedPack ? "valid" : "valid-not-updated";
                 }
@@ -1501,12 +1542,22 @@ async function updateBallerinaDistribution(isBallerinaInstalledGlobally: boolean
     });
 }
 
+// The update-version endpoint is hit from several startup paths (isMIUpToDate,
+// isServerUpdateRequested, and the env-setup UI). Each cold HTTPS round trip costs
+// ~1s, so share a single in-flight request and cache the result briefly.
+let latestMIVersionFetch: { promise: Promise<{ data: any }>, fetchedAt: number } | undefined;
+const MI_UPDATE_CHECK_TTL_MS = 10 * 60 * 1000;
+
 async function fetchLatestMIVersion(miVersion: string): Promise<string> {
     try {
-        const response = await axios.get(miUpdateVersionCheckUrl);
+        if (!latestMIVersionFetch || Date.now() - latestMIVersionFetch.fetchedAt > MI_UPDATE_CHECK_TTL_MS) {
+            latestMIVersionFetch = { promise: axios.get(miUpdateVersionCheckUrl), fetchedAt: Date.now() };
+        }
+        const response = await latestMIVersionFetch.promise;
         const versions = response.data;
         return versions[miVersion] || '';
     } catch (error) {
+        latestMIVersionFetch = undefined; // do not cache failures
         console.error('Error fetching MI update version:', error);
         return '';
     }

--- a/workspaces/mi/mi-visualizer/webpack.config.js
+++ b/workspaces/mi/mi-visualizer/webpack.config.js
@@ -1,12 +1,18 @@
 const path = require("path");
 const webpack = require("webpack");
-const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
 
-module.exports = {
+// Development mode (eval-source-map, ~87MB unminified bundle) is only used by
+// `webpack-dev-server --mode=development` (the `start` script). Any other build —
+// including `rush build` output that gets packaged into the .vsix — must be
+// production: the dev bundle wraps every module in eval() and takes several
+// seconds to parse inside the webview, which delays the Overview page.
+module.exports = (env, argv) => {
+    const isDev = argv && argv.mode === "development";
+    return {
     entry: "./src/index.tsx",
     target: "web",
-    devtool: !process.env.CI ? "eval-source-map" : undefined,
-    mode: !process.env.CI ? "development" : "production",
+    devtool: isDev ? "eval-source-map" : false,
+    mode: isDev ? "development" : "production",
     output: {
         path: path.resolve(__dirname, "build"),
         filename: "Visualizer.js",
@@ -99,6 +105,10 @@ module.exports = {
         new webpack.ProvidePlugin({
             process: "process/browser",
         }),
-        !process.env.CI & new ReactRefreshWebpackPlugin(),
+        // Note: ReactRefreshWebpackPlugin was previously listed here guarded by
+        // `!process.env.CI & new ReactRefreshWebpackPlugin()` — the bitwise `&`
+        // always evaluated to 0, so the plugin was never actually enabled.
+        // Removed rather than silently changing dev-server behavior.
     ].filter(Boolean),
+    };
 };


### PR DESCRIPTION
- Build mi-visualizer webview bundle in production mode by default (dev-mode eval-source-map bundle was ~87MB and shipped in the vsix)
- Cache the MI update-version fetch (single-flight, 10min TTL)
- Move server update checks off the startup critical path; prompt in the background after the UI is up
- Memoize java -version lookups per JDK path (spawnSync blocks the extension host)
- Avoid re-running the full project setup probe during LS launch
- Create the visualizer webview in parallel with language server startup, gated by a webviewReady latch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Startup now checks environment readiness in the background, reducing delays when opening projects.
  * The app can pre-open the web panel and wait until it is fully ready before continuing.

* **Bug Fixes**
  * Improved JDK compatibility detection for faster, more reliable setup.
  * Refreshed MI and Java version checks now reuse cached results to reduce repeated lookups.
  * Environment refresh actions now work more consistently from any app state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->