### PR TITLE
Recover project structure with a full rebuild when the initial artifacts fetch fails

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/utils/project-artifacts.ts
+++ b/workspaces/ballerina/ballerina-extension/src/utils/project-artifacts.ts
@@ -17,11 +17,16 @@
  */
 import * as vscode from "vscode";
 import { URI, Utils } from "vscode-uri";
-import { ARTIFACT_TYPE, Artifacts, ArtifactsNotification, BaseArtifact, DIRECTORY_MAP, isSamePath, PROJECT_KIND, ProjectInfo, ProjectStructure, ProjectStructureArtifactResponse, ProjectStructureResponse } from "@wso2/ballerina-core";
+import { ARTIFACT_TYPE, Artifacts, ArtifactsNotification, BaseArtifact, DIRECTORY_MAP, isSamePath, PROJECT_KIND, ProjectInfo, ProjectStructure, ProjectStructureArtifactResponse, ProjectStructureResponse, SHARED_COMMANDS } from "@wso2/ballerina-core";
 import { StateMachine } from "../stateMachine";
 import { ExtendedLangClient } from "../core/extended-language-client";
 import { ArtifactsUpdated, ArtifactNotificationHandler } from "./project-artifacts-handler";
 import { isLibraryProject } from "./config";
+
+// Tracks projects whose artifacts could not be fetched (e.g., the initial load raced with a
+// missing-module pull and the compilation failed). Used to recover with a full rebuild once
+// the LS publishes artifacts after the pull completes.
+const failedArtifactProjects = new Set<string>();
 
 export async function buildProjectsStructure(
     projectInfo: ProjectInfo,
@@ -88,14 +93,37 @@ async function buildProjectArtifactsStructure(
     const designArtifacts = await langClient.getProjectArtifacts({ projectPath });
     console.log("designArtifacts", designArtifacts);
     if (designArtifacts?.artifacts) {
+        failedArtifactProjects.delete(projectPath);
         traverseComponents(designArtifacts.artifacts, projectPath, result);
         await populateLocalConnectors(projectPath, result);
+    } else {
+        // The artifact fetch failed (e.g., compilation error while modules are being pulled).
+        // Remember it so the next publishArtifacts notification triggers a full rebuild.
+        failedArtifactProjects.add(projectPath);
+        console.warn("[buildProjectArtifactsStructure] Failed to fetch artifacts for project:", projectPath);
     }
 
     return result;
 }
 
 export async function updateProjectArtifacts(publishedArtifacts: ArtifactsNotification): Promise<void> {
+    // If any project's artifacts failed to load earlier (e.g., the initial load raced with a
+    // missing-module pull), the cached structure is empty and incremental deltas cannot repair
+    // it. The LS publishes artifacts once the pull completes and the project is reloaded, so
+    // recover here with a full rebuild instead of applying the deltas.
+    if (failedArtifactProjects.size > 0) {
+        console.log("[updateProjectArtifacts] Rebuilding project structure; artifacts previously failed for:",
+            Array.from(failedArtifactProjects));
+        failedArtifactProjects.clear();
+        const notificationHandler = ArtifactNotificationHandler.getInstance();
+        notificationHandler.publish(ArtifactsUpdated.method, {
+            data: [],
+            timestamp: Date.now()
+        });
+        await vscode.commands.executeCommand(SHARED_COMMANDS.FORCE_UPDATE_PROJECT_ARTIFACTS);
+        return;
+    }
+
     // Current project structure
     const currentProjectStructure: ProjectStructureResponse = StateMachine.context().projectStructure;
 

--- a/workspaces/ballerina/ballerina-extension/src/utils/project-artifacts.ts
+++ b/workspaces/ballerina/ballerina-extension/src/utils/project-artifacts.ts
@@ -28,6 +28,11 @@ import { isLibraryProject } from "./config";
 // the LS publishes artifacts after the pull completes.
 const failedArtifactProjects = new Set<string>();
 
+// True while a recovery rebuild is in flight. Overlapping publishArtifacts notifications are
+// skipped during this window: the rebuild fetches the latest project state anyway, and letting
+// them run the incremental path would race the rebuild with updates based on stale structure.
+let artifactRecoveryInProgress = false;
+
 export async function buildProjectsStructure(
     projectInfo: ProjectInfo,
     langClient: ExtendedLangClient,
@@ -107,20 +112,38 @@ async function buildProjectArtifactsStructure(
 }
 
 export async function updateProjectArtifacts(publishedArtifacts: ArtifactsNotification): Promise<void> {
+    // A recovery rebuild is already running; it fetches the post-edit state, so this
+    // notification's changes are covered by the rebuild.
+    if (artifactRecoveryInProgress) {
+        return;
+    }
+
     // If any project's artifacts failed to load earlier (e.g., the initial load raced with a
     // missing-module pull), the cached structure is empty and incremental deltas cannot repair
     // it. The LS publishes artifacts once the pull completes and the project is reloaded, so
     // recover here with a full rebuild instead of applying the deltas.
     if (failedArtifactProjects.size > 0) {
+        const failedSnapshot = Array.from(failedArtifactProjects);
         console.log("[updateProjectArtifacts] Rebuilding project structure; artifacts previously failed for:",
-            Array.from(failedArtifactProjects));
+            failedSnapshot);
+        artifactRecoveryInProgress = true;
+        // Clear before the rebuild; buildProjectArtifactsStructure re-adds any project that
+        // still fails, and stale entries (e.g., removed packages) get pruned.
         failedArtifactProjects.clear();
         const notificationHandler = ArtifactNotificationHandler.getInstance();
         notificationHandler.publish(ArtifactsUpdated.method, {
             data: [],
             timestamp: Date.now()
         });
-        await vscode.commands.executeCommand(SHARED_COMMANDS.FORCE_UPDATE_PROJECT_ARTIFACTS);
+        try {
+            await vscode.commands.executeCommand(SHARED_COMMANDS.FORCE_UPDATE_PROJECT_ARTIFACTS);
+        } catch (error) {
+            // Restore the failed state so the next notification retries the recovery.
+            failedSnapshot.forEach(projectPath => failedArtifactProjects.add(projectPath));
+            console.error("[updateProjectArtifacts] Failed to rebuild the project structure:", error);
+        } finally {
+            artifactRecoveryInProgress = false;
+        }
         return;
     }
 


### PR DESCRIPTION


## Purpose

When a workspace is opened while dependency balas are missing from the local repository
(e.g., a transitively required version like `ballerina/task:2.7.0` was evicted from the cache),
the initial `designModelService/artifacts` request fails for every package because the
compilation crashes with a `BLangCompilerException`. The extension silently ignores the error
response and never retries, so the project overview cards and the project explorer tree stay
empty — even after the LS auto-pulls the missing modules successfully. The user has to navigate
into an integration and back to force a refresh.

Fixes https://github.com/wso2/product-integrator/issues/1807

## Goals

- Recover the project overview and project explorer automatically once the missing-module pull
  completes, without requiring the user to navigate away and back.
- Keep the recovery entirely on the extension side, using notifications the LS already sends —
  no LS changes and no new protocol messages.

## Approach

After a successful pull, the LS reloads the project and sends the existing
`designModelService/publishArtifacts` notification. That notification is used as the recovery
trigger:

- `buildProjectArtifactsStructure` now tracks project paths whose `getProjectArtifacts` call
  returned no artifacts (i.e., the fetch failed) in a module-level `failedArtifactProjects` set,
  and clears the entry on a successful fetch.
- `updateProjectArtifacts` (the `publishArtifacts` handler) checks the set before applying
  incremental deltas. If any project previously failed, incremental deltas cannot repair the
  empty cached structure, so it clears the set and runs `FORCE_UPDATE_PROJECT_ARTIFACTS`
  (a full `buildProjectsStructure` for all workspace members) instead, then returns.

Notes:

- An earlier approach of listening on `$/progress` for the `pull-module` token was rejected:
  vscode-jsonrpc keeps a single handler per notification method, so registering on `$/progress`
  replaces the language client's built-in progress dispatcher. This breaks the progress UI
  (e.g., the "Pull Module" notification never dismisses) for the rest of the session.
- The rebuild cannot loop: it issues `artifacts` requests, which do not produce
  `publishArtifacts` notifications, and the LS cannot publish at all while the workspace is
  still failing to compile.

**Testing:** Repro with `rm -rf ~/.ballerina/repositories/central.ballerina.io/bala/ballerina/task/2.7.0`,
open a multi-package workspace — overview and tree populate right after "Module(s) pulled
successfully!" without navigation. Regression-checked that normal file edits still update the
tree through the incremental delta path.

## UI Component Development
> Specify the reason if following are not followed.
- [ ] Added reusable UI components to the ui-toolkit. Follow the [intructions](./workspaces/common-libs/ui-toolkit/README.md) when adding the componenent.
- [ ] Use ui-toolkit components wherever possible. Run `npm run storybook` from the root directory to view current components.
- [ ] Matches with the native VSCode look and feel.

## Manage Icons
> Specify the reason if following are not followed.
- [ ] Added Icons to the font-wso2-vscode. Follow the [instructions](./workspaces/common-libs/font-wso2-vscode/README.md).

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project artifact loading when a workspace initially fails to fetch artifacts.
  * If artifact loading fails, the app now recovers by refreshing the project artifacts view and retrying with a full rebuild path.
  * This helps ensure connectors and related project items appear correctly after transient load issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->