### PR TITLE
Fix duplicate `designModelService/projectInfo` calls and missing-scheme LSP notification errors

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/stateMachine.ts
+++ b/workspaces/ballerina/ballerina-extension/src/stateMachine.ts
@@ -43,7 +43,7 @@ import { AIStateMachine, openAIPanelWithPrompt } from './views/ai-panel/aiMachin
 import { StateMachinePopup } from './stateMachinePopup';
 import { checkIsBallerinaPackage, checkIsBI, fetchScope, getOrgPackageName, UndoRedoManager, getProjectTomlValues, getOrgAndPackageName, checkIsBallerinaWorkspace, isInWI, isInDevant } from './utils';
 import { activateDevantFeatures } from './features/devant/activator';
-import { buildProjectsStructure } from './utils/project-artifacts';
+import { buildProjectsStructure, refreshProjectStructure } from './utils/project-artifacts';
 import { runCommandWithOutput } from './utils/runCommand';
 import { buildOutputChannel } from './utils/logger';
 import { closeOrphanWebviewTabs } from './views/closeOrphanWebviewTabs';
@@ -69,6 +69,7 @@ interface MachineContext extends VisualizerLocation {
 export let history: History;
 export let undoRedoManager: IUndoRedoManager;
 let pendingProjectRootUpdateResolvers: Array<() => void> = [];
+let pendingProjectInfoUpdateResolvers: Array<() => void> = [];
 let scaffoldPromptTriggered = false;
 
 const stateMachine = createMachine<MachineContext>(
@@ -124,24 +125,10 @@ const stateMachine = createMachine<MachineContext>(
             REFRESH_PROJECT_INFO: {
                 actions: [
                     async (context, event) => {
-                        try {
-                            const projectPath = context.workspacePath || context.projectPath;
-                            if (!projectPath) {
-                                console.warn("No project path available for refreshing project info");
-                                return;
-                            }
-
-                            // Fetch updated project info from language server
-                            const projectInfo = await context.langClient.getProjectInfo({ projectPath });
-
-                            // Update context with new project info
-                            stateService.send({
-                                type: 'UPDATE_PROJECT_INFO',
-                                projectInfo
-                            });
-                        } catch (error) {
-                            console.error("Error refreshing project info:", error);
-                        }
+                        // Single-flight: concurrent refresh triggers (explicit refreshes and
+                        // publishArtifacts notifications for untracked packages) share one
+                        // projectInfo fetch and one structure rebuild.
+                        await refreshProjectStructure();
                     }
                 ]
             },
@@ -151,10 +138,15 @@ const stateMachine = createMachine<MachineContext>(
                         projectInfo: (context, event) => event.projectInfo
                     }),
                     async (context, event) => {
-                        // Rebuild project structure with updated project info
-                        await buildProjectsStructure(event.projectInfo, StateMachine.langClient(), true);
-                        if (!event.silent) {
-                            openView(EVENT_TYPE.OPEN_VIEW, { view: MACHINE_VIEW.WorkspaceOverview });
+                        try {
+                            // Rebuild project structure with updated project info
+                            await buildProjectsStructure(event.projectInfo, StateMachine.langClient(), true);
+                            if (!event.silent) {
+                                openView(EVENT_TYPE.OPEN_VIEW, { view: MACHINE_VIEW.WorkspaceOverview });
+                            }
+                        } finally {
+                            // Resolve the next pending promise waiting for the update to complete
+                            pendingProjectInfoUpdateResolvers.shift()?.();
                         }
                     }
                 ]
@@ -878,6 +870,12 @@ export const StateMachine = {
     },
     updateProjectInfo: (projectInfo: ProjectInfo, options?: { silent?: boolean }) => {
         stateService.send({ type: 'UPDATE_PROJECT_INFO', projectInfo, silent: options?.silent });
+    },
+    updateProjectInfoAndWait: (projectInfo: ProjectInfo, options?: { silent?: boolean }): Promise<void> => {
+        return new Promise<void>((resolve) => {
+            pendingProjectInfoUpdateResolvers.push(resolve);
+            stateService.send({ type: 'UPDATE_PROJECT_INFO', projectInfo, silent: options?.silent });
+        });
     },
     resetToExtensionReady: () => {
         stateService.send({ type: 'RESET_TO_EXTENSION_READY' });

--- a/workspaces/ballerina/ballerina-extension/src/stateMachine.ts
+++ b/workspaces/ballerina/ballerina-extension/src/stateMachine.ts
@@ -69,7 +69,6 @@ interface MachineContext extends VisualizerLocation {
 export let history: History;
 export let undoRedoManager: IUndoRedoManager;
 let pendingProjectRootUpdateResolvers: Array<() => void> = [];
-let pendingProjectInfoUpdateResolvers: Array<() => void> = [];
 let scaffoldPromptTriggered = false;
 
 const stateMachine = createMachine<MachineContext>(
@@ -144,9 +143,11 @@ const stateMachine = createMachine<MachineContext>(
                             if (!event.silent) {
                                 openView(EVENT_TYPE.OPEN_VIEW, { view: MACHINE_VIEW.WorkspaceOverview });
                             }
-                        } finally {
-                            // Resolve the next pending promise waiting for the update to complete
-                            pendingProjectInfoUpdateResolvers.shift()?.();
+                            // Resolve only this invocation's own waiter, if any
+                            event.onComplete?.();
+                        } catch (error) {
+                            // Reject only this invocation's own waiter so callers don't proceed on failed rebuilds
+                            event.onError?.(error);
                         }
                     }
                 ]
@@ -872,9 +873,14 @@ export const StateMachine = {
         stateService.send({ type: 'UPDATE_PROJECT_INFO', projectInfo, silent: options?.silent });
     },
     updateProjectInfoAndWait: (projectInfo: ProjectInfo, options?: { silent?: boolean }): Promise<void> => {
-        return new Promise<void>((resolve) => {
-            pendingProjectInfoUpdateResolvers.push(resolve);
-            stateService.send({ type: 'UPDATE_PROJECT_INFO', projectInfo, silent: options?.silent });
+        return new Promise<void>((resolve, reject) => {
+            stateService.send({
+                type: 'UPDATE_PROJECT_INFO',
+                projectInfo,
+                silent: options?.silent,
+                onComplete: resolve,
+                onError: reject
+            });
         });
     },
     resetToExtensionReady: () => {

--- a/workspaces/ballerina/ballerina-extension/src/utils/modification.ts
+++ b/workspaces/ballerina/ballerina-extension/src/utils/modification.ts
@@ -82,8 +82,9 @@ export function writeBallerinaFileDidOpenTemp(filePath: string, content: string)
     }
     const contentWithNewline = ensureTrailingNewline(content);
     writeFileSync(filePath, contentWithNewline);
+    const fileUri = Uri.file(filePath).toString();
     StateMachine.langClient().didChange({
-        textDocument: { uri: filePath, version: 1 },
+        textDocument: { uri: fileUri, version: 1 },
         contentChanges: [
             {
                 text: contentWithNewline,
@@ -92,7 +93,7 @@ export function writeBallerinaFileDidOpenTemp(filePath: string, content: string)
     });
     StateMachine.langClient().didOpen({
         textDocument: {
-            uri: Uri.file(filePath).toString(),
+            uri: fileUri,
             languageId: 'ballerina',
             version: 1,
             text: contentWithNewline
@@ -103,8 +104,9 @@ export function writeBallerinaFileDidOpenTemp(filePath: string, content: string)
 export async function writeBallerinaFileDidOpen(filePath: string, content: string) {
     const contentWithNewline = ensureTrailingNewline(content);
     writeFileSync(filePath, contentWithNewline);
+    const fileUri = Uri.file(filePath).toString();
     StateMachine.langClient().didChange({
-        textDocument: { uri: filePath, version: 1 },
+        textDocument: { uri: fileUri, version: 1 },
         contentChanges: [
             {
                 text: contentWithNewline,
@@ -113,7 +115,7 @@ export async function writeBallerinaFileDidOpen(filePath: string, content: strin
     });
     StateMachine.langClient().didOpen({
         textDocument: {
-            uri: Uri.file(filePath).toString(),
+            uri: fileUri,
             languageId: 'ballerina',
             version: 1,
             text: contentWithNewline

--- a/workspaces/ballerina/ballerina-extension/src/utils/project-artifacts.ts
+++ b/workspaces/ballerina/ballerina-extension/src/utils/project-artifacts.ts
@@ -17,7 +17,7 @@
  */
 import * as vscode from "vscode";
 import { URI, Utils } from "vscode-uri";
-import { ARTIFACT_TYPE, Artifacts, ArtifactsNotification, BaseArtifact, DIRECTORY_MAP, PROJECT_KIND, ProjectInfo, ProjectStructure, ProjectStructureArtifactResponse, ProjectStructureResponse, SHARED_COMMANDS } from "@wso2/ballerina-core";
+import { ARTIFACT_TYPE, Artifacts, ArtifactsNotification, BaseArtifact, DIRECTORY_MAP, isPathInside, PROJECT_KIND, ProjectInfo, ProjectStructure, ProjectStructureArtifactResponse, ProjectStructureResponse, SHARED_COMMANDS } from "@wso2/ballerina-core";
 import { StateMachine } from "../stateMachine";
 import { ExtendedLangClient } from "../core/extended-language-client";
 import { ArtifactsUpdated, ArtifactNotificationHandler } from "./project-artifacts-handler";
@@ -190,15 +190,15 @@ export async function updateProjectArtifacts(publishedArtifacts: ArtifactsNotifi
         console.warn("[updateProjectArtifacts] No project or workspace path found in the StateMachine context.");
         return;
     }
-    const notificationPath = URI.parse(publishedArtifacts.uri).fsPath.toLowerCase();
-    const isWithinProject = notificationPath.includes(URI.file(rootPath).fsPath.toLowerCase());
+    const notificationPath = URI.parse(publishedArtifacts.uri).fsPath;
+    const isWithinProject = isPathInside(rootPath, notificationPath);
 
     const isSubmodule = publishedArtifacts?.moduleName;
 
     if (currentProjectStructure && isWithinProject && !isSubmodule) {
         // Route the notification to the package it belongs to.
         const targetProject = currentProjectStructure.projects?.find(project =>
-            project.projectPath && notificationPath.includes(URI.file(project.projectPath).fsPath.toLowerCase()));
+            isPathInside(project.projectPath, notificationPath));
 
         if (!targetProject) {
             // The notification is for a package missing from the structure — a package created
@@ -217,8 +217,8 @@ export async function updateProjectArtifacts(publishedArtifacts: ArtifactsNotifi
             return;
         }
 
-        const persistDir = Utils.joinPath(URI.file(targetProject.projectPath), 'persist').fsPath.toLowerCase();
-        if (notificationPath.includes(persistDir)) {
+        const persistDir = Utils.joinPath(URI.file(targetProject.projectPath), 'persist').fsPath;
+        if (isPathInside(persistDir, notificationPath)) {
             const notificationHandler = ArtifactNotificationHandler.getInstance();
             notificationHandler.publish(ArtifactsUpdated.method, {
                 data: [],

--- a/workspaces/ballerina/ballerina-extension/src/utils/project-artifacts.ts
+++ b/workspaces/ballerina/ballerina-extension/src/utils/project-artifacts.ts
@@ -40,7 +40,7 @@ let artifactRecoveryInProgress = false;
 // request and one rebuild instead of one per notification.
 let projectRefreshInFlight: Promise<void> | null = null;
 
-export function refreshProjectStructure(): Promise<void> {
+export function refreshProjectStructure(silent: boolean = false): Promise<void> {
     if (!projectRefreshInFlight) {
         projectRefreshInFlight = (async () => {
             try {
@@ -54,7 +54,7 @@ export function refreshProjectStructure(): Promise<void> {
                     console.warn("[refreshProjectStructure] Project info not found for:", workspacePath);
                     return;
                 }
-                await StateMachine.updateProjectInfoAndWait(projectInfo);
+                await StateMachine.updateProjectInfoAndWait(projectInfo, { silent });
             } catch (error) {
                 console.error("[refreshProjectStructure] Failed to refresh the project structure:", error);
             } finally {
@@ -211,7 +211,9 @@ export async function updateProjectArtifacts(publishedArtifacts: ArtifactsNotifi
                 data: [],
                 timestamp: Date.now()
             });
-            await refreshProjectStructure();
+            // Silent: this refresh is triggered by a background LS notification, not a user
+            // action, so it must not steal focus by opening WorkspaceOverview.
+            await refreshProjectStructure(true);
             return;
         }
 

--- a/workspaces/ballerina/ballerina-extension/src/utils/project-artifacts.ts
+++ b/workspaces/ballerina/ballerina-extension/src/utils/project-artifacts.ts
@@ -17,7 +17,7 @@
  */
 import * as vscode from "vscode";
 import { URI, Utils } from "vscode-uri";
-import { ARTIFACT_TYPE, Artifacts, ArtifactsNotification, BaseArtifact, DIRECTORY_MAP, isSamePath, PROJECT_KIND, ProjectInfo, ProjectStructure, ProjectStructureArtifactResponse, ProjectStructureResponse, SHARED_COMMANDS } from "@wso2/ballerina-core";
+import { ARTIFACT_TYPE, Artifacts, ArtifactsNotification, BaseArtifact, DIRECTORY_MAP, PROJECT_KIND, ProjectInfo, ProjectStructure, ProjectStructureArtifactResponse, ProjectStructureResponse, SHARED_COMMANDS } from "@wso2/ballerina-core";
 import { StateMachine } from "../stateMachine";
 import { ExtendedLangClient } from "../core/extended-language-client";
 import { ArtifactsUpdated, ArtifactNotificationHandler } from "./project-artifacts-handler";
@@ -32,6 +32,38 @@ const failedArtifactProjects = new Set<string>();
 // skipped during this window: the rebuild fetches the latest project state anyway, and letting
 // them run the incremental path would race the rebuild with updates based on stale structure.
 let artifactRecoveryInProgress = false;
+
+// Single-flight full refresh of the project info and structure. Every trigger — an explicit
+// refresh (e.g. addProjectToWorkspace after creating a package) or a publishArtifacts
+// notification for a package missing from the structure — funnels through here, so the burst
+// of notifications the LS emits after a workspace-wide change results in one projectInfo
+// request and one rebuild instead of one per notification.
+let projectRefreshInFlight: Promise<void> | null = null;
+
+export function refreshProjectStructure(): Promise<void> {
+    if (!projectRefreshInFlight) {
+        projectRefreshInFlight = (async () => {
+            try {
+                const workspacePath = StateMachine.context().workspacePath ?? StateMachine.context().projectPath;
+                if (!workspacePath) {
+                    console.warn("[refreshProjectStructure] No project or workspace path found in the StateMachine context.");
+                    return;
+                }
+                const projectInfo = await StateMachine.langClient().getProjectInfo({ projectPath: workspacePath });
+                if (!projectInfo) {
+                    console.warn("[refreshProjectStructure] Project info not found for:", workspacePath);
+                    return;
+                }
+                await StateMachine.updateProjectInfoAndWait(projectInfo);
+            } catch (error) {
+                console.error("[refreshProjectStructure] Failed to refresh the project structure:", error);
+            } finally {
+                projectRefreshInFlight = null;
+            }
+        })();
+    }
+    return projectRefreshInFlight;
+}
 
 export async function buildProjectsStructure(
     projectInfo: ProjectInfo,
@@ -150,62 +182,50 @@ export async function updateProjectArtifacts(publishedArtifacts: ArtifactsNotifi
     // Current project structure
     const currentProjectStructure: ProjectStructureResponse = StateMachine.context().projectStructure;
 
-    const rootPath = StateMachine.context().projectPath ?? StateMachine.context().workspacePath;
+    // Use the widest root available so notifications for every package in the workspace are
+    // handled the same way regardless of which view the user has navigated to. The project
+    // path fallback covers standalone integrations/libraries opened without a workspace.
+    const rootPath = StateMachine.context().workspacePath ?? StateMachine.context().projectPath;
     if (!rootPath) {
         console.warn("[updateProjectArtifacts] No project or workspace path found in the StateMachine context.");
         return;
     }
-    const projectUri = URI.file(rootPath);
-    const isWithinProject = URI
-        .parse(publishedArtifacts.uri).fsPath.toLowerCase()
-        .includes(projectUri.fsPath.toLowerCase());
+    const notificationPath = URI.parse(publishedArtifacts.uri).fsPath.toLowerCase();
+    const isWithinProject = notificationPath.includes(URI.file(rootPath).fsPath.toLowerCase());
 
     const isSubmodule = publishedArtifacts?.moduleName;
 
-    const persistDir = Utils.joinPath(projectUri, 'persist').fsPath.toLowerCase();
-    const isInPersistDir = URI.parse(publishedArtifacts.uri).fsPath.toLowerCase().includes(persistDir);
+    if (currentProjectStructure && isWithinProject && !isSubmodule) {
+        // Route the notification to the package it belongs to.
+        const targetProject = currentProjectStructure.projects?.find(project =>
+            project.projectPath && notificationPath.includes(URI.file(project.projectPath).fsPath.toLowerCase()));
 
-    if (currentProjectStructure && isWithinProject && !isSubmodule && !isInPersistDir) {
-        // If user is working on a workspace project pick the workspace path, otherwise fallback to the project path.
-        // Fallback can happen when user is working on a standalone integration/library and
-        // adding another integration/library via AI chat.
-        const workspacePath = StateMachine.context().workspacePath ?? StateMachine.context().projectPath;
-        if (!workspacePath) {
-            console.warn("[updateProjectArtifacts] Workspace path not found in the StateMachine context.");
-            return;
-        }
-        
-        const projectInfo = await StateMachine.langClient().getProjectInfo({ projectPath: workspacePath });
-        if (!projectInfo) {
-            console.warn("[updateProjectArtifacts] Project info not found for the project:", rootPath);
-            return;
-        }
-
-        const isWorkspace = projectInfo.projectKind === PROJECT_KIND.WORKSPACE_PROJECT;
-        const packages = isWorkspace ? projectInfo.children : [projectInfo];
-
-        const untrackedProjectPaths = packages
-            ?.filter(child => child?.projectPath !== undefined)
-            ?.filter(
-                child => !currentProjectStructure.projects
-                    ?.some(project => isSamePath(project.projectPath, child.projectPath))
-            ).map(child => child.projectPath) ?? [];
-
-        // Check if the active project exists in the current structure.
-        // If not (e.g., a new package was added by Copilot), a full rebuild is needed
-        // since we can't incrementally update a project that doesn't exist yet.
-        for (const untrackedProjectPath of untrackedProjectPaths) {
-            console.log("[updateProjectArtifacts] Project not found in structure, triggering full rebuild:", untrackedProjectPath);
+        if (!targetProject) {
+            // The notification is for a package missing from the structure — a package created
+            // without an explicit refresh (e.g., by Ballerina Copilot). Trigger a full refresh;
+            // it is single-flight, so the notification burst the LS emits for a new package
+            // (and an already-running refresh from addProjectToWorkspace) share one rebuild.
+            console.log("[updateProjectArtifacts] Package not found in structure, refreshing project structure:", notificationPath);
             const notificationHandler = ArtifactNotificationHandler.getInstance();
             notificationHandler.publish(ArtifactsUpdated.method, {
                 data: [],
                 timestamp: Date.now()
             });
-            StateMachine.refreshProjectInfo();
+            await refreshProjectStructure();
             return;
         }
 
-        const entryLocations = await traverseUpdatedComponents(publishedArtifacts.artifacts, currentProjectStructure);
+        const persistDir = Utils.joinPath(URI.file(targetProject.projectPath), 'persist').fsPath.toLowerCase();
+        if (notificationPath.includes(persistDir)) {
+            const notificationHandler = ArtifactNotificationHandler.getInstance();
+            notificationHandler.publish(ArtifactsUpdated.method, {
+                data: [],
+                timestamp: Date.now()
+            });
+            return;
+        }
+
+        const entryLocations = await traverseUpdatedComponents(publishedArtifacts.artifacts, targetProject);
         const notificationHandler = ArtifactNotificationHandler.getInstance();
         // Publish a notification to the artifact handler
         notificationHandler.publish(ArtifactsUpdated.method, {
@@ -408,20 +428,13 @@ function getDirectoryMapKeyAndIcon(artifact: BaseArtifact, artifactCategoryKey: 
  * Processes a single artifact deletion.
  * @param artifact The artifact to delete.
  * @param artifactCategoryKey The category key (from ARTIFACT_TYPE).
- * @param projectStructure The project structure to modify.
+ * @param project The project structure of the package the artifact belongs to.
  */
-function processDeletion(artifact: BaseArtifact, artifactCategoryKey: string, projectStructure: ProjectStructureResponse): void {
+function processDeletion(artifact: BaseArtifact, artifactCategoryKey: string, project: ProjectStructure): void {
     const mapping = getDirectoryMapKeyAndIcon(artifact, artifactCategoryKey);
     if (mapping) {
-        try {
-            const projectPath = StateMachine.context().projectPath;
-            const project = projectStructure.projects.find(project => isSamePath(project.projectPath, projectPath));
-            project.directoryMap[mapping.mapKey] =
-                project.directoryMap[mapping.mapKey]?.filter(value => value.id !== artifact.id) ?? [];
-        } catch (error) {
-            //TODO: Hack: Properly fix for the workspace scenario
-            console.error(`Error processing deletion for artifact ${artifact.id} in category ${artifactCategoryKey}:`, error);
-        }
+        project.directoryMap[mapping.mapKey] =
+            project.directoryMap[mapping.mapKey]?.filter(value => value.id !== artifact.id) ?? [];
     } else {
         console.error(`Could not determine directory map key for deletion of artifact ${artifact.id} in category ${artifactCategoryKey}`);
     }
@@ -431,17 +444,15 @@ function processDeletion(artifact: BaseArtifact, artifactCategoryKey: string, pr
  * Processes a single artifact addition.
  * @param artifact The artifact to add.
  * @param artifactCategoryKey The category key (from ARTIFACT_TYPE).
- * @param projectStructure The project structure to modify.
+ * @param project The project structure of the package the artifact belongs to.
  * @returns A promise resolving to the potentially relevant visualization entry, or undefined.
  */
-async function processAddition(artifact: BaseArtifact, artifactCategoryKey: string, projectStructure: ProjectStructureResponse): Promise<ProjectStructureArtifactResponse | undefined> {
+async function processAddition(artifact: BaseArtifact, artifactCategoryKey: string, project: ProjectStructure): Promise<ProjectStructureArtifactResponse | undefined> {
     const mapping = getDirectoryMapKeyAndIcon(artifact, artifactCategoryKey);
     if (mapping) {
         try {
-            const projectPath = StateMachine.context().projectPath;
-            const entryValue = await getEntryValue(artifact, projectPath, mapping.icon);
+            const entryValue = await getEntryValue(artifact, project.projectPath, mapping.icon);
 
-            const project = projectStructure.projects.find(project => isSamePath(project.projectPath, projectPath));
             // Ensure the array exists before pushing
             if (!project.directoryMap[mapping.mapKey]) {
                 project.directoryMap[mapping.mapKey] = [];
@@ -463,16 +474,14 @@ async function processAddition(artifact: BaseArtifact, artifactCategoryKey: stri
  * Processes a single artifact update.
  * @param artifact The artifact to update.
  * @param artifactCategoryKey The category key (from ARTIFACT_TYPE).
- * @param projectStructure The project structure to modify.
+ * @param project The project structure of the package the artifact belongs to.
  * @returns A promise resolving to the potentially relevant visualization entry, or undefined.
  */
-async function processUpdate(artifact: BaseArtifact, artifactCategoryKey: string, projectStructure: ProjectStructureResponse): Promise<ProjectStructureArtifactResponse | undefined> {
+async function processUpdate(artifact: BaseArtifact, artifactCategoryKey: string, project: ProjectStructure): Promise<ProjectStructureArtifactResponse | undefined> {
     const mapping = getDirectoryMapKeyAndIcon(artifact, artifactCategoryKey);
     if (mapping) {
         try {
-            const projectPath = StateMachine.context().projectPath;
-            const entryValue = await getEntryValue(artifact, projectPath, mapping.icon);
-            const project = projectStructure.projects.find(project => isSamePath(project.projectPath, projectPath));
+            const entryValue = await getEntryValue(artifact, project.projectPath, mapping.icon);
             // Ensure the array exists
             if (!project.directoryMap[mapping.mapKey]) {
                 project.directoryMap[mapping.mapKey] = [];
@@ -496,7 +505,7 @@ async function processUpdate(artifact: BaseArtifact, artifactCategoryKey: string
     }
 }
 
-async function traverseUpdatedComponents(publishedArtifacts: Artifacts, currentProjectStructure: ProjectStructureResponse): Promise<ProjectStructureArtifactResponse[]> {
+async function traverseUpdatedComponents(publishedArtifacts: Artifacts, targetProject: ProjectStructure): Promise<ProjectStructureArtifactResponse[]> {
     const entryLocations: ProjectStructureArtifactResponse[] = [];
     const promises: Promise<ProjectStructureArtifactResponse | undefined>[] = [];
 
@@ -505,21 +514,21 @@ async function traverseUpdatedComponents(publishedArtifacts: Artifacts, currentP
         // Process Deletions first (synchronous)
         if (actionMap.deletions) {
             for (const artifact of Object.values(actionMap.deletions) as BaseArtifact[]) {
-                processDeletion(artifact, artifactCategoryKey, currentProjectStructure);
+                processDeletion(artifact, artifactCategoryKey, targetProject);
             }
         }
 
         // Process Additions (asynchronous)
         if (actionMap.additions) {
             for (const artifact of Object.values(actionMap.additions) as BaseArtifact[]) {
-                promises.push(processAddition(artifact, artifactCategoryKey, currentProjectStructure));
+                promises.push(processAddition(artifact, artifactCategoryKey, targetProject));
             }
         }
 
         // Process Updates (asynchronous)
         if (actionMap.updates) {
             for (const artifact of Object.values(actionMap.updates) as BaseArtifact[]) {
-                promises.push(processUpdate(artifact, artifactCategoryKey, currentProjectStructure));
+                promises.push(processUpdate(artifact, artifactCategoryKey, targetProject));
             }
         }
     }
@@ -527,19 +536,10 @@ async function traverseUpdatedComponents(publishedArtifacts: Artifacts, currentP
     // Wait for all additions and updates to complete
     const results = await Promise.all(promises);
 
-    const projectPath = StateMachine.context().projectPath;
-    const project = currentProjectStructure.projects.find(project => isSamePath(project.projectPath, projectPath));
-    try {
-        if (project) {
-            for (const key of Object.keys(project.directoryMap)) {
-                if (project.directoryMap[key]) {
-                    project.directoryMap[key].sort((a, b) => a.name.localeCompare(b.name));
-                }
-            }
+    for (const key of Object.keys(targetProject.directoryMap)) {
+        if (targetProject.directoryMap[key]) {
+            targetProject.directoryMap[key].sort((a, b) => a.name.localeCompare(b.name));
         }
-    } catch (error) {
-        //TODO: Hack: Properly fix for the workspace scenario
-        console.error(`Error sorting directory map entries for project ${projectPath}:`, error);
     }
 
     // Populate addition entry locations

--- a/workspaces/ballerina/ballerina-extension/src/views/notebook/languageProvider.ts
+++ b/workspaces/ballerina/ballerina-extension/src/views/notebook/languageProvider.ts
@@ -18,7 +18,7 @@
 
 import {
     CancellationToken, CompletionContext, CompletionItem, CompletionItemProvider, CompletionList,
-    Disposable, DocumentSelector, languages, Position, TextDocument,
+    Disposable, DocumentSelector, languages, Position, TextDocument, Uri,
 } from "vscode";
 import { CompletionItemKind as MonacoCompletionItemKind } from "monaco-languageclient";
 import { SyntaxTree, NotebookFileSource } from "@wso2/ballerina-core";
@@ -53,12 +53,13 @@ export class NotebookCompletionItemProvider implements CompletionItemProvider {
             return [];
         }
         let { content, filePath } = response as NotebookFileSource;
-        performDidOpen(langClient, filePath, content);
-        let endPositionOfMain = await this.getEndPositionOfMain(langClient, filePath);
+        const fileUri = Uri.file(filePath).toString();
+        performDidOpen(langClient, fileUri, content);
+        let endPositionOfMain = await this.getEndPositionOfMain(langClient, fileUri);
         let textToWrite = content ? `${content.substring(0, content.length - 1)}${document.getText()}\n}` : document.getText();
         langClient.didChange({
             textDocument: {
-                uri: filePath,
+                uri: fileUri,
                 version: 2,
             },
             contentChanges: [
@@ -69,7 +70,7 @@ export class NotebookCompletionItemProvider implements CompletionItemProvider {
         });
         let completions = await langClient.getCompletion({
             textDocument: {
-                uri: filePath
+                uri: fileUri
             },
             position: {
                 character: endPositionOfMain.character + position.character,
@@ -89,10 +90,10 @@ export class NotebookCompletionItemProvider implements CompletionItemProvider {
         });
     }
 
-    private async getEndPositionOfMain(langClient: ExtendedLangClient, filePath: string) {
+    private async getEndPositionOfMain(langClient: ExtendedLangClient, fileUri: string) {
         let response = await langClient.getSyntaxTree({
             documentIdentifier: {
-                uri: filePath
+                uri: fileUri
             }
         });
         let syntaxTree = response as any;
@@ -125,10 +126,10 @@ export function registerLanguageProviders(ballerinaExtInstance: BallerinaExtensi
     return Disposable.from(...disposables);
 }
 
-function performDidOpen(langClient: ExtendedLangClient, filePath: string, content: string) {
+function performDidOpen(langClient: ExtendedLangClient, fileUri: string, content: string) {
     langClient.didOpen({
         textDocument: {
-            uri: filePath,
+            uri: fileUri,
             languageId: LANGUAGE.BALLERINA,
             version: 1,
             text: content


### PR DESCRIPTION
## Purpose
$title
- Adding a new integration fired multiple `designModelService/projectInfo` requests. Replaced with URI-based untracked-package detection and a single-flight `refreshProjectStructure()` shared across all refresh triggers.
- Fixed `Missing scheme` LS errors on `text/didChange` caused by passing raw filesystem paths instead of `file://` URIs in `modification.ts` and the notebook completion provider.

Addresses: https://github.com/wso2/product-integrator/issues/1888

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project information refresh behavior under concurrent updates, including safer error handling and clearer completion/failure signaling.
  * Kept project structure and artifact details better synchronized, with more accurate package matching and fewer unnecessary updates.
  * Added a single-flight full refresh mechanism to reduce redundant refresh work.
  * Standardized file URI handling across editor notifications and notebook completion/syntax-tree lookups, including for temporary files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->