### PR TITLE
Support query params when importing an API

### DIFF
--- a/workspaces/mi/mi-core/src/rpc-types/mi-diagram/types.ts
+++ b/workspaces/mi/mi-core/src/rpc-types/mi-diagram/types.ts
@@ -1835,6 +1835,7 @@ export interface ExportProjectRequest {
 
 interface GenerateAPIBase {
     apiName: string;
+    context?: string | null;
     swaggerOrWsdlPath: string;
 }
 

--- a/workspaces/mi/mi-extension/src/rpc-managers/mi-diagram/rpc-manager.ts
+++ b/workspaces/mi/mi-extension/src/rpc-managers/mi-diagram/rpc-manager.ts
@@ -779,6 +779,7 @@ export class MiDiagramRpcManager implements MiDiagramAPI {
                 if (swaggerDefPath) {
                     response = await langClient.generateAPI({
                         apiName: name,
+                        context: apiContext !== "" ? apiContext : null,
                         swaggerOrWsdlPath: swaggerDefPath,
                         publishSwaggerPath: saveSwaggerDef ? getPublishSwaggerPath(swaggerDefPath) : undefined,
                         mode: "create.api.from.swagger"
@@ -787,6 +788,7 @@ export class MiDiagramRpcManager implements MiDiagramAPI {
                     const filePath = wsdlType === "file" && Uri.file(wsdlDefPath).toString();
                     response = await langClient.generateAPI({
                         apiName: name,
+                        context: apiContext !== "" ? apiContext : null,
                         swaggerOrWsdlPath: filePath || wsdlDefPath,
                         mode: "create.api.from.wsdl",
                         wsdlEndpointName

--- a/workspaces/mi/mi-visualizer/src/views/Forms/APIform/index.tsx
+++ b/workspaces/mi/mi-visualizer/src/views/Forms/APIform/index.tsx
@@ -461,12 +461,14 @@ export function APIWizard({ apiData, path }: APIWizardProps) {
             if (swaggerDefPath) {
                 createAPIParams = {
                     ...createAPIParams,
+                    context: values.apiContext,
                     saveSwaggerDef: values.saveSwaggerDef,
                     swaggerDefPath: swaggerDefPath
                 }
             } else if (wsdlDefPath) {
                 createAPIParams = {
                     ...createAPIParams,
+                    context: values.apiContext,
                     wsdlType: values.wsdlType,
                     wsdlDefPath: wsdlDefPath,
                     wsdlEndpointName: values.wsdlEndpointName


### PR DESCRIPTION
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API creation now supports an optional context value for generated requests.
  * Context entered in the API form is now carried through for Swagger- and WSDL-based API creation flows.
* **Bug Fixes**
  * Empty context values are now handled consistently, improving request payload reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->