### PR TITLE
Disable the visualize code lens of a submodule construct

### DIFF
--- a/workspaces/ballerina/ballerina-extension/src/core/extension.ts
+++ b/workspaces/ballerina/ballerina-extension/src/core/extension.ts
@@ -46,7 +46,8 @@ import {
     isSupportedSLVersion,
     createVersionNumber,
     checkIsBallerinaWorkspace,
-    isInWI
+    isInWI,
+    codeLensMiddleware
 } from '../utils';
 import { AssertionError } from "assert";
 import {
@@ -268,6 +269,7 @@ export class BallerinaExtension {
                     synchronize: { configurationSection: LANGUAGE.BALLERINA },
                     outputChannel: getOutputChannel(),
                     revealOutputChannelOn: RevealOutputChannelOn.Never,
+                    middleware: codeLensMiddleware,
                     initializationOptions: {
                         "enableSemanticHighlighting": <string>workspace.getConfiguration().get(ENABLE_SEMANTIC_HIGHLIGHTING),
                         "enableBackgroundDriftCheck": <string>workspace.getConfiguration().get(ENABLE_BACKGROUND_DRIFT_CHECK),

--- a/workspaces/ballerina/ballerina-extension/src/utils/codelens-middleware.ts
+++ b/workspaces/ballerina/ballerina-extension/src/utils/codelens-middleware.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { CancellationToken, CodeLens, TextDocument } from "vscode";
+import { CodeLensMiddleware, ProvideCodeLensesSignature } from "vscode-languageclient/node";
+import { SHARED_COMMANDS } from "@wso2/ballerina-core";
+import { isSubmoduleFile } from "./file-utils";
+
+export const SUBMODULE_NOT_SUPPORTED_TOOLTIP =
+    "Visualizing submodules is not supported yet. Move this construct to the default module of the package to " +
+    "visualize it.";
+
+/**
+ * Middleware over the code lenses of the language server.
+ *
+ * The language server offers a `Visualize` lens for every function, service, class and type of a document, and it
+ * derives them from the syntax tree alone. The visualizer navigates by the project artifacts instead, which
+ * `ArtifactsGenerator` reports for the default module alone. A construct of a submodule therefore matches no artifact,
+ * and the command silently lands on the package overview rather than on the view of the construct.
+ *
+ * The lens of such a construct is disabled here rather than removed, so that the reason is reported to the user
+ * instead of the affordance disappearing without an explanation. This is held on the client, since the limitation is
+ * one of the visualizer rather than of the language server, and it is a single deletion once submodules are supported.
+ */
+export const codeLensMiddleware: CodeLensMiddleware = {
+    provideCodeLenses: async (document: TextDocument, token: CancellationToken,
+                              next: ProvideCodeLensesSignature): Promise<CodeLens[] | null | undefined> => {
+        const lenses = await next(document, token);
+        if (!lenses || !isSubmoduleFile(document.uri.fsPath)) {
+            return lenses;
+        }
+        lenses.forEach(disableVisualizeLens);
+        return lenses;
+    }
+};
+
+/**
+ * Renders the given lens as plain text when it is a `Visualize` lens, and leaves it untouched otherwise.
+ *
+ * An empty command identifier is what disables a lens: VS Code renders an anchor for a lens that holds a command
+ * identifier, and a span for one that does not, so the title is shown without the styling and the behaviour of a link.
+ * The reason is carried in the tooltip, which the language server cannot set, since the `Command` of the protocol
+ * holds a title, an identifier and the arguments alone.
+ *
+ * The lens is mutated rather than replaced, so that it remains the `ProtocolCodeLens` of the client along with the
+ * data that a resolve request would carry, should the language server offer one later.
+ */
+function disableVisualizeLens(lens: CodeLens): void {
+    if (lens.command?.command !== SHARED_COMMANDS.SHOW_VISUALIZER) {
+        return;
+    }
+    lens.command = {
+        title: lens.command.title,
+        command: "",
+        tooltip: SUBMODULE_NOT_SUPPORTED_TOOLTIP
+    };
+}

--- a/workspaces/ballerina/ballerina-extension/src/utils/codelens-middleware.ts
+++ b/workspaces/ballerina/ballerina-extension/src/utils/codelens-middleware.ts
@@ -21,9 +21,7 @@ import { CodeLensMiddleware, ProvideCodeLensesSignature } from "vscode-languagec
 import { SHARED_COMMANDS } from "@wso2/ballerina-core";
 import { isSubmoduleFile } from "./file-utils";
 
-export const SUBMODULE_NOT_SUPPORTED_TOOLTIP =
-    "Visualizing submodules is not supported yet. Move this construct to the default module of the package to " +
-    "visualize it.";
+export const SUBMODULE_NOT_SUPPORTED_TOOLTIP = "Visualizer does not support submodules yet";
 
 /**
  * Middleware over the code lenses of the language server.

--- a/workspaces/ballerina/ballerina-extension/src/utils/codelens-middleware.ts
+++ b/workspaces/ballerina/ballerina-extension/src/utils/codelens-middleware.ts
@@ -34,8 +34,13 @@ export const SUBMODULE_NOT_SUPPORTED_TOOLTIP =
  * and the command silently lands on the package overview rather than on the view of the construct.
  *
  * The lens of such a construct is disabled here rather than removed, so that the reason is reported to the user
- * instead of the affordance disappearing without an explanation. This is held on the client, since the limitation is
- * one of the visualizer rather than of the language server, and it is a single deletion once submodules are supported.
+ * instead of the affordance disappearing without an explanation.
+ *
+ * TODO: Remove this middleware, along with `isSubmoduleFile()`, once the visualizer supports submodules.
+ * It is not the intended design: `isSubmoduleFile()` re-derives from the file system what the language server already knows
+ * through `Module.isDefaultModule()`, and it hardcodes the `modules` and `generated` convention. The durable fix belongs
+ * on the server, where `VisualizeCodeLensProvider` and `ArtifactsGenerator` should share one notion of what can be
+ * visualized, so that a lens is offered only where an artifact is reported..
  */
 export const codeLensMiddleware: CodeLensMiddleware = {
     provideCodeLenses: async (document: TextDocument, token: CancellationToken,

--- a/workspaces/ballerina/ballerina-extension/src/utils/file-utils.ts
+++ b/workspaces/ballerina/ballerina-extension/src/utils/file-utils.ts
@@ -464,6 +464,8 @@ const MODULE_ROOT_DIRS = ['modules', 'generated'];
 /**
  * Checks whether the given file belongs to a non-default module of a Ballerina package.
  *
+ * TODO: Remove this along with `codeLensMiddleware`, its only caller, once the visualizer supports submodules.
+ *
  * The package root is located by walking up until a `Ballerina.toml` is found, and the file is in a non-default module
  * when the directory below that root is a module root, i.e. `<root>/modules/<name>/...` or `<root>/generated/<name>/...`.
  * A file of a package that holds no `Ballerina.toml`, such as a single `.bal` file, belongs to no submodule.

--- a/workspaces/ballerina/ballerina-extension/src/utils/file-utils.ts
+++ b/workspaces/ballerina/ballerina-extension/src/utils/file-utils.ts
@@ -457,6 +457,48 @@ export async function findBallerinaPackageRoot(filePath: string) {
     return null;
 }
 
+// The directories that hold the non-default modules of a package. `generated` holds the modules that the connector
+// generation emits, and it is a module root in the same manner as `modules`.
+const MODULE_ROOT_DIRS = ['modules', 'generated'];
+
+/**
+ * Checks whether the given file belongs to a non-default module of a Ballerina package.
+ *
+ * The package root is located by walking up until a `Ballerina.toml` is found, and the file is in a non-default module
+ * when the directory below that root is a module root, i.e. `<root>/modules/<name>/...` or `<root>/generated/<name>/...`.
+ * A file of a package that holds no `Ballerina.toml`, such as a single `.bal` file, belongs to no submodule.
+ *
+ * Note that this is deliberately synchronous and holds no cache. It performs one `existsSync` per level of the path,
+ * which is negligible beside the language server round trip that its callers already await, and it cannot go stale
+ * when a package is created or removed.
+ *
+ * @param filePath the absolute path of the file
+ * @return true if the file belongs to a non-default module
+ */
+export function isSubmoduleFile(filePath: string): boolean {
+    if (!filePath) {
+        return false;
+    }
+
+    let currentFolderPath = path.dirname(filePath);
+    // The directory below `currentFolderPath`, which names the module root once the package root is reached.
+    let childFolderPath: string | undefined;
+
+    while (true) {
+        if (existsSync(path.join(currentFolderPath, 'Ballerina.toml'))) {
+            return childFolderPath !== undefined && MODULE_ROOT_DIRS.includes(path.basename(childFolderPath));
+        }
+
+        const parentPath = path.dirname(currentFolderPath);
+        if (parentPath === currentFolderPath) {
+            // The file system root is reached without a package root, so the file belongs to no package.
+            return false;
+        }
+        childFolderPath = currentFolderPath;
+        currentFolderPath = parentPath;
+    }
+}
+
 export async function handleResolveMissingDependencies(ballerinaExtInstance: BallerinaExtension) {
     openClonedTempFile(ballerinaExtInstance);
     const langClient = ballerinaExtInstance.langClient;

--- a/workspaces/ballerina/ballerina-extension/src/utils/index.ts
+++ b/workspaces/ballerina/ballerina-extension/src/utils/index.ts
@@ -20,6 +20,7 @@ export * from './config';
 export * from './logger';
 export * from './webview-utils';
 export * from './file-utils';
+export * from './codelens-middleware';
 export * from './source-utils';
 export * from './pull-module-progress';
 export * from './undo-redo-manager';


### PR DESCRIPTION
## Purpose
Disable the `Visualize` code lens of a construct that belongs to a submodule, since the visualizer does not support submodules yet.
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/d244b427-6122-47bf-a8d8-d2e76faedaf2" />


For a package such as the following, the lens is offered for the functions and the types of `modules/utils`:

```
testxom2/
├── Ballerina.toml
├── main.bal
└── modules/
    └── utils/
        └── utils.bal
```

Clicking it navigates to the package overview rather than to the flow view or the type view of the construct, with no indication of why.

The language server derives the lens from the syntax tree alone. `VisualizeCodeLensProvider` offers one for every function, service, class and type of the requested document, and it carries the file URI and the range of the construct:

```java
Command command = new Command(CodeLensUtil.VISUALIZE_CODELENS, "ballerina.showVisualizer", args);
```

The view that the command opens is resolved separately, from the project artifacts. `getViewByArtifacts()` matches the file and the start position of the click against `projectStructure`, and the type of the artifact that matches decides the view. That structure comes from `getProjectArtifacts`, and `ArtifactsGenerator` walks the default module alone:

```java
Module defaultModule = currentPackage.getDefaultModule();
```

A construct of a submodule is therefore reported as no artifact, no entry matches, and the resolution falls through to its last case:

```ts
// If no view is found, return the overview view
return { location: { view: MACHINE_VIEW.PackageOverview, documentUri: documentUri } };
```

The navigation is correct for a construct that the visualizer holds no model of. The lens should not be offered for it in the first place.

## Approach
The lens is kept and disabled, rather than removed, so that the reason is reported to the user instead of the affordance disappearing without an explanation.

- `codelens-middleware.ts` adds a `provideCodeLenses` middleware to the language client. When the document belongs to a submodule, the command identifier of each `Visualize` lens is emptied and the reason is placed in its tooltip. VS Code renders a lens that holds a command identifier as an anchor and one that does not as a span, so the title is shown without the styling and the behaviour of a link. The tooltip cannot come from the language server, since the `Command` of the protocol holds a title, an identifier and the arguments alone.
- The lens is mutated rather than replaced, so that it remains the `ProtocolCodeLens` of the client along with the data that a resolve request would carry, should the language server offer one later.
- The `Run`, `Debug` and `Try it` lenses are matched out by the command identifier and pass through untouched. A service of a submodule still runs when the package runs, so those lenses are not equally affected.
- `isSubmoduleFile()` locates the package root by walking up to the first `Ballerina.toml`, and reports a submodule when the directory directly below that root is `modules` or `generated`. `generated` is included, since the connector generation emits its modules there and they are non-default modules in the same manner. It holds no cache, so that it cannot go stale when a package is created or removed. It performs one `existsSync` per level of the path, which is negligible beside the language server round trip that the middleware already awaits.

This is held on the client, since the limitation is one of the visualizer rather than of the language server, and it is a single deletion once submodules are supported.

## Tests
Verified in the extension that the lens of a construct of `modules/utils` is present but not clickable, that its tooltip reports the reason, and that the lens of a construct of the default module still opens its view.

The resolution of the path was verified against the package above along with the cases that must keep the lens: the files of the default module, a test of the default module under `tests/`, a `.bal` file that belongs to no package and an empty path. A test of the submodule under `modules/utils/tests/` and a module under `generated/` are reported as submodules.

`tsc -p ./ --noEmit` and `tslint` pass over the extension.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Disabled unavailable **Visualize** code lenses in Ballerina submodule and generated files.
- Added an explanatory tooltip when visualization is not supported.
- Preserved existing code lenses for files outside these directories.
- Improved handling for files that are not part of a recognized Ballerina package.
- Other supported code lenses continue to work as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->