### PR TITLE
fix: Read the bound port after listening, not synchronously

### DIFF
--- a/workspaces/common-libs/vscode-webview-bridge/src/extension.ts
+++ b/workspaces/common-libs/vscode-webview-bridge/src/extension.ts
@@ -357,13 +357,32 @@ function createWsBackend<TRequest, TResponse>(options: WebSocketBackendOptions<T
       return;
     }
 
-    server.once('listening', () => {
+    // Settle on every terminal outcome, including `close` — disposing before the
+    // bind completes would otherwise leave this promise pending forever and hang
+    // anyone awaiting it.
+    const settle = (finish: () => void) => {
+      server.off('listening', onListening);
+      server.off('error', onError);
+      server.off('close', onClose);
+      finish();
+    };
+
+    const onListening = () => settle(() => {
       readAssignedPort();
       resolve(resolvedPort);
     });
-    server.once('error', (error: Error) => {
+
+    const onError = (error: Error) => settle(() => {
       reject(error instanceof Error ? error : new Error('Failed to allocate the WebSocket port.'));
     });
+
+    const onClose = () => settle(() => {
+      reject(new Error('WebSocket server closed before it finished binding.'));
+    });
+
+    server.on('listening', onListening);
+    server.on('error', onError);
+    server.on('close', onClose);
   });
 
   const send = (socket: WebSocket, payload: TResponse) => {
@@ -500,7 +519,7 @@ export function createExtensionTransportManager<TRequest, TResponse>(
       return backend.ready;
     }
 
-    backend = createWsBackend<TRequest, TResponse>({
+    const nextBackend = createWsBackend<TRequest, TResponse>({
       port: wsPort,
       host: wsHost,
       authToken,
@@ -509,7 +528,21 @@ export function createExtensionTransportManager<TRequest, TResponse>(
       serialize,
       initialResponse: options.initialResponse
     });
-    return backend.ready;
+    backend = nextBackend;
+
+    // A backend that failed to bind must not be left in place: it would make
+    // `isWebSocketServerRunning()` lie and pin every later call to the same
+    // rejected promise, so the server could never be retried. Attaching this
+    // handler also keeps the rejection observed when a caller ignores the
+    // returned promise.
+    nextBackend.ready.catch(() => {
+      if (backend === nextBackend) {
+        backend = undefined;
+      }
+      nextBackend.dispose();
+    });
+
+    return nextBackend.ready;
   };
 
   const registerWebviewInternal = (panel: WebviewPanelLike) => {
@@ -601,12 +634,22 @@ export function createExtensionTransportManager<TRequest, TResponse>(
      * before `getWebviewBootstrap()` reports an OS-allocated port.
      */
     switchMode(nextMode: TransportMode): Promise<number> | undefined {
+      const previousMode = mode;
       mode = nextMode;
-      if (mode === 'websocket') {
-        return startWebSocketServer();
+      if (mode !== 'websocket') {
+        return undefined;
       }
 
-      return undefined;
+      return startWebSocketServer().catch((error: unknown) => {
+        // The websocket transport never came up, and websocket mode silences the
+        // proxy path, so staying here would leave the webview with no working
+        // transport at all. Fall back to the mode we switched from.
+        if (mode === 'websocket') {
+          mode = previousMode;
+        }
+
+        throw error;
+      });
     },
     /** Returns `true` when internal WebSocket backend is running. */
     isWebSocketServerRunning() {

--- a/workspaces/common-libs/vscode-webview-bridge/src/extension.ts
+++ b/workspaces/common-libs/vscode-webview-bridge/src/extension.ts
@@ -25,9 +25,7 @@ import type * as vscode from 'vscode';
 export type { ProxyEnvelope, TransportMode } from './types';
 
 const DEFAULT_WS_PORT = 8787;
-// Bind the backend to the loopback interface only. The webview client always
-// connects to `127.0.0.1`, so listening on all interfaces would needlessly
-// expose the socket to other hosts on the network.
+// The webview client always connects to 127.0.0.1, so bind loopback only.
 const DEFAULT_WS_HOST = '127.0.0.1';
 const DEFAULT_WS_URL_BASE = 'ws://127.0.0.1';
 const INVALID_JSON_PAYLOAD_ERROR = 'Invalid JSON payload.';
@@ -324,10 +322,7 @@ function createWsBackend<TRequest, TResponse>(options: WebSocketBackendOptions<T
   const server = new WebSocketServer({
     port,
     host,
-    // Reject the upgrade during the handshake when a token is required and the
-    // client did not present a matching one. This gates both requests and any
-    // broadcast traffic, and — because a cross-site page cannot know the
-    // token — also defends against cross-site WebSocket hijacking.
+    // Refuse the upgrade unless the client presents a matching token.
     verifyClient: authToken
       ? (info: { req: IncomingMessage }) => {
         const provided = readRequestToken(info.req);
@@ -335,11 +330,8 @@ function createWsBackend<TRequest, TResponse>(options: WebSocketBackendOptions<T
       }
       : undefined
   });
-  // Binding to an explicit host puts Node on the `listen(port, host)` path,
-  // which resolves the host before binding. The socket is therefore not bound
-  // yet and `address()` returns null in this tick, so the assigned port has to
-  // be read once the server reports `listening`. Callers await `ready` before
-  // relying on `port` (it matters most for `port: 0`, where the OS picks one).
+  // With an explicit host, Node resolves the host before binding, so
+  // `address()` is null until `listening` fires. Read the port from there.
   let resolvedPort = port;
 
   const readAssignedPort = () => {
@@ -357,9 +349,8 @@ function createWsBackend<TRequest, TResponse>(options: WebSocketBackendOptions<T
       return;
     }
 
-    // Settle on every terminal outcome, including `close` — disposing before the
-    // bind completes would otherwise leave this promise pending forever and hang
-    // anyone awaiting it.
+    // `close` counts too: disposing before the bind completes would otherwise
+    // leave this pending forever.
     const settle = (finish: () => void) => {
       server.off('listening', onListening);
       server.off('error', onError);
@@ -510,9 +501,7 @@ export function createExtensionTransportManager<TRequest, TResponse>(
 
   /**
    * Starts the internal WebSocket backend and resolves with the bound port.
-   *
-   * The port is only known after the server reports `listening`, so callers
-   * must await this before reading `getWebviewBootstrap()` when `wsPort` is 0.
+   * Await this before reading `getWebviewBootstrap()` when `wsPort` is 0.
    */
   const startWebSocketServer = (): Promise<number> => {
     if (backend) {
@@ -530,11 +519,9 @@ export function createExtensionTransportManager<TRequest, TResponse>(
     });
     backend = nextBackend;
 
-    // A backend that failed to bind must not be left in place: it would make
-    // `isWebSocketServerRunning()` lie and pin every later call to the same
-    // rejected promise, so the server could never be retried. Attaching this
-    // handler also keeps the rejection observed when a caller ignores the
-    // returned promise.
+    // Drop a backend that failed to bind so the running state stays accurate and
+    // a later call can retry. Also keeps the rejection observed if the caller
+    // ignores the returned promise.
     nextBackend.ready.catch(() => {
       if (backend === nextBackend) {
         backend = undefined;
@@ -629,9 +616,8 @@ export function createExtensionTransportManager<TRequest, TResponse>(
       return mode;
     },
     /**
-     * Switches runtime transport mode. When switching to `websocket` the
-     * returned promise resolves with the bound port; awaiting it is required
-     * before `getWebviewBootstrap()` reports an OS-allocated port.
+     * Switches runtime transport mode. Switching to `websocket` resolves with
+     * the bound port; await it before reading an OS-allocated port.
      */
     switchMode(nextMode: TransportMode): Promise<number> | undefined {
       const previousMode = mode;
@@ -641,9 +627,8 @@ export function createExtensionTransportManager<TRequest, TResponse>(
       }
 
       return startWebSocketServer().catch((error: unknown) => {
-        // The websocket transport never came up, and websocket mode silences the
-        // proxy path, so staying here would leave the webview with no working
-        // transport at all. Fall back to the mode we switched from.
+        // Websocket mode silences the proxy path, so staying here would leave the
+        // webview with no transport at all.
         if (mode === 'websocket') {
           mode = previousMode;
         }
@@ -665,11 +650,9 @@ export function createExtensionTransportManager<TRequest, TResponse>(
     /**
      * Returns bootstrap metadata consumed by webview startup.
      *
-     * Stays synchronous so it can be called while building webview HTML. It
-     * reports the port the backend is actually bound to, so in `websocket` mode
-     * `startWebSocketServer()` (or the promise from `switchMode('websocket')`)
-     * must be awaited first; otherwise the configured `wsPort` is reported,
-     * which is 0 when the OS is asked to allocate one.
+     * Synchronous, so it can be called while building webview HTML. Reports the
+     * port the backend is bound to, so in `websocket` mode the start must be
+     * awaited first; otherwise the configured `wsPort` is reported.
      */
     getWebviewBootstrap() {
       const currentMode = mode;

--- a/workspaces/common-libs/vscode-webview-bridge/src/extension.ts
+++ b/workspaces/common-libs/vscode-webview-bridge/src/extension.ts
@@ -335,10 +335,36 @@ function createWsBackend<TRequest, TResponse>(options: WebSocketBackendOptions<T
       }
       : undefined
   });
-  const address = server.address();
-  if (!address || typeof address === 'string') {
-    throw new Error('Failed to allocate the WebSocket port.');
-  }
+  // Binding to an explicit host puts Node on the `listen(port, host)` path,
+  // which resolves the host before binding. The socket is therefore not bound
+  // yet and `address()` returns null in this tick, so the assigned port has to
+  // be read once the server reports `listening`. Callers await `ready` before
+  // relying on `port` (it matters most for `port: 0`, where the OS picks one).
+  let resolvedPort = port;
+
+  const readAssignedPort = () => {
+    const address = server.address();
+    if (address && typeof address !== 'string') {
+      resolvedPort = address.port;
+    }
+  };
+
+  readAssignedPort();
+
+  const ready = new Promise<number>((resolve, reject) => {
+    if (server.address()) {
+      resolve(resolvedPort);
+      return;
+    }
+
+    server.once('listening', () => {
+      readAssignedPort();
+      resolve(resolvedPort);
+    });
+    server.once('error', (error: Error) => {
+      reject(error instanceof Error ? error : new Error('Failed to allocate the WebSocket port.'));
+    });
+  });
 
   const send = (socket: WebSocket, payload: TResponse) => {
     socket.send(serialize(payload));
@@ -392,7 +418,11 @@ function createWsBackend<TRequest, TResponse>(options: WebSocketBackendOptions<T
   });
 
   return {
-    port: address.port,
+    /** Assigned port. Accurate once `ready` has resolved. */
+    get port() {
+      return resolvedPort;
+    },
+    ready,
     broadcastResponse(payload: TResponse) {
       broadcast(payload);
     },
@@ -421,7 +451,8 @@ export function createExtensionTransportManager<TRequest, TResponse>(
   const proxyClients = new Set<(message: ProxyEnvelope) => void>();
   let backend:
     | {
-      port: number;
+      readonly port: number;
+      ready: Promise<number>;
       broadcastResponse: (payload: TResponse) => void;
       dispose: () => void;
     }
@@ -458,9 +489,15 @@ export function createExtensionTransportManager<TRequest, TResponse>(
     }
   };
 
-  const startWebSocketServer = () => {
+  /**
+   * Starts the internal WebSocket backend and resolves with the bound port.
+   *
+   * The port is only known after the server reports `listening`, so callers
+   * must await this before reading `getWebviewBootstrap()` when `wsPort` is 0.
+   */
+  const startWebSocketServer = (): Promise<number> => {
     if (backend) {
-      return backend.port;
+      return backend.ready;
     }
 
     backend = createWsBackend<TRequest, TResponse>({
@@ -472,7 +509,7 @@ export function createExtensionTransportManager<TRequest, TResponse>(
       serialize,
       initialResponse: options.initialResponse
     });
-    return backend.port;
+    return backend.ready;
   };
 
   const registerWebviewInternal = (panel: WebviewPanelLike) => {
@@ -558,12 +595,18 @@ export function createExtensionTransportManager<TRequest, TResponse>(
     getMode() {
       return mode;
     },
-    /** Switches runtime transport mode. */
-    switchMode(nextMode: TransportMode) {
+    /**
+     * Switches runtime transport mode. When switching to `websocket` the
+     * returned promise resolves with the bound port; awaiting it is required
+     * before `getWebviewBootstrap()` reports an OS-allocated port.
+     */
+    switchMode(nextMode: TransportMode): Promise<number> | undefined {
       mode = nextMode;
       if (mode === 'websocket') {
-        startWebSocketServer();
+        return startWebSocketServer();
       }
+
+      return undefined;
     },
     /** Returns `true` when internal WebSocket backend is running. */
     isWebSocketServerRunning() {
@@ -576,10 +619,18 @@ export function createExtensionTransportManager<TRequest, TResponse>(
       backend = undefined;
     },
     publish,
-    /** Returns bootstrap metadata consumed by webview startup. */
+    /**
+     * Returns bootstrap metadata consumed by webview startup.
+     *
+     * Stays synchronous so it can be called while building webview HTML. It
+     * reports the port the backend is actually bound to, so in `websocket` mode
+     * `startWebSocketServer()` (or the promise from `switchMode('websocket')`)
+     * must be awaited first; otherwise the configured `wsPort` is reported,
+     * which is 0 when the OS is asked to allocate one.
+     */
     getWebviewBootstrap() {
       const currentMode = mode;
-      const port = currentMode === 'websocket' ? startWebSocketServer() : backend?.port ?? wsPort;
+      const port = backend?.port ?? wsPort;
       const server = wsUrlBase.replace(/^wss?:\/\//, '');
       return {
         mode: currentMode,


### PR DESCRIPTION
## Purpose

**Regression fix for #2435.** That PR added `host` to the `WebSocketServer` options so the backend binds to loopback instead of all interfaces. That change is correct and stays — but it also moved Node onto the `listen(port, host)` code path, which resolves the host **before** binding. The socket is therefore not bound in the same tick, and `server.address()` returns `null`:

```
new WebSocketServer({ port: 0 })                     -> address() = { address: '::', port: 56278 }   (sync)
new WebSocketServer({ port: 0, host: '127.0.0.1' })  -> address() = null                             (async)
                                                     -> after 'listening': { port: 56279 }
```

`createWsBackend` read `address()` immediately and threw:

```
Error: Failed to allocate the WebSocket port.
    at createWsBackend (dist/extension.js:216)
    at startWebSocketServer (dist/extension.js:318)
    at getWebviewBootstrap (dist/extension.js:425)
```

**Every attempt to start the websocket backend failed**, for any configured port — not just `port: 0`.

Nothing caught it because the failure is purely at runtime (typechecks pass) and no test in this repo starts a server.

### Blast radius

No consumer in this repo enables websocket mode, and downstream consumers pinned to older submodule commits are unaffected. The breakage would have shipped with the two consumer PRs that bump to `be1a5b98a`:

- wso2/product-integrator#1953 — `wi` welcome page (`BridgeLayer.startWebSocketServer`)
- ballerina-platform/ballerina-vscode#741 — `DefaultServer.getWsBootstrap()`

Both need a small follow-up to await the new promise; they are being updated alongside this.

## Approach

The bound port genuinely cannot be known synchronously once you bind to a specific host, so it is now read from the `listening` event:

- **`createWsBackend`** — resolves the port from `listening` and exposes `ready: Promise<number>`. `port` becomes a getter reflecting the bound port. No throw on a null first read.
- **`startWebSocketServer()`** — returns `Promise<number>` resolving with the bound port.
- **`switchMode('websocket')`** — returns the same promise so callers can await it.
- **`getWebviewBootstrap()`** — deliberately **stays synchronous**, because consumers call it while building webview HTML. It reports the port the backend is actually bound to, so in websocket mode the start must be awaited first; otherwise the configured `wsPort` is reported (0 when the OS allocates).

Rejected alternatives: reverting to the all-interfaces bind and merely refusing non-loopback connections in `verifyClient` (leaves the port bound and reachable — weaker than the security fix intends), and forcing a fixed port (gives up OS allocation, risks collisions).

## Release note

Fixed the webview bridge failing to start its WebSocket backend with "Failed to allocate the WebSocket port."

## Documentation

N/A — internal library behaviour. The API change is described in the doc comments on the affected methods.

## Automation tests

- Unit tests
  > No test harness exists in this package, so none were added. Verified with a script against the built output instead (below).
- Integration tests
  > N/A

**Verified end to end against the built library:**

| check | result |
|---|---|
| `startWebSocketServer()` resolves the OS-allocated port | 60058 |
| `getWebviewBootstrap().wsPort` matches it | ✅ |
| fixed port (8791) still resolves unchanged | ✅ |
| no token → rejected | HTTP 401, socket never opens, no broadcast |
| wrong token → rejected | HTTP 401, socket never opens, no broadcast |
| correct token → connected | request reaches `handleRequest`, receives broadcast |

The auth rows confirm #2435's handshake gate works as intended — that behaviour was previously unverifiable because the server could not start.

## Security checks

- Followed secure coding standards? **yes** — the loopback bind and handshake token from #2435 are preserved; this only changes *when* the port is read
- Ran FindSecurityBugs plugin? **N/A** — TypeScript, not Java
- Confirmed no keys/passwords/tokens committed? **yes**

## Related PRs

- wso2/vscode-extensions#2435 — introduced the regression this fixes
- wso2/product-integrator#1953 and ballerina-platform/ballerina-vscode#741 — consumers that must await the new promise

## Test environment

macOS (darwin 25.5.0), Node 20.19.0 (build) and 22.21.1 (runtime verification).

## Learning

The lesson is that "it compiles and the types line up" was not evidence the change worked. Adding one option (`host`) silently changed `listen()` from a synchronous bind to an asynchronous one, which no amount of typechecking could surface. It only appeared when a script actually started the server and connected to it — which is also what finally verified the token gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket startup reliability by waiting for the server to finish binding before reporting its port.
  * Updated error handling so port allocation failures are reported asynchronously instead of causing immediate initialization errors.
  * Prevented incomplete connection details from being returned during WebSocket startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->