### PR TITLE
Persist the review view with a generation

### DIFF
--- a/workspaces/common-libs/copilot-utilities/src/chat-persistence/types.ts
+++ b/workspaces/common-libs/copilot-utilities/src/chat-persistence/types.ts
@@ -24,7 +24,16 @@ export interface PersistedReviewState {
     status: 'generating' | 'done' | 'accepted' | 'reverted' | 'error';
     modifiedFiles: string[];
     errorMessage?: string;
-    // NOTE: tempProjectPath and affectedPackagePaths are runtime-only — not persisted
+    /**
+     * Only ever set while the generation is 'done' — settling clears it — so at most one
+     * generation per thread carries this. tempProjectPath and affectedPackagePaths stay
+     * runtime-only: they are absolute paths that a moved workspace would silently invalidate.
+     */
+    reviewView?: {
+        semanticDiffs: object[];
+        loadDesignDiagrams: boolean;
+        isWorkspace: boolean;
+    };
 }
 
 // ============================================


### PR DESCRIPTION
- Add `reviewView` to `PersistedReviewState` so a review survives an extension-host restart
- Settling a generation clears it, so at most one per thread is ever stored

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Review sessions can now preserve semantic differences, diagram-loading status, and workspace context.
  - Returning to a saved review provides a more consistent view of the review information and workspace state.

- **Improvements**
  - Clarified how review view information is saved and restored throughout the review lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->