### PR TITLE
Fix side panel crash for a list element with a comma

### DIFF
--- a/workspaces/ballerina/ballerina-side-panel/package.json
+++ b/workspaces/ballerina/ballerina-side-panel/package.json
@@ -9,7 +9,7 @@
     "types": "lib/index.d.ts",
     "scripts": {
         "build": "tsc --pretty && npm run copy:assets",
-        "test": "npm run build && node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test test/typeCompletionUtils.test.mjs test/formValidationUtils.test.mjs",
+        "test": "npm run build && node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test test/typeCompletionUtils.test.mjs test/formValidationUtils.test.mjs test/rawValueUtils.test.mjs",
         "storybook": "start-storybook -p 6006",
         "watch": "tsc --pretty --watch",
         "build-storybook": "build-storybook",

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/FormArrayEditor.tsx
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/FormArrayEditor.tsx
@@ -174,8 +174,11 @@ export const FormArrayEditor = (props: FormFieldEditorProps & {
             });
             elementDiagnosticsRef.current = initialDioagnostics;
         }
-        let newValue = buildStringArray(props.value);
-        const initialValues = stringToRawArrayElements(newValue);
+        // An array holds the elements already, so the values are read from it directly. Building a string out of it
+        // and splitting it back apart loses an element that contains a comma, such as a string template.
+        const initialValues: string[] = Array.isArray(props.value)
+            ? props.value.map((val: any) => (typeof val === "string" ? val : String(val?.value ?? "")))
+            : stringToRawArrayElements(buildStringArray(props.value));
         if (!Array.isArray(props.value)) {
             initialValues.forEach((val: any, index: number) => {
                 const key = crypto.randomUUID();
@@ -183,7 +186,13 @@ export const FormArrayEditor = (props: FormFieldEditorProps & {
             })
         }
         if (keyArray.length !== initialValues.length) {
-            throw new Error("Key array length and initial values length do not match");
+            // The keys are only used to identify the elements of the editor. Hence, they are adjusted to the values
+            // instead of failing the render of the form.
+            console.warn(`FormArrayEditor: ${keyArray.length} keys for ${initialValues.length} values`);
+            while (keyArray.length < initialValues.length) {
+                keyArray.push(crypto.randomUUID());
+            }
+            keyArray.length = initialValues.length;
         }
         const initialFields = initialValues.map((val, index) => {
             const key = keyArray[index];

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/rawValueUtils.ts
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/rawValueUtils.ts
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { FormField } from "../Form/types";
+
+/**
+ * Splits the raw text of an array into its elements.
+ *
+ * Only a comma that lies outside of every quoted string, backtick template and nested `[]`, `{}` or `()` is an
+ * element separator. The module holds no import of its own, so that it can be exercised in isolation.
+ */
+export function stringToRawArrayElements(input: string): string[] {
+    // remove outer [ ]
+    const s = input.trim().slice(1, -1);
+
+    if (s === "") {
+        return [];
+    }
+
+    const result: string[] = [];
+    let current = "";
+    let depth = 0;
+    let inString = false;
+    // Backtick templates such as `string \`...\``, `xml \`...\`` and `re \`...\``. A comma within a template is never
+    // an element separator.
+    let inTemplate = false;
+    // The nesting of the `${...}` interpolations of a template. The expression of an interpolation may hold a quoted
+    // string, which in turn may hold a backtick, so the template only ends outside of an interpolation.
+    let interpolationDepth = 0;
+
+    for (let i = 0; i < s.length; i++) {
+        const char = s[i];
+        const prev = s[i - 1];
+
+        // within a quoted string, only its closing quote is significant
+        if (inString) {
+            if (char === '"' && prev !== "\\") {
+                inString = false;
+            }
+            current += char;
+            continue;
+        }
+
+        // within the interpolation of a template, the expression ends the interpolation alone
+        if (interpolationDepth > 0) {
+            if (char === '"') {
+                inString = true;
+            } else if (char === "{") {
+                interpolationDepth++;
+            } else if (char === "}") {
+                interpolationDepth--;
+            }
+            current += char;
+            continue;
+        }
+
+        // within the text of a template, only an interpolation and the closing backtick are significant
+        if (inTemplate) {
+            if (char === "{" && prev === "$") {
+                interpolationDepth++;
+            } else if (char === "`") {
+                inTemplate = false;
+            }
+            current += char;
+            continue;
+        }
+
+        // handle template boundaries
+        if (char === "`") {
+            inTemplate = true;
+            current += char;
+            continue;
+        }
+
+        // handle string boundaries
+        if (char === '"' && prev !== "\\") {
+            inString = true;
+            current += char;
+            continue;
+        }
+
+        if (char === "[" || char === "{" || char === "(") depth++;
+        if (char === "]" || char === "}" || char === ")") depth--;
+
+        if (char === "," && depth === 0) {
+            result.push(current);
+            current = "";
+            continue;
+        }
+
+        current += char;
+    }
+
+    // Always push the final element (even if empty) to preserve trailing empty values
+    result.push(current);
+
+    return result;
+}
+
+/**
+ * Builds the raw text of an array out of the elements of the editor.
+ */
+export function buildStringArray(elements: FormField[]): string {
+    if (typeof elements === "string") return elements;
+    const parts = elements.map(el => {
+        return ((el.value as string) ?? "").trim();
+    });
+    return `[${parts.join(", ")}]`;
+}

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/utils.ts
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/utils.ts
@@ -197,21 +197,31 @@ export function stringToRawArrayElements(input: string): string[] {
     let current = "";
     let depth = 0;
     let inString = false;
+    // Backtick templates such as `string \`...\``, `xml \`...\`` and `re \`...\``. A comma within a template is never
+    // an element separator, not even inside an interpolation, so the whole span is treated as opaque.
+    let inTemplate = false;
 
     for (let i = 0; i < s.length; i++) {
         const char = s[i];
         const prev = s[i - 1];
 
+        // handle template boundaries
+        if (char === "`" && prev !== "\\" && !inString) {
+            inTemplate = !inTemplate;
+            current += char;
+            continue;
+        }
+
         // handle string boundaries
-        if (char === '"' && prev !== "\\") {
+        if (char === '"' && prev !== "\\" && !inTemplate) {
             inString = !inString;
             current += char;
             continue;
         }
 
-        if (!inString) {
-            if (char === "[" || char === "{") depth++;
-            if (char === "]" || char === "}") depth--;
+        if (!inString && !inTemplate) {
+            if (char === "[" || char === "{" || char === "(") depth++;
+            if (char === "]" || char === "}" || char === ")") depth--;
 
             if (char === "," && depth === 0) {
                 result.push(current);

--- a/workspaces/ballerina/ballerina-side-panel/src/components/editors/utils.ts
+++ b/workspaces/ballerina/ballerina-side-panel/src/components/editors/utils.ts
@@ -23,6 +23,9 @@ import { InputMode } from "../..";
 import { EditorMode } from "./ExpandedEditor";
 import { EXPANDABLE_MODES } from "./ExpandedEditor/modes/types";
 
+// Re-exported so that the existing imports of these helpers keep working.
+export { stringToRawArrayElements, buildStringArray } from "./rawValueUtils";
+
 export function isDropdownField(field: FormField) {
     return field.type === "MULTIPLE_SELECT" || field.type === "SINGLE_SELECT" || field.type?.toUpperCase() === "ENUM";
 }
@@ -185,60 +188,6 @@ export const getMapSubFormFieldFromTypes = (formId: string, types: InputType[]):
     ]
 }
 
-export function stringToRawArrayElements(input: string): string[] {
-    // remove outer [ ]
-    const s = input.trim().slice(1, -1);
-
-    if (s === "") {
-        return [];
-    }
-
-    const result: string[] = [];
-    let current = "";
-    let depth = 0;
-    let inString = false;
-    // Backtick templates such as `string \`...\``, `xml \`...\`` and `re \`...\``. A comma within a template is never
-    // an element separator, not even inside an interpolation, so the whole span is treated as opaque.
-    let inTemplate = false;
-
-    for (let i = 0; i < s.length; i++) {
-        const char = s[i];
-        const prev = s[i - 1];
-
-        // handle template boundaries
-        if (char === "`" && prev !== "\\" && !inString) {
-            inTemplate = !inTemplate;
-            current += char;
-            continue;
-        }
-
-        // handle string boundaries
-        if (char === '"' && prev !== "\\" && !inTemplate) {
-            inString = !inString;
-            current += char;
-            continue;
-        }
-
-        if (!inString && !inTemplate) {
-            if (char === "[" || char === "{" || char === "(") depth++;
-            if (char === "]" || char === "}" || char === ")") depth--;
-
-            if (char === "," && depth === 0) {
-                result.push(current);
-                current = "";
-                continue;
-            }
-        }
-
-        current += char;
-    }
-
-    // Always push the final element (even if empty) to preserve trailing empty values
-    result.push(current);
-
-    return result;
-}
-
 export function stringToRawObjectEntries(
     input: string
 ): { key: string; value: string }[] {
@@ -317,14 +266,6 @@ function pushPair(
             }
         }
     }
-}
-
-export function buildStringArray(elements: FormField[]): string {
-    if (typeof elements === "string") return elements;
-    const parts = elements.map(el => {
-        return ((el.value as string) ?? "").trim();
-    });
-    return `[${parts.join(", ")}]`;
 }
 
 export function buildStringMap(elements: FormField[][] | string): string {

--- a/workspaces/ballerina/ballerina-side-panel/test/rawValueUtils.test.mjs
+++ b/workspaces/ballerina/ballerina-side-panel/test/rawValueUtils.test.mjs
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { stringToRawArrayElements, buildStringArray } from "../lib/components/editors/rawValueUtils.js";
+
+test("stringToRawArrayElements splits on the separators of the array", () => {
+    assert.deepEqual(stringToRawArrayElements("[a, b, c]"), ["a", " b", " c"]);
+    assert.deepEqual(stringToRawArrayElements('["a", [1, 2], {k: 1}]').length, 3);
+});
+
+test("stringToRawArrayElements returns no element for an empty array", () => {
+    assert.deepEqual(stringToRawArrayElements("[]"), []);
+});
+
+test("stringToRawArrayElements preserves a trailing empty element", () => {
+    assert.deepEqual(stringToRawArrayElements("[a, ]"), ["a", " "]);
+});
+
+test("stringToRawArrayElements keeps a comma of a quoted string within its element", () => {
+    assert.deepEqual(stringToRawArrayElements('["a, b"]'), ['"a, b"']);
+});
+
+test("stringToRawArrayElements keeps a comma of a call within its element", () => {
+    assert.deepEqual(stringToRawArrayElements("[foo(a, b)]"), ["foo(a, b)"]);
+});
+
+test("stringToRawArrayElements keeps a comma of a template within its element", () => {
+    const element = "string `Customer details: ID ${customerIdElement.data()}, Name ${firstNameElement.data()}`";
+    assert.deepEqual(stringToRawArrayElements(`[${element}]`), [element]);
+});
+
+test("stringToRawArrayElements keeps a comma of an interpolation within its element", () => {
+    const element = "string `a ${f(1, 2)} b`";
+    assert.deepEqual(stringToRawArrayElements(`[${element}]`), [element]);
+});
+
+test("stringToRawArrayElements ends a template that holds a backtick within an interpolation", () => {
+    // string `Backtick:${"`"}` holds a literal backtick, which does not end the template
+    const element = 'string `Backtick:${"`"}`';
+    assert.deepEqual(stringToRawArrayElements(`[${element}, next]`), [element, " next"]);
+});
+
+test("stringToRawArrayElements splits after a template", () => {
+    assert.deepEqual(stringToRawArrayElements('[string `p, q`, "r"]'), ["string `p, q`", ' "r"']);
+});
+
+test("an element of an array survives a round trip through buildStringArray", () => {
+    const element = "string `Customer details: ID ${a.data()}, Name ${b.data()}`";
+    assert.deepEqual(stringToRawArrayElements(buildStringArray([{ value: element }])), [element]);
+});


### PR DESCRIPTION
## Purpose
Fixes : https://github.com/wso2/product-integrator/issues/1979

Keep an element of a repeatable list intact when it holds a comma, so that the form of a node such as the following can be opened:

```ballerina
io:println(string `Customer details: ID ${customerIdElement.data()}, Name ${firstNameElement.data()}`);
```

The rest parameter of the call is a `REPEATABLE_LIST`, which `EditorFactory` renders through `FormArrayEditor`. The editor built a string out of the value array and split it back apart to obtain the elements:

```ts
let newValue = buildStringArray(props.value);
const initialValues = stringToRawArrayElements(newValue);
```

`stringToRawArrayElements()` splits on a comma that it considers to be at the top level, and it tracked only a double quoted string and the `[` and `{` nesting. A backtick template was tracked by neither, and the braces of the `${...}` interpolation that precedes the comma close before it is reached. The comma of the template was therefore read as an element separator, and the single argument was split into two.

The editor then held one key per element of the value array and two values, and failed the render of the whole form:

```ts
if (keyArray.length !== initialValues.length) {
    throw new Error("Key array length and initial values length do not match");
}
```

Since the throw happens within an effect, the side panel crashed instead of showing the form. The same call without a comma in the template is unaffected, which is why this surfaced only for some arguments. A comma within parentheses, such as `io:println(foo(a, b))`, fails the same way, since the parentheses were not counted either.

The node template that the language server returns for such a node is correct, so this is a fix on the editor alone.

## Approach
- `FormArrayEditor` reads the values directly from the value array, instead of building a string out of it and splitting it back apart. The keys are already assigned one per element of that array, so the two can no longer disagree. The string path is unchanged, since the mode switcher hands over a raw string.
- `stringToRawArrayElements()` tracks a backtick template, and treats the whole span as opaque. A comma within a template is never an element separator, not even within an interpolation such as `${f(1, 2)}`. The parentheses are counted along with `[` and `{`, so that a comma within a call is not a separator either. This path is still used by the mode switcher and by `FlowNodeForm`, where a wrong split silently attaches the diagnostics of one element to another.
- The length check no longer throws. The keys only identify the elements of the editor, so they are adjusted to the values, and a warning is logged instead of failing the render of the form.

## Tests
Verified in the extension that the form of the above node opens, and that the argument is presented as a single element.

The behaviour of the two functions was also verified against the compiled output for the element that failed, an element with a comma within parentheses, within double quotes and within an interpolation, along with the inputs that must still be split: a plain separator, a mix of the nested forms, a template that is followed by a separator, an empty array and a trailing empty element.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved array elements containing commas during initialization.
  * Improved parsing of template literals so embedded commas and delimiters remain intact.
  * Enhanced handling of nested parentheses, brackets, and braces in array values.
  * Prevented errors when array keys and values have different counts by safely reconciling them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->