### PR TITLE
Remove ICP for ballerina-ext users

### DIFF
--- a/workspaces/ballerina/ballerina-core/src/state-machine-types.ts
+++ b/workspaces/ballerina/ballerina-core/src/state-machine-types.ts
@@ -187,6 +187,7 @@ export interface ApprovalOverlayState {
 export interface VisualizerMetadata {
     haveLS?: boolean;
     isBISupported?: boolean;
+    isICPSupported?: boolean; // ICP is only available alongside the WSO2 Integrator extension
     recordFilePath?: string;
     enableSequenceDiagram?: boolean; // Enable sequence diagram view
     target?: LinePosition;

--- a/workspaces/ballerina/ballerina-extension/package.json
+++ b/workspaces/ballerina/ballerina-extension/package.json
@@ -783,13 +783,13 @@
                 "command": "ballerina.icp.start",
                 "title": "Start ICP",
                 "category": "Ballerina",
-                "enablement": "isSupportedProject && !ballerina.icpRunning && !devant.editor"
+                "enablement": "isSupportedProject && ballerina.icpSupported && !ballerina.icpRunning && !devant.editor"
             },
             {
                 "command": "ballerina.icp.stop",
                 "title": "Stop ICP",
                 "category": "Ballerina",
-                "enablement": "isSupportedProject && ballerina.icpRunning && !devant.editor"
+                "enablement": "isSupportedProject && ballerina.icpSupported && ballerina.icpRunning && !devant.editor"
             },
             {
                 "command": "ballerina.showTraceWindow",

--- a/workspaces/ballerina/ballerina-extension/src/RPCLayer.ts
+++ b/workspaces/ballerina/ballerina-extension/src/RPCLayer.ts
@@ -43,6 +43,7 @@ import { registerDataMapperRpcHandlers } from './rpc-managers/data-mapper/rpc-ha
 import { registerTestManagerRpcHandlers } from './rpc-managers/test-manager/rpc-handler';
 import { registerIcpServiceRpcHandlers } from './rpc-managers/icp-service/rpc-handler';
 import { extension } from './BalExtensionContext';
+import { isICPSupported } from './utils/config';
 import { registerAgentChatRpcHandlers } from './rpc-managers/agent-chat/rpc-handler';
 import { ChatPanel } from './views/agent-chat/webview';
 import { activeAgentChanged, tracingStatusChanged, TraceStatus } from '@wso2/ballerina-core';
@@ -150,6 +151,7 @@ async function getContext(): Promise<VisualizerLocation> {
             rootDiagramId: context.rootDiagramId,
             metadata: {
                 isBISupported: context.isBISupported,
+                isICPSupported: isICPSupported(),
                 haveLS: StateMachine.langClient() && true,
                 recordFilePath: context.projectPath ? path.join(context.projectPath, "types.bal") : undefined,
                 enableSequenceDiagram: extension.ballerinaExtInstance.enableSequenceDiagramView(),

--- a/workspaces/ballerina/ballerina-extension/src/extension.ts
+++ b/workspaces/ballerina/ballerina-extension/src/extension.ts
@@ -37,7 +37,7 @@ import { activate as activateBIFeatures } from './features/bi';
 import { activate as activateERDiagram } from './views/persist-layer-diagram';
 import { activateAiPanel } from './views/ai-panel';
 import { activateMigrationPanel } from './views/migration-panel';
-import { debug, handleResolveMissingDependencies, isInDevant, log } from './utils';
+import { debug, handleResolveMissingDependencies, isICPSupported, isInDevant, log } from './utils';
 import { activateUriHandlers } from './utils/uri-handlers';
 import { StateMachine } from './stateMachine';
 import { activateSubscriptions } from './views/visualizer/activate';
@@ -250,8 +250,8 @@ export async function activateBallerina(): Promise<BallerinaExtension> {
         // Activate Tracing Feature
         activateTracing(ballerinaExtInstance);
 
-        // Activate ICP (Integration Control Plane) — skip in Devant
-        if (!isInDevant()) {
+        // Activate ICP (Integration Control Plane) — skip in Devant and without the Integrator extension
+        if (!isInDevant() && isICPSupported()) {
             activateICP(ballerinaExtInstance);
         }
 

--- a/workspaces/ballerina/ballerina-extension/src/features/bi/activator.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/bi/activator.ts
@@ -37,7 +37,7 @@ import { StateMachine } from "../../stateMachine";
 import { BiDiagramRpcManager } from "../../rpc-managers/bi-diagram/rpc-manager";
 import { readFileSync, readdirSync, statSync } from "fs";
 import path from "path";
-import { isInDevant } from "../../utils";
+import { isICPSupported, isInDevant } from "../../utils";
 import { isPositionEqual, isPositionWithinDeletedComponent } from "../../utils/history/util";
 import { startDebugging } from "../editor-support/activator";
 import {
@@ -74,8 +74,8 @@ export function activate(context: BallerinaExtension) {
         const isWebviewOpen = VisualizerWebview.currentPanel !== undefined;
         const hasActiveTextEditor = !!window.activeTextEditor;
 
-        // Check if ICP is enabled for this project (skip entirely in Devant)
-        if (!isInDevant() && projectPath && stateMachineContext.langClient) {
+        // Check if ICP is enabled for this project (skip in Devant and without the Integrator extension)
+        if (!isInDevant() && isICPSupported() && projectPath && stateMachineContext.langClient) {
             try {
                 const icpStatus = await stateMachineContext.langClient.isIcpEnabled({ projectPath });
                 if (icpStatus && 'enabled' in icpStatus && icpStatus.enabled) {

--- a/workspaces/ballerina/ballerina-extension/src/features/icp/activator.ts
+++ b/workspaces/ballerina/ballerina-extension/src/features/icp/activator.ts
@@ -265,6 +265,10 @@ function createICPTask(icpPath: string): vscode.Task {
 }
 
 export function activateICP(ballerinaExtInstance: BallerinaExtension) {
+    // Only set when ICP is available — the ICP commands are gated on this key in package.json,
+    // and an unset key evaluates as false for the standalone Ballerina extension.
+    vscode.commands.executeCommand('setContext', 'ballerina.icpSupported', true);
+
     statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 99);
     setICPState(false);
     statusBarItem.show();

--- a/workspaces/ballerina/ballerina-extension/src/rpc-managers/icp-service/rpc-manager.ts
+++ b/workspaces/ballerina/ballerina-extension/src/rpc-managers/icp-service/rpc-manager.ts
@@ -31,6 +31,7 @@ import { updateSourceCode } from "../../utils/source-utils";
 import { parse, stringify } from "@iarna/toml";
 import { getProjectHandle, getStoredICPSecret } from "../../features/icp/setup";
 import { ensureICPServerRunning, isICPServerRunning, getICPUrl } from "../../features/icp";
+import { isICPSupported } from "../../utils/config";
 
 const ICP_IMPORTS = [
     'import wso2/icp.runtime.bridge as _;',
@@ -272,6 +273,9 @@ function removeICPConfigToml(projectPath: string): void {
 export class ICPServiceRpcManager implements ICPServiceAPI {
 
     async addICP(params: ICPEnabledRequest): Promise<ICPEnabledResponse> {
+        if (!isICPSupported()) {
+            return { enabled: false };
+        }
         return new Promise(async (resolve) => {
             const context = StateMachine.context();
             try {
@@ -292,6 +296,9 @@ export class ICPServiceRpcManager implements ICPServiceAPI {
     }
 
     async disableICP(params: ICPEnabledRequest): Promise<ICPEnabledResponse> {
+        if (!isICPSupported()) {
+            return { enabled: false };
+        }
         return new Promise(async (resolve) => {
             const context = StateMachine.context();
             try {
@@ -313,10 +320,13 @@ export class ICPServiceRpcManager implements ICPServiceAPI {
 
 
     async isICPServerRunning(params: ICPEnabledRequest): Promise<ICPEnabledResponse> {
-        return { enabled: isICPServerRunning() };
+        return { enabled: isICPSupported() && isICPServerRunning() };
     }
 
     async viewInICP(params: ICPEnabledRequest): Promise<ICPEnabledResponse> {
+        if (!isICPSupported()) {
+            return { enabled: false };
+        }
         try {
             const icpUrl = getICPUrl();
 
@@ -350,6 +360,9 @@ export class ICPServiceRpcManager implements ICPServiceAPI {
     }
 
     async isIcpEnabled(params: ICPEnabledRequest): Promise<ICPEnabledResponse> {
+        if (!isICPSupported()) {
+            return { enabled: false };
+        }
         return new Promise(async (resolve) => {
             const context = StateMachine.context();
             try {

--- a/workspaces/ballerina/ballerina-extension/src/utils/config.ts
+++ b/workspaces/ballerina/ballerina-extension/src/utils/config.ts
@@ -233,6 +233,15 @@ export function isInWI(): boolean {
     return !!extensions.getExtension(WI_EXTENSION_ID);
 }
 
+/**
+ * ICP (Integration Control Plane) ships inside the WSO2 Integrator installation, so it is only
+ * offered when the Integrator extension is present. Users running the Ballerina extension on its
+ * own get no ICP commands, status bar item, or ICP sections in the overview webviews.
+ */
+export function isICPSupported(): boolean {
+    return isInWI();
+}
+
 export function isInDevant(): boolean {
     return !!process.env.CLOUD_STS_TOKEN;
 }

--- a/workspaces/ballerina/ballerina-visualizer/src/MainPanel.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/MainPanel.tsx
@@ -337,6 +337,7 @@ const MainPanel = () => {
                                 <PackageOverview
                                     projectPath={value.projectPath}
                                     isInDevant={value.isInDevant}
+                                    isICPSupported={value.metadata?.isICPSupported}
                                 />
                             );
                             break;
@@ -344,7 +345,12 @@ const MainPanel = () => {
                         case MACHINE_VIEW.WorkspaceOverview: {
                             const { WorkspaceOverview } = await import("./views/BI/WorkspaceOverview");
                             if (isStaleNavigation()) return;
-                            setViewComponent(<WorkspaceOverview isInDevant={value.isInDevant} />);
+                            setViewComponent(
+                                <WorkspaceOverview
+                                    isInDevant={value.isInDevant}
+                                    isICPSupported={value.metadata?.isICPSupported}
+                                />
+                            );
                             break;
                         }
                         case MACHINE_VIEW.ServiceDesigner: {

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
@@ -782,10 +782,11 @@ function DevantDashboard({ projectStructure, handleDeploy, goToDevant }: { proje
 interface PackageOverviewProps {
     projectPath: string;
     isInDevant: boolean;
+    isICPSupported?: boolean;
 }
 
 export function PackageOverview(props: PackageOverviewProps) {
-    const { projectPath, isInDevant } = props;
+    const { projectPath, isInDevant, isICPSupported } = props;
     const { rpcClient } = useRpcContext();
     const [readmeContent, setReadmeContent] = React.useState<string>("");
     const { platformExtState } = usePlatformExtContext();
@@ -817,12 +818,14 @@ export function PackageOverview(props: PackageOverviewProps) {
                 setReadmeContent(res.content);
             });
 
-        rpcClient
-            .getICPRpcClient()
-            .isIcpEnabled({ projectPath: '' })
-            .then((res) => {
-                setEnableICP(res.enabled);
-            });
+        if (isICPSupported) {
+            rpcClient
+                .getICPRpcClient()
+                .isIcpEnabled({ projectPath: '' })
+                .then((res) => {
+                    setEnableICP(res.enabled);
+                });
+        }
 
         rpcClient
             .getBIDiagramRpcClient()
@@ -830,7 +833,7 @@ export function PackageOverview(props: PackageOverviewProps) {
             .then((res) => {
                 setReadmeContent(res.content);
             });
-    }, [rpcClient, projectPath]);
+    }, [rpcClient, projectPath, isICPSupported]);
 
     useEffect(() => {
         fetchContext();
@@ -1178,11 +1181,15 @@ export function PackageOverview(props: PackageOverviewProps) {
                                         hasDeployableIntegration={deployableIntegrationTypes.length > 0}
                                         projectPath={projectPath}
                                     />
-                                    <Divider sx={{ margin: "16px 0" }} />
-                                    <IntegrationControlPlane enabled={enabled} handleICP={handleICP} />
-                                    <div style={{ marginTop: 8 }}>
-                                        <LocalICPDeployment />
-                                    </div>
+                                    {isICPSupported && (
+                                        <>
+                                            <Divider sx={{ margin: "16px 0" }} />
+                                            <IntegrationControlPlane enabled={enabled} handleICP={handleICP} />
+                                            <div style={{ marginTop: 8 }}>
+                                                <LocalICPDeployment />
+                                            </div>
+                                        </>
+                                    )}
                                 </>
                             }
                             {isInDevant &&

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/PackageOverview/index.tsx
@@ -826,13 +826,6 @@ export function PackageOverview(props: PackageOverviewProps) {
                     setEnableICP(res.enabled);
                 });
         }
-
-        rpcClient
-            .getBIDiagramRpcClient()
-            .getReadmeContent({ projectPath })
-            .then((res) => {
-                setReadmeContent(res.content);
-            });
     }, [rpcClient, projectPath, isICPSupported]);
 
     useEffect(() => {

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/WorkspaceOverview/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/WorkspaceOverview/index.tsx
@@ -719,9 +719,10 @@ function IntegrationControlPlane({
 
 interface WorkspaceOverviewProps {
     isInDevant: boolean;
+    isICPSupported?: boolean;
 }
 
-export function WorkspaceOverview({ isInDevant }: WorkspaceOverviewProps) {
+export function WorkspaceOverview({ isInDevant, isICPSupported }: WorkspaceOverviewProps) {
     const { rpcClient } = useRpcContext();
     const [readmeContent, setReadmeContent] = React.useState<string>("");
     const [projectCollection, setProjectCollection] = React.useState<ProjectStructureResponse>();
@@ -745,7 +746,7 @@ export function WorkspaceOverview({ isInDevant }: WorkspaceOverviewProps) {
     };
 
     const syncProjectICPStatus = async (projectPaths: string[]) => {
-        if (projectPaths.length === 0) {
+        if (!isICPSupported || projectPaths.length === 0) {
             setIcpStatusByProjectPath({});
             return;
         }
@@ -1122,7 +1123,7 @@ export function WorkspaceOverview({ isInDevant }: WorkspaceOverviewProps) {
                                 <PackageListView
                                     projectCollection={projectCollection}
                                     icpStatusByProjectPath={icpStatusByProjectPath}
-                                    showICPBadge={icpState !== "none"}
+                                    showICPBadge={isICPSupported && icpState !== "none"}
                                 />
                             )}
                         </ContentPanel>
@@ -1175,16 +1176,20 @@ export function WorkspaceOverview({ isInDevant }: WorkspaceOverviewProps) {
                                     deployableProjectPaths={deployableProjectPaths}
                                     libraryProjectPaths={libraryProjectPaths}
                                 />
-                                <Divider sx={{ margin: "16px 0" }} />
-                                <IntegrationControlPlane
-                                    icpState={icpState}
-                                    enabledCount={icpEnabledCount}
-                                    totalCount={icpProjectPaths.length}
-                                    onEnableAll={handleEnableAllICP}
-                                    onDisableAll={handleDisableAllICP}
-                                    onEnableRemaining={handleEnableRemainingICP}
-                                    icpActionLoading={icpActionLoading}
-                                />
+                                {isICPSupported && (
+                                    <>
+                                        <Divider sx={{ margin: "16px 0" }} />
+                                        <IntegrationControlPlane
+                                            icpState={icpState}
+                                            enabledCount={icpEnabledCount}
+                                            totalCount={icpProjectPaths.length}
+                                            onEnableAll={handleEnableAllICP}
+                                            onDisableAll={handleDisableAllICP}
+                                            onEnableRemaining={handleEnableRemainingICP}
+                                            icpActionLoading={icpActionLoading}
+                                        />
+                                    </>
+                                )}
                             </>
                         )}
                         {isInDevant && (

--- a/workspaces/ballerina/ballerina-visualizer/src/views/BI/WorkspaceOverview/index.tsx
+++ b/workspaces/ballerina/ballerina-visualizer/src/views/BI/WorkspaceOverview/index.tsx
@@ -780,13 +780,6 @@ export function WorkspaceOverview({ isInDevant, isICPSupported }: WorkspaceOverv
                     .then((res) => {
                         setReadmeContent(res.content);
                     });
-        
-                rpcClient
-                    .getBIDiagramRpcClient()
-                    .getReadmeContent({ projectPath: res.workspacePath })
-                    .then((res) => {
-                        setReadmeContent(res.content);
-                    });
 
                 syncProjectICPStatus(getICPProjectPaths(res.projects));
             });


### PR DESCRIPTION
## Purpose

ICP (Integration Control Plane) ships as part of the WSO2 Integrator installation, but the Ballerina extension was activating it unconditionally. Users running the Ballerina extension on its own were shown ICP commands, the ICP status bar item, and ICP sections in the overview webviews — none of which are usable without the Integrator.

Addresses: https://github.com/wso2/product-integrator/issues/1927

## Goals

Gate every ICP entry point behind a single check so ICP is only surfaced when the WSO2 Integrator extension is present. Behaviour under the Integrator is unchanged.

## Approach

Added `isICPSupported()` to `ballerina-extension/src/utils/config.ts` as the single source of truth (currently delegating to `isInWI()`), then applied it at four layers so no entry point is left open.

### 1. Activation

`extension.ts` no longer calls `activateICP()` for standalone users, alongside the existing Devant skip. `features/bi/activator.ts` skips the per-project `isIcpEnabled` probe under the same condition, so we also avoid a pointless LS round trip on every visualizer open.

### 2. Commands

`activateICP()` sets a `ballerina.icpSupported` context key, and the `enablement` clauses for `ballerina.icp.start` / `ballerina.icp.stop` in `package.json` now require it. Because that key is only ever set inside `activateICP()`, it evaluates as false for standalone users and both commands stay out of the command palette — no separate teardown path needed.

### 3. RPC layer

`ICPServiceRpcManager` guards `addICP`, `disableICP`, `viewInICP`, `isIcpEnabled` and `isICPServerRunning` with an early `{ enabled: false }`.

This is defence in depth rather than a second gate on the same path. Once the UI is hidden the webview shouldn't reach these at all, but `addICP` writes ICP imports and `Config.toml` entries into the user's project, so a restored or stale webview state must not be able to mutate a project with a feature that isn't supported.

### 4. Webviews

`isICPSupported` is threaded through `VisualizerMetadata` → `MainPanel` → `PackageOverview` / `WorkspaceOverview`. Both now hide the ICP panel and its divider, and skip the ICP status fetch entirely rather than rendering an empty or disabled section. `WorkspaceOverview` additionally suppresses the per-package ICP badge and short-circuits `syncProjectICPStatus`.

The flag is optional (`isICPSupported?: boolean`) and read via `value.metadata?.isICPSupported`, so a context payload without it falls through to hiding ICP.

## UI Component Development

- [x] Matches with the native VSCode look and feel — no new components; this only removes existing sections from the two overview views.
- [x] No new reusable components introduced, so nothing to add to the ui-toolkit.

## Manage Icons

N/A — no new icons.

## Release note

ICP is no longer offered in the standalone Ballerina extension. It remains available as before when the WSO2 Integrator extension is installed.

## Documentation

N/A — no documented behaviour changes for Integrator users; this only removes a feature that was never functional standalone.

## Automation tests

No unit or integration tests added — the change is a set of activation and render guards with no new logic to assert against, and the existing ICP suites run in the Integrator configuration where behaviour is unchanged.

## Test environment

To verify:

- [ ] Ballerina extension **without** WSO2 Integrator: no ICP status bar item, `Ballerina: Start ICP` / `Stop ICP` absent from the command palette, no ICP section in Package Overview or Workspace Overview, no ICP badges in the package list
- [ ] Ballerina extension **with** WSO2 Integrator: ICP section, badges, status bar item and both commands all behave as before
- [ ] Enable/disable ICP still writes and reverts the expected imports and `Config.toml` entries under the Integrator
- [ ] Devant: unchanged (still skipped, as before this change)

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ICP options, status indicators, and deployment controls now appear only when ICP is supported.
  * Added support detection based on the available Integrator environment.
  * ICP commands are enabled only when the feature is supported and applicable.

* **Bug Fixes**
  * Prevented unsupported ICP actions and status checks.
  * Removed redundant README loading during workspace and package overview updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->